### PR TITLE
Connecting playback state to player screen

### DIFF
--- a/app/src/main/java/com/example/music/di/UiDiModule.kt
+++ b/app/src/main/java/com/example/music/di/UiDiModule.kt
@@ -27,21 +27,27 @@ private const val TAG = "UI-DI-Module"
 object UiDiModule {
     @Singleton
     @Provides
-    fun provideAudioAttributes() = AudioAttributes.Builder()
-        .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
-        .setUsage(C.USAGE_MEDIA)
-        .build()
+    fun provideAudioAttributes(): AudioAttributes {
+        Log.i(TAG, "Providing Audio Attributes")
+        return AudioAttributes.Builder()
+            .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+            .setUsage(C.USAGE_MEDIA)
+            .build()
+    }
 
     @OptIn(UnstableApi::class)
     @Provides
     fun providePlayer(
         @ApplicationContext context: Context,
         audioAttributes: AudioAttributes,
-    ): Player = ExoPlayer.Builder(context, DefaultMediaSourceFactory(context))
-        .setAudioAttributes(audioAttributes, true)
-        .setWakeMode(C.WAKE_MODE_LOCAL)
-        .setHandleAudioBecomingNoisy(true)
-        .build()
+    ): Player {
+        Log.i(TAG, "Providing Player")
+        return ExoPlayer.Builder(context, DefaultMediaSourceFactory(context))
+            .setAudioAttributes(audioAttributes, true)
+            .setWakeMode(C.WAKE_MODE_LOCAL)
+            .setHandleAudioBecomingNoisy(true)
+            .build()
+    }
 
     @OptIn(UnstableApi::class)
     @Provides

--- a/app/src/main/java/com/example/music/service/MediaService.kt
+++ b/app/src/main/java/com/example/music/service/MediaService.kt
@@ -134,6 +134,7 @@ class MediaService : MediaSessionService(), Callback, Player.Listener {
         Log.i(TAG, "Building Media Session")
         mediaSession = MediaSession.Builder(this, mediaPlayer)
             .setSessionActivity(activity)
+            .setCallback(this)
             .build()
         Log.i(TAG, "Media Session created")
 
@@ -151,9 +152,9 @@ class MediaService : MediaSessionService(), Callback, Player.Listener {
             }
 
             // Connects the MediaService's Player.Listener to mediaPlayer
-            Log.i(TAG, "Adding listener to a media player.")
+            Log.i(TAG, "Adding @MediaService listener to a media player.")
             mediaPlayer.addListener(this@MediaService)
-            Log.i(TAG, "Added listener to a media player.")
+            Log.i(TAG, "Added @MediaService listener to a media player.")
 
             sendBroadcast(NowPlaying.from(this@MediaService, mediaPlayer))
 

--- a/app/src/main/java/com/example/music/service/SongController.kt
+++ b/app/src/main/java/com/example/music/service/SongController.kt
@@ -1,8 +1,10 @@
 package com.example.music.service
 
 import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import com.example.music.data.repository.RepeatType
 import com.example.music.domain.model.SongInfo
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import java.time.Duration
 
@@ -14,48 +16,74 @@ import java.time.Duration
  */
 
 val DefaultPlaybackSpeed: Duration = Duration.ofSeconds(1)
-// FUTURE THOUGHT: see if there is way to confirm what type DefaultPlaybackSpeed is supposed to be
 
-data class SongControllerState(
+/*data class SongControllerState(
     val currentSong: MediaItem? = null,
-    val playbackSpeed: Duration = DefaultPlaybackSpeed,
+    //val playbackSpeed: Duration = DefaultPlaybackSpeed,
     val isPlaying: Boolean = false, //tracks the current playing state
     val timeElapsed: Duration = Duration.ZERO,
-    val isShuffled: Boolean = false,
-    val repeatState: RepeatType = RepeatType.OFF,
+    //val isShuffled: Boolean = false,
+    //val repeatState: RepeatType = RepeatType.OFF,
+    val hasNext: Boolean = false,
     //val shuffleType: ShuffleType = ShuffleType.ONCE,
-)
+)*/
 
 /**
- * Interface definition for a song player defining high-level functions such as queuing
- * episodes, playing an episode, pausing, seeking, etc.
+ * Interface wrapper for a Media Controller to define high-level functions for
+ * interacting with MediaService and a media3 Player.
  */
 interface SongController {
 
     /**
-     * A StateFlow that emits the [SongControllerState] as controls as invoked on this player.
+     * The current playing song.
      */
-    val playerState: StateFlow<SongControllerState>
+    val currentSong: MediaItem?
 
     /**
-     * Gets the current episode playing, or to be played, by this player.
+     * Current playback position from MediaController
      */
-    var currentSong: MediaItem?
+    val position: Long
+
+    /**
+     * The playback length for the current playing song.
+     */
+    val duration: Long
+
+    /**
+     * If the Player is playing a song.
+     */
+    val isPlaying: Boolean
+
+    /**
+     * A MediaController setting to say that the Player has permission to play when
+     * when it is done buffering/loading.
+     */
+    val playWhenReady: Boolean
+
+    /**
+     * If there is a song queued to play after the current song.
+     */
+    val hasNext: Boolean
+
+    /**
+     * A reflection of the events occurring in Player
+     */
+    val events: Flow<Player.Events?>
+
+    /**
+     * A reflection of the loaded state for SongController
+     */
+    val loaded: Flow<Boolean>
 
     /**
      * The speed of which the player increments
      */
-    var playerSpeed: Duration
+    //var playerSpeed: Duration
 
     /**
-     * The object for providing mediaPlayer functionality to song player
+     * The media3 Player object that provides Player functionality to SongController
      */
-    //val mediaPlayer: MediaPlayer?
-        //get() = null
-
-    fun addMediaItem(song: SongInfo)
-
-    fun addMediaItems(songs: List<SongInfo>)
+    val player: Player?
 
     /**
      * Add song to end of queue
@@ -70,7 +98,7 @@ interface SongController {
     /**
      * Add song to beginning of queue. This is for "PlayNext" to both place the song after the
      * current song regardless if the queue is shuffled or not, it will be the next song. So when
-     * the queue is unshuffled, it will be set after the placement of where the current song is.
+     * the queue is un-shuffled, it will be set after the placement of where the current song is.
      * Which means this implementation would need to know the placement of the current song to be
      * able to iterate on.
      */
@@ -101,13 +129,15 @@ interface SongController {
     /**
     * Flushes the queue
     */
-    fun removeAllFromQueue()
+    fun clearQueue()
 
     /**
      * Get the player to play. Effectively this should be the one that affects the
      * isPlaying state as well as confirms the currentMediaItem within the mediaController.
      */
     fun play()
+
+    fun play(playWhenReady: Boolean)
 
     /**
      * Plays a specified song.
@@ -126,17 +156,22 @@ interface SongController {
     fun play(songs: List<SongInfo>)
 
     /**
-     * Pauses the currently played song
+     * Pauses the currently playing song
      */
     fun pause()
 
     /**
-     * Stops the currently played song
+     * Stops the currently playing song
      */
     fun stop()
 
     /**
-     * Plays another song in the queue (if available)
+     * Sets the current playback to a given time specified in [Long].
+     */
+    fun seekTo(position: Long)
+
+    /**
+     * Plays the next song in the queue (if available)
      */
     fun next()
 
@@ -145,26 +180,6 @@ interface SongController {
      * playing this will start the song from the beginning
      */
     fun previous()
-
-    /**
-     * Advances a currently played song by a given time interval specified in [duration].
-     */
-    fun advanceBy(duration: Duration)
-
-    /**
-     * Rewinds a currently played song by a given time interval specified in [duration].
-     */
-    fun rewindBy(duration: Duration)
-
-    /**
-     * Signal that user started seeking.
-     */
-    fun onSeekingStarted()
-
-    /**
-     * Seeks to a given time interval specified in [duration].
-     */
-    fun onSeekingFinished(duration: Duration)
 
     /**
      * Use to change the shuffle mode
@@ -179,24 +194,14 @@ interface SongController {
     /**
      * Increases the speed of Player playback by a given time specified in [Duration].
      */
-    fun increaseSpeed(speed: Duration = Duration.ofMillis(500))
+    //fun increaseSpeed(speed: Duration = Duration.ofMillis(500))
 
     /**
      * Decreases the speed of Player playback by a given time specified in [Duration].
      */
-    fun decreaseSpeed(speed: Duration = Duration.ofMillis(500))
+    //fun decreaseSpeed(speed: Duration = Duration.ofMillis(500))
 
     fun shuffle(songs: List<SongInfo>)
-
-    fun getIsPlaying() : Boolean
-
-    fun getIsShuffled() : Boolean
-
-    fun getRepeatState() : RepeatType
-
-    fun getTimeElapsed() : Duration
-
-    fun getHasNext() : Boolean
 
     fun isConnected() : Boolean
 }

--- a/app/src/main/java/com/example/music/service/SongController.kt
+++ b/app/src/main/java/com/example/music/service/SongController.kt
@@ -13,7 +13,7 @@ import java.time.Duration
  * Removed PlayerSong completely
  */
 
-val DefaultPlaybackSpeed = Duration.ofSeconds(1)
+val DefaultPlaybackSpeed: Duration = Duration.ofSeconds(1)
 // FUTURE THOUGHT: see if there is way to confirm what type DefaultPlaybackSpeed is supposed to be
 
 data class SongControllerState(
@@ -53,19 +53,19 @@ interface SongController {
     //val mediaPlayer: MediaPlayer?
         //get() = null
 
-    fun addMediaItem(item: SongInfo)
+    fun addMediaItem(song: SongInfo)
 
-    fun addMediaItems(items: List<SongInfo>)
+    fun addMediaItems(songs: List<SongInfo>)
 
     /**
      * Add song to end of queue
      */
-    fun addToQueue(songInfo: SongInfo)
+    fun addToQueue(song: SongInfo)
 
     /**
      * Add multiple songs to end of queue
      */
-    fun addToQueue(songInfos: List<SongInfo>)
+    fun addToQueue(songs: List<SongInfo>)
 
     /**
      * Add song to beginning of queue. This is for "PlayNext" to both place the song after the
@@ -74,24 +74,24 @@ interface SongController {
      * Which means this implementation would need to know the placement of the current song to be
      * able to iterate on.
      */
-    fun addToQueueNext(songInfo: SongInfo)
+    fun addToQueueNext(song: SongInfo)
 
     /**
      * Add multiple songs to beginning of queue. Similar to [addToQueueNext] it's "PlayNext" but
      * on a list of songs. So when shuffled is on, does it shuffle the incoming list? or place them
      * next in its original order. survey says yes, place the new songs in order.
      */
-    fun addToQueueNext(songInfos: List<SongInfo>)
+    fun addToQueueNext(songs: List<SongInfo>)
 
     /**
      * Clear the current queue and set it with provided item
      */
-    fun setMediaItem(item: SongInfo)
+    fun setMediaItem(song: SongInfo)
 
     /**
      * Clear the current queue and set it with provided items
      */
-    fun setMediaItems(items: List<SongInfo>)
+    fun setMediaItems(songs: List<SongInfo>)
 
     /**
      * Prepare the media player
@@ -114,7 +114,7 @@ interface SongController {
      * Note: If the given songInfo is from an item that is already within the queue,
      * it should play that item.
      */
-    fun play(songInfo: SongInfo)
+    fun play(song: SongInfo)
 
     /**
      * Plays a specified list of songs.
@@ -123,7 +123,7 @@ interface SongController {
      * queue from "AddToQueue". So if the queue started from "Play" or "Shuffle", it will get
      * replaced with the new item(s) being played or shuffled.
      */
-    fun play(songInfos: List<SongInfo>)
+    fun play(songs: List<SongInfo>)
 
     /**
      * Pauses the currently played song
@@ -186,7 +186,7 @@ interface SongController {
      */
     fun decreaseSpeed(speed: Duration = Duration.ofMillis(500))
 
-    fun shuffle(songInfos: List<SongInfo>)
+    fun shuffle(songs: List<SongInfo>)
 
     fun getIsPlaying() : Boolean
 

--- a/app/src/main/java/com/example/music/service/SongControllerImpl.kt
+++ b/app/src/main/java/com/example/music/service/SongControllerImpl.kt
@@ -150,61 +150,61 @@ class SongControllerImpl @Inject constructor(
 
     override var currentSong: MediaItem? by _currentSong
 
-    override fun addMediaItem(item: SongInfo) {
-        Log.i(TAG, "Add Media Item: ${item.id}")
-        addToQueue(item)
-        mediaController?.setMediaItem(item.toMediaItem)
+    override fun addMediaItem(song: SongInfo) {
+        Log.i(TAG, "Add Media Item: ${song.id}")
+        addToQueue(song)
+        mediaController?.setMediaItem(song.toMediaItem)
     }
 
-    override fun addMediaItems(items: List<SongInfo>) {
-        Log.i(TAG, "Add Media Items: ${items.size}")
-        addToQueue(items)
+    override fun addMediaItems(songs: List<SongInfo>) {
+        Log.i(TAG, "Add Media Items: ${songs.size}")
+        addToQueue(songs)
         mediaController?.setMediaItems(
-            items.map {
+            songs.map {
                 it.toMediaItem
             }
         )
     }
 
-    override fun addToQueue(songInfo: SongInfo) {
+    override fun addToQueue(song: SongInfo) {
         Log.i(TAG, "Add To Queue - 1 song")
-        mediaController?.addMediaItem(songInfo.toMediaItem)
+        mediaController?.addMediaItem(song.toMediaItem)
     }
 
-    override fun addToQueue(songInfos: List<SongInfo>) {
+    override fun addToQueue(songs: List<SongInfo>) {
         Log.i(TAG, "Add To Queue - multiple songs")
         mediaController?.addMediaItems(
-            songInfos.map {
+            songs.map {
                 it.toMediaItem
             }
         )
     }
 
-    override fun addToQueueNext(songInfo: SongInfo) {
+    override fun addToQueueNext(song: SongInfo) {
         Log.i(TAG, "Add to Queue Next - 1 song:\n" +
-                "Song ID: ${songInfo.id}; Song Title: ${songInfo.title}")
-        mediaController?.addMediaItem(1,songInfo.toMediaItem)
+                "Song ID: ${song.id}; Song Title: ${song.title}")
+        mediaController?.addMediaItem(1,song.toMediaItem)
     }
 
-    override fun addToQueueNext(songInfos: List<SongInfo>) {
-        Log.i(TAG, "Add to Queue Next - multiple songs: ${songInfos.size}")
-        mediaController?.addMediaItems(1,songInfos.map {
+    override fun addToQueueNext(songs: List<SongInfo>) {
+        Log.i(TAG, "Add to Queue Next - multiple songs: ${songs.size}")
+        mediaController?.addMediaItems(1,songs.map {
             Log.i(TAG, "Song ID: ${it.id}; Song Title: ${it.title}")
             it.toMediaItem
         })
     }
 
-    override fun setMediaItem(item: SongInfo) {
+    override fun setMediaItem(song: SongInfo) {
         //addToQueue(item)
-        Log.i(TAG, "Set Media Item: ${item.id}")
-        //mediaController?.setMediaItem(item.toMediaItem) //want this to be the only thing this function does
-        play(item) //currently this is the only way playing a song actually works
+        Log.i(TAG, "Set Media Item: ${song.id}")
+        //mediaController?.setMediaItem(song.toMediaItem) //want this to be the only thing this function does
+        play(song) //currently this is the only way playing a song actually works
     }
 
-    override fun setMediaItems(items: List<SongInfo>) {
-        Log.i(TAG, "Set Media Items: ${items.size}")
+    override fun setMediaItems(songs: List<SongInfo>) {
+        Log.i(TAG, "Set Media Items: ${songs.size}")
         mediaController?.setMediaItems(
-            items.map {
+            songs.map {
                 Log.i(TAG, "Song ID: ${it.id}; Song Title: ${it.title}")
                 it.toMediaItem
             }
@@ -267,19 +267,19 @@ class SongControllerImpl @Inject constructor(
         }
     }
 
-    override fun play(songInfo: SongInfo) {
+    override fun play(song: SongInfo) {
         Log.d(TAG, "In play(SongInfo)")
-        play(listOf(songInfo))
+        play(listOf(song))
     }
 
-    override fun play(songInfos: List<SongInfo>) {
+    override fun play(songs: List<SongInfo>) {
         Log.d(TAG, "In play(List<SongInfo>)")
         if (isPlaying.value) {
             pause()
             mediaController?.pause()
         }
 
-        val queue = songInfos.map{it.toMediaItem}
+        val queue = songs.map{it.toMediaItem}
         mediaController?.setMediaItems(queue)
         Log.e(TAG, "Current queue has ${queue.size} items.")
         Log.e(TAG, "Current media controller state before apply is ${mediaController?.playbackState}.")
@@ -458,7 +458,7 @@ class SongControllerImpl @Inject constructor(
         }
     }
 
-    override fun shuffle(songInfos: List<SongInfo>) {
+    override fun shuffle(songs: List<SongInfo>) {
         // ground rules
         // 1 if the songs here are the first items going into the queue, then the shuffled
         // order here is the originating order, aka it is the queue's default track order. hitting un-shuffle will keep this order intact, and hitting shuffle can change the order but the original needs to remain untouched
@@ -473,12 +473,12 @@ class SongControllerImpl @Inject constructor(
         // AND IT WILL BE AT THE TOP OF THE QUEUE, REMOVING THE ORIGINAL CONTEXT BUT KEEPING THE ITEMS THAT WERE
         // "ADD TO QUEUE"
 //        queue.update {
-//            songInfos.shuffled(Random(RandSeed))
+//            songs.shuffled(Random(RandSeed))
 //        }
         removeAllFromQueue()
 
         mediaController?.setMediaItems(
-            songInfos.map {
+            songs.map {
                 it.toMediaItem
             }.shuffled( Random(RAND_SEED) )
         )

--- a/app/src/main/java/com/example/music/service/SongControllerImpl.kt
+++ b/app/src/main/java/com/example/music/service/SongControllerImpl.kt
@@ -4,29 +4,28 @@ import android.content.ComponentName
 import android.content.Context
 import android.util.Log
 import androidx.annotation.OptIn
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
-import com.example.music.data.repository.AppPreferencesRepo
-import com.example.music.data.repository.RepeatType
-import com.example.music.data.util.combine
 import com.example.music.domain.model.SongInfo
-import com.example.music.domain.player.model.duration
 import com.example.music.domain.player.model.title
 import com.example.music.domain.player.model.toMediaItem
+import com.example.music.ui.shared.mediaItems
 import com.example.music.ui.shared.queue
 import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.time.Duration
 import javax.inject.Inject
@@ -62,112 +61,46 @@ class SongControllerImpl @Inject constructor(
     mainDispatcher: CoroutineDispatcher
 ) : SongController, MediaController.Listener {
 
-    //@Inject
-    //lateinit var appPreferences: AppPreferencesRepo
+    private val coroutineScope = CoroutineScope(mainDispatcher)
 
-    // The Media Controller that will interact with MediaService
     private var mediaControllerFuture: ListenableFuture<MediaController> = context.mediaController(this)
     private val mediaController: MediaController?
         get() = if (mediaControllerFuture.isDone) mediaControllerFuture.get() else null
 
-    private val _playerState = MutableStateFlow(SongControllerState())
-    //private val _currentSong = MutableStateFlow<SongInfo?>(null)
-    private val _currentSong = MutableStateFlow<MediaItem?>(null)
-    private val isPlaying = MutableStateFlow(false)
-    private val isShuffled = MutableStateFlow(false)
-    private val repeatState = MutableStateFlow(RepeatType.OFF)
-    private val timeElapsed = MutableStateFlow(Duration.ZERO)
-    private val _playerSpeed = MutableStateFlow(DefaultPlaybackSpeed)
-    // rethink from here which of these values are still needed for propagation between media service and rest of app
-    // or if that is even needed as well
-
-    private val coroutineScope = CoroutineScope(mainDispatcher)
-
-    private var timerJob: Job? = null
-
-    /*override var mediaControllerCallback: (
-        (
-            playerState: PlayerState,
-            currentMusic: Song?,
-            currentPosition: Long,
-            totalDuration: Long,
-            isShuffleEnabled: Boolean,
-            isRepeatOneEnabled: Boolean
-        ) -> Unit
-    )? = null*/
-
-    init {
-        Log.i(TAG, "SongController init start")
-
-        coroutineScope.launch {
-            Log.i(TAG, "SongController coroutine start")
-            // Combine streams here
-            //val appPref = appPreferences.appPreferencesFlow
-            //isShuffled.value = appPreferences.isShuffleEnabled()
-            //repeatState.value = appPreferences.getRepeatType()
-            combine(
-                //collects flow to generate SongPlayer's State
-                _currentSong,
-                isPlaying,
-                timeElapsed,
-                _playerSpeed,
-                repeatState,
-                isShuffled,
-                //appPref,
-            ) {
-                currentSong,
-                isPlaying,
-                timeElapsed,
-                playerSpeed,
-                repeatState,
-                isShuffled,
-                ->
-                Log.i(TAG, "Song Controller State launch: ${currentSong?.title} " +
-                    "\n isPlaying: $isPlaying" +
-                    "\n timeElapsed: $timeElapsed" +
-                    "\n playbackSpeed: $playerSpeed" +
-                    "\n repeatState: $repeatState" +
-                    "\n isShuffled: $isShuffled" )
-                SongControllerState(
-                    currentSong = currentSong,
-                    isPlaying = isPlaying,
-                    timeElapsed = timeElapsed,
-                    playbackSpeed = playerSpeed,
-                    repeatState = repeatState,
-                    isShuffled = isShuffled,
-                )
-            }.catch {
-                throw it
-            }.collect {
-                _playerState.value = it
+    override val currentSong: MediaItem?
+        get() = mediaController?.currentMediaItem
+    override val position: Long
+        get() = mediaController?.currentPosition ?: C.TIME_UNSET
+    override val duration: Long
+        get() = mediaController?.contentDuration ?: C.TIME_UNSET
+    override val isPlaying: Boolean
+        get() = mediaController?.isPlaying ?: false
+    override val playWhenReady: Boolean
+        get() = mediaController?.playWhenReady ?: false
+    override val hasNext: Boolean
+        get() = mediaController?.hasNextMediaItem() ?: false
+    override val player: Player?
+        get() = mediaController
+    override val events: Flow<Player.Events?>
+        get() = callbackFlow {
+            val observer = object : Player.Listener {
+                override fun onEvents(player: Player, events: Player.Events) {
+                    trySend(events)
+                }
             }
-        }
-    }
-
-    override var playerSpeed: Duration = _playerSpeed.value
-
-    override val playerState: StateFlow<SongControllerState> = _playerState.asStateFlow()
-
-    override var currentSong: MediaItem? by _currentSong
-
-    override fun addMediaItem(song: SongInfo) {
-        Log.i(TAG, "Add Media Item: ${song.id}")
-        addToQueue(song)
-        mediaController?.setMediaItem(song.toMediaItem)
-    }
-
-    override fun addMediaItems(songs: List<SongInfo>) {
-        Log.i(TAG, "Add Media Items: ${songs.size}")
-        addToQueue(songs)
-        mediaController?.setMediaItems(
-            songs.map {
-                it.toMediaItem
+            val controller = mediaControllerFuture.await()
+            trySend(null)
+            controller.addListener(observer)
+            awaitClose {
+                controller.removeListener(observer)
             }
-        )
-    }
+        }.flowOn(Dispatchers.Main)
+    override val loaded: Flow<Boolean>
+        get() = events.map { currentSong != null }
 
     override fun addToQueue(song: SongInfo) {
-        Log.i(TAG, "Add To Queue - 1 song")
+        Log.i(TAG, "Add To Queue - 1 song:\n" +
+            "Song ID: ${song.id}; Song Title: ${song.title}")
         mediaController?.addMediaItem(song.toMediaItem)
     }
 
@@ -175,6 +108,7 @@ class SongControllerImpl @Inject constructor(
         Log.i(TAG, "Add To Queue - multiple songs")
         mediaController?.addMediaItems(
             songs.map {
+                Log.i(TAG, "Song ID: ${it.id}; Song Title: ${it.title}")
                 it.toMediaItem
             }
         )
@@ -195,10 +129,9 @@ class SongControllerImpl @Inject constructor(
     }
 
     override fun setMediaItem(song: SongInfo) {
-        //addToQueue(item)
-        Log.i(TAG, "Set Media Item: ${song.id}")
-        //mediaController?.setMediaItem(song.toMediaItem) //want this to be the only thing this function does
-        play(song) //currently this is the only way playing a song actually works
+        Log.i(TAG, "Set Media Item: ${song.id}\n" +
+            "Song ID: ${song.id}; Song Title: ${song.title}")
+        mediaController?.setMediaItem(song.toMediaItem)
     }
 
     override fun setMediaItems(songs: List<SongInfo>) {
@@ -216,151 +149,129 @@ class SongControllerImpl @Inject constructor(
         mediaController?.prepare()
     }
 
-    override fun removeAllFromQueue() {
-        Log.i(TAG, "in removeAllFromQueue(): Remove all items from Queue")
+    override fun clearQueue() {
+        Log.i(TAG, "in clearQueue(): Remove all items from Queue")
         mediaController?.clearMediaItems()
     }
 
     override fun play() {
-        //mediaPlayer.play()
-        Log.d(TAG, "in play():\n" +
-                "isPlaying is set to ${isPlaying.value}.\n" +
-                "Current song is ${_currentSong.value?.title}")
+        Log.d(TAG, "in play(): START\n" +
+                "SongController isPlaying is set to ${isPlaying}.\n" +
+                "Current Song Controller song is ${currentSong?.title}")
 
-        // Do nothing if already playing
-        if (isPlaying.value) {
-            return
-        }
-        Log.i(TAG, "Starting Song Controller Impl Play()")
-
-        val song = _currentSong.value ?: return
         val item = mediaController?.currentMediaItem
-        Log.i(TAG, "Current media item is ${item?.title}")
+        Log.i(TAG, "MediaController isPlaying is set to ${mediaController?.isPlaying}\n" +
+                "Current Media Controller item is ${item?.title}")
 
-        // This is almost definitely in the wrong place.
-        //play(currentSong!!.asExternalModel())
-        isPlaying.value = true
-        //mediaController?.mediaItemCount
-        timerJob = coroutineScope.launch {
-            // Increment timer by a second
-            Log.i(TAG, "Song Controller Impl Play() coroutine")
-            while (isActive && timeElapsed.value < Duration.ofMillis(song.duration?:0)) {
-                delay(playerSpeed.toMillis())
-                timeElapsed.update { it + playerSpeed }
-            }
-
-            // Once done playing, see if
-            isPlaying.value = false
-            timeElapsed.value = Duration.ZERO
-
-            if (hasNext() == true) {
-                next()
+        /* // there's 4 playback states to check for: idle, buffering, ready, ended
+        // ideally, if we're in here that means the app requested to play something, so should be in buffering
+        // want to wait for the media controller to finish buffering, then when it is ready, get to play/pause */
+        coroutineScope.launch {
+            while (mediaController?.playbackState == Player.STATE_BUFFERING) {
+                delay(1000)
             }
         }
 
         if (mediaController?.isPlaying == true) {
             Log.d(TAG, "Song Controller Impl IS PLAYING -- set to pause")
-            mediaController?.pause()
+            pause()
         } else {
             Log.d(TAG, "Song Controller Impl IS PAUSED -- set to play")
-            mediaController?.play()
+            play(true)
+            preparePlayer()
         }
+        Log.d(TAG, "in play(): END")
+    }
+
+    override fun play(playWhenReady: Boolean) {
+        mediaController?.playWhenReady = playWhenReady
+        mediaController?.play()
     }
 
     override fun play(song: SongInfo) {
-        Log.d(TAG, "In play(SongInfo)")
+        Log.d(TAG, "In play(SongInfo): START")
         play(listOf(song))
+        Log.d(TAG, "In play(SongInfo): END")
     }
 
     override fun play(songs: List<SongInfo>) {
-        Log.d(TAG, "In play(List<SongInfo>)")
-        if (isPlaying.value) {
-            pause()
-            mediaController?.pause()
-        }
+        Log.d(TAG, "In play(List<SongInfo>): START")
 
-        val queue = songs.map{it.toMediaItem}
-        mediaController?.setMediaItems(queue)
-        Log.e(TAG, "Current queue has ${queue.size} items.")
-        Log.e(TAG, "Current media controller state before apply is ${mediaController?.playbackState}.")
+        Log.d(TAG, "Count of items to queue: ${songs.size} items.")
+        setMediaItems(songs)
+
+        Log.d(TAG, "Current media controller state before apply is ${mediaController?.playbackState}.")
 
         mediaController?.apply {
             seekToDefaultPosition()
             playWhenReady = true
             prepare()
-//            play()
         }
-        Log.e(TAG, "Current media controller state after apply is ${mediaController?.playbackState}.")
-
+        Log.d(TAG, "Current media controller state after apply is ${mediaController?.playbackState}.\n" +
+                "Current media controller queue is ${mediaController?.mediaItems?.size} items\n" +
+                "Current media item is ${mediaController?.currentMediaItem?.title}")
+        play()
+        Log.d(TAG, "In play( List<SongInfo> ): END")
     }
 
     override fun pause() {
-        Log.d(TAG, "in pause() start --- isPlaying is ${isPlaying.value}")
-        isPlaying.value = false
-        Log.d(TAG, "in pause() --- isPlaying is set to ${isPlaying.value}")
+        Log.d(TAG, "in pause() START --- isPlaying is $isPlaying")
         mediaController?.pause()
-
-        timerJob?.cancel()
-        timerJob = null
+        Log.d(TAG, "in pause() END --- isPlaying is set to $isPlaying")
     }
 
     override fun stop() {
-        Log.d(TAG, "in stop() --- isPlaying is ${isPlaying.value}")
-        isPlaying.value = false
-        Log.d(TAG, "in stop() --- isPlaying is set to ${isPlaying.value}")
+        Log.d(TAG, "in stop() --- isPlaying is $isPlaying")
         mediaController?.stop()
-
-        timeElapsed.value = Duration.ZERO
-
-        timerJob?.cancel()
-        timerJob = null
+        Log.d(TAG, "in stop() --- isPlaying is set to $isPlaying")
     }
 
-    override fun advanceBy(duration: Duration) {
-        Log.d(TAG, "in advanceBy(Duration)")
-        val currentSongDuration = _currentSong.value?.duration ?: return
-//        timeElapsed.update {
-//            (it + duration).coerceAtMost(currentSongDuration)
-//        }
-
-        mediaController?.seekTo(duration.toMillis())
+    override fun seekTo(position: Long) {
+        Log.d(TAG, "in seekTo(Long) START: $position")
+        mediaController?.seekTo(position)
+        Log.d(TAG, "in seekTo(Long) END: new position is ${mediaController?.currentPosition}")
+        play(true)
     }
 
-    override fun rewindBy(duration: Duration) {
-        Log.d(TAG, "in rewindBy(Duration)")
-//        timeElapsed.update {
-//            (it - duration).coerceAtLeast(Duration.ZERO)
-//        }
-
-        mediaController?.seekTo(duration.toMillis())
+    override fun next() {
+        Log.d(TAG, "in next() function")
+        mediaController?.seekToNextMediaItem()
+        play()
     }
 
-    override fun onSeekingStarted() {
-        Log.i(TAG, "in onSeekingStarted()")
-        // Need to pause the player so that it doesn't compete with timeline progression.
-        // this is called to pause the player so that it's' prepared for seekTo
-        pause()
-    }
+    override fun previous() {
+        Log.d(TAG, "in previous() function")
 
-    override fun onSeekingFinished(duration: Duration) {
-        Log.i(TAG, "in onSeekingFinished(Duration)")
-        //val currentSongDuration = _currentSong.value?.duration ?: return
-        //timeElapsed.update { duration.coerceIn(Duration.ZERO, currentSongDuration) }
-        //play()
-        Log.i(TAG, "In the controller's onSeekingFinished() function, presumably after a song has finished.")
-
+        if (position < 2000L && mediaController?.hasPreviousMediaItem() == true) {
+            // if media item passed less than 2s, restart position
+            mediaController?.seekToPreviousMediaItem()
+        } else {
+            // else there isn't any previous item, just restart position
+            mediaController?.seekToDefaultPosition()
+        }
         play()
     }
 
     override fun onShuffle() {
-        Log.i(TAG, "in onShuffle() --- isShuffled is set to ${isShuffled.value}")
-        isShuffled.value = !isShuffled.value
-        if (isShuffled.value) { //aka shuffle turned on
+        /* // v1
+        Log.d(TAG, "in onShuffle() --- isShuffled is set to ${_isShuffled.value}")
+        _isShuffled.value = !_isShuffled.value!!
+        if (_isShuffled.value == true) { //aka shuffle turned on
             //TODO: change the queue to be randomized order
             Log.i(TAG, "BEGIN SHUFFLE QUEUE")
             shuffleQueue()
-        }
-        else { //aka shuffle turned off
+
+        } // v1 end */
+
+        /* // v2
+        Log.i(TAG, "in onShuffle() --- isShuffled is set to ${isShuffled.value}")
+        isShuffled.value = !_isShuffled.value!!
+        if (isShuffled.value == true) { //aka shuffle turned on
+            //TODO: change the queue to be randomized order
+            Log.i(TAG, "BEGIN SHUFFLE QUEUE")
+            shuffleQueue()
+        } // v2 end */
+        /*else { //aka shuffle turned off
             //TODO: change the queue to be in normal order
             Log.i(TAG, "BEGIN UNDO QUEUE SHUFFLE")
             //unShuffleQueue()
@@ -377,82 +288,52 @@ class SongControllerImpl @Inject constructor(
             // that move after the queue was shuffled, then un-shuffled. it returned to its original
             // placement when it was first added to the queue. maybe it really does use a history ...
             // or keeps the original placement and reordering uses a temporary shift
-        }
+        }*/
         //updatePlayerPreferences.updateShuffleType
     }
 
     override fun onRepeat() {
-        Log.i(TAG, "in onRepeat --- repeatState is set to ${repeatState.value}")
-        when(repeatState.value) {
+        /*Log.i(TAG, "in onRepeat --- repeatState is set to ${_repeatState.value}") // v1
+        // Log.i(TAG, "in onRepeat --- repeatState is set to ${repeatState.value}") // v2
+        when(_repeatState.value) { // v1
+        //when(repeatState.value) { // v2
             //TODO: figure out how the queue / player needs to change
             RepeatType.OFF -> {
-                repeatState.value = RepeatType.ON
+                _repeatState.value = RepeatType.ON // v1
+                // repeatState.value = RepeatType.ON // v2
                 Log.i(TAG, "REPEAT TYPE CHANGED TO ON")
                 //in checking the queue, if the current song is the last song of the queue, set the onNext to play the first song
             }
             RepeatType.ON -> {
-                repeatState.value = RepeatType.ONE
+                _repeatState.value = RepeatType.ONE // v1
+                // repeatState.value = RepeatType.ONE // v2
                 Log.i(TAG, "REPEAT TYPE CHANGED TO ONE")
                 //want to keep queue as is, just include boolean logic to put onNext to play the song over
                 //use same boolean logic/value for onPrevious to restart song over
             }
             RepeatType.ONE -> {
-                repeatState.value = RepeatType.OFF
+                _repeatState.value = RepeatType.OFF // v1
+                // repeatState.value = RepeatType.OFF // v2
                 Log.i(TAG, "REPEAT TYPE CHANGED TO OFF")
                 //in checking the queue, if the current song is the last song of the queue, trigger the stop function to end the session/queue
             }
-        }
+        }*/
     }
 
-    override fun increaseSpeed(speed: Duration) {
-        _playerSpeed.value += speed
+    /*override fun increaseSpeed(speed: Duration) {
+        //_playerSpeed.value += speed
     }
 
     override fun decreaseSpeed(speed: Duration) {
-        _playerSpeed.value -= speed
-    }
+        //_playerSpeed.value -= speed
+    }*/
 
-    override fun next() {
-        Log.i(TAG, "in next() function, presumably after a song is skipped.")
-        //val q = queue.value
-        val q = mediaController?.queue
-        if (q?.isEmpty() == true) {
-            return
-        }
-
-        timeElapsed.value = Duration.ZERO
-        val nextSong = q?.get(0)
-        currentSong = nextSong
-        //queue.value = q - nextSong
-        mediaController?.removeMediaItem(0)
-        mediaController?.seekToNextMediaItem()
-        play()
-    }
-
-    override fun previous() {
-        Log.i(TAG, "in previous() function")
-        timeElapsed.value = Duration.ZERO
-        isPlaying.value = false
-
-        mediaController?.seekToPreviousMediaItem()
-
-        timerJob?.cancel()
-        timerJob = null
-    }
-
-    private fun hasNext(): Boolean? {
-        //return queue.value.isNotEmpty()
-        return mediaController?.hasNextMediaItem()
-        //androidx. media3.common. Player Returns whether a next MediaItem exists, which may depend on the current repeat mode and whether shuffle mode is enabled.
-        //Note: When the repeat mode is REPEAT_MODE_ONE, this method behaves the same as when the current repeat mode is REPEAT_MODE_OFF. See REPEAT_MODE_ONE for more details.
-        //This method must only be called if COMMAND_GET_TIMELINE is available.
-    }
-
+    /**
+     * Internal function to shuffle the MediaController queue.
+     */
     private fun shuffleQueue() { //this would get called if the queue itself needs to be shuffled
-//        queue.update {
-//            it.shuffled(Random(RandSeed))
-//        }
         val temp = mediaController?.queue
+        clearQueue()
         temp?.shuffled( Random(RAND_SEED) )?.let {
             mediaController?.setMediaItems( it )
         }
@@ -472,36 +353,13 @@ class SongControllerImpl @Inject constructor(
         // THIS ALSO APPLIES TO NON PLAYLISTS, IE IF AN ALBUM'S ADDED USING SHUFFLE. THE NEW SORT IS THE DEFAULT
         // AND IT WILL BE AT THE TOP OF THE QUEUE, REMOVING THE ORIGINAL CONTEXT BUT KEEPING THE ITEMS THAT WERE
         // "ADD TO QUEUE"
-//        queue.update {
-//            songs.shuffled(Random(RandSeed))
-//        }
-        removeAllFromQueue()
+        clearQueue()
 
         mediaController?.setMediaItems(
             songs.map {
                 it.toMediaItem
             }.shuffled( Random(RAND_SEED) )
         )
-    }
-
-    override fun getIsPlaying() : Boolean {
-        return mediaController?.isPlaying ?: false
-    }
-
-    override fun getIsShuffled() : Boolean {
-        return isShuffled.value
-    }
-
-    override fun getRepeatState() : RepeatType {
-        return repeatState.value
-    }
-
-    override fun getTimeElapsed() : Duration {
-        return timeElapsed.value
-    }
-
-    override fun getHasNext(): Boolean {
-        return mediaController?.hasNextMediaItem() ?: false
     }
 
     override fun isConnected(): Boolean = mediaController?.connectedToken != null

--- a/app/src/main/java/com/example/music/service/Util.kt
+++ b/app/src/main/java/com/example/music/service/Util.kt
@@ -1,0 +1,77 @@
+package com.example.music.service
+
+import android.content.Context
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.MoreExecutors
+import com.google.common.util.concurrent.Uninterruptibles
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.util.concurrent.ExecutionException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Awaits completion of `this` [ListenableFuture] without blocking a thread.
+ *
+ * This suspend function is cancellable.
+ *
+ * If the [Job] of the current coroutine is cancelled or completed while this suspending function is waiting, this function
+ * stops waiting for the future and immediately resumes with [CancellationException][kotlinx.coroutines.CancellationException].
+ *
+ * This method is intended to be used with one-shot Futures, so on coroutine cancellation, the Future is cancelled as well.
+ * If cancelling the given future is undesired, use [Futures.nonCancellationPropagating] or
+ * [kotlinx.coroutines.NonCancellable].
+ */
+internal suspend fun <T> ListenableFuture<T>.await(): T {
+    try {
+        if (isDone) return Uninterruptibles.getUninterruptibly(this)
+    } catch (e: ExecutionException) {
+        // ExecutionException is the only kind of exception that can be thrown from a gotten
+        // Future, other than CancellationException. Cancellation is propagated upward so that
+        // the coroutine running this suspend function may process it.
+        // Any other Exception showing up here indicates a very fundamental bug in a
+        // Future implementation.
+        throw e.cause!!
+    }
+
+    return suspendCancellableCoroutine { cont: CancellableContinuation<T> ->
+        addListener(
+            ToContinuation(this, cont),
+            MoreExecutors.directExecutor()
+        )
+        cont.invokeOnCancellation {
+            cancel(false)
+        }
+    }
+}
+
+/**
+ * Propagates the outcome of [futureToObserve] to [continuation] on completion.
+ *
+ * Cancellation is propagated as cancelling the continuation. If [futureToObserve] completes
+ * and fails, the cause of the Future will be propagated without a wrapping
+ * [ExecutionException] when thrown.
+ */
+private class ToContinuation<T>(
+    val futureToObserve: ListenableFuture<T>,
+    val continuation: CancellableContinuation<T>
+) : Runnable {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun run() {
+        if (futureToObserve.isCancelled) {
+            continuation.cancel()
+        } else {
+            try {
+                continuation.resume(Uninterruptibles.getUninterruptibly(futureToObserve))
+            } catch (e: ExecutionException) {
+                // ExecutionException is the only kind of exception that can be thrown from a gotten
+                // Future. Anything else showing up here indicates a very fundamental bug in a
+                // Future implementation.
+                continuation.resumeWithException(e.cause!!)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/music/ui/MusicApp.kt
+++ b/app/src/main/java/com/example/music/ui/MusicApp.kt
@@ -98,6 +98,18 @@ fun MusicApp(
                 )
             }
 
+            //Player Screen Navigation Router
+            composable(Screen.PlayerV2.route) { backStackEntry ->
+                PlayerScreen(
+                    windowSizeClass = adaptiveInfo.windowSizeClass, //needed for screens meant to use full screen
+                    displayFeatures = displayFeatures, //used to determine physical properties of display device to accommodate view accordingly
+                    navigateBack = appState::navigateBack, //navigation back button
+                    navigateToHome = { appState.navigateToHome(backStackEntry) },
+                    navigateToLibrary = { appState.navigateToLibrary(backStackEntry) },
+                    //navigateToSettings = { appState.navigateToSettings(backStackEntry) },
+                )
+            }
+
             //Library Screen Navigation Router
             composable(Screen.Library.route) { backStackEntry ->
                 LibraryScreen(
@@ -154,6 +166,10 @@ fun MusicApp(
                     // want ability to navigate to song player when song selected to play -- dependent on song list being on screen
                     navigateToPlayer = { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
+                    },
+
+                    navigateToPlayerV2 = {
+                        appState.navigateToPlayerV2(backStackEntry)
                     },
 
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },

--- a/app/src/main/java/com/example/music/ui/MusicApp.kt
+++ b/app/src/main/java/com/example/music/ui/MusicApp.kt
@@ -64,24 +64,18 @@ fun MusicApp(
                     // seems like that could be the case because the navigator in HomeScreenReady gets set to rememberSupportingPaneScaffoldNavigator with scaffoldDirective that starts the calculation process for the features and bounds
 
                     navigateToHome = { appState.navigateToHome(backStackEntry) },
-
-                    //would it make sense to include all the variations of navigable screens that could come from here?
                     navigateToLibrary = { appState.navigateToLibrary(backStackEntry) },
-
                     navigateToAlbumDetails = { album ->
                         appState.navigateToAlbumDetails(album.id, backStackEntry)
                     },
-
                     navigateToPlaylistDetails = { playlist ->
                         appState.navigateToPlaylistDetails(playlist.id, backStackEntry)
                     },
-
                     navigateToPlayer = { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
-
+                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
                     navigateToSettings = { appState.navigateToSettings(backStackEntry) },
-
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) }
                 )
             }
@@ -159,19 +153,11 @@ fun MusicApp(
             composable(Screen.AlbumDetails.route) { backStackEntry ->
                 AlbumDetailsScreen(
                     //windowSizeClass = adaptiveInfo.windowSizeClass, //needed for screens meant to use full screen
-
-                    // want ability to return to previous screen
                     navigateBack = appState::navigateBack,
-
-                    // want ability to navigate to song player when song selected to play -- dependent on song list being on screen
                     navigateToPlayer = { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
-
-                    navigateToPlayerV2 = {
-                        appState.navigateToPlayerV2(backStackEntry)
-                    },
-
+                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
 
                     //dependent on context, ie if showing in pane or as own screen
@@ -184,20 +170,13 @@ fun MusicApp(
                 ArtistDetailsScreen(
                     //keeping for now in case window class size becomes relevant
                     //windowSizeClass = adaptiveInfo.windowSizeClass,
-
-                    // want ability to return to previous screen
                     navigateBack = appState::navigateBack,
-
-                    // want ability to navigate to selected album details
                     navigateToAlbumDetails = { album ->
                         appState.navigateToAlbumDetails(album.id, backStackEntry)
                     },
-
-                    // want ability to navigate to song player when song selected to play -- dependent on song list being on screen
                     navigateToPlayer = { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
-
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
 
                     //dependent on context, ie if showing in pane or as own screen
@@ -211,14 +190,10 @@ fun MusicApp(
                     //keeping for now in case window class size becomes relevant
                     //windowSizeClass = adaptiveInfo.windowSizeClass,
 
-                    // want ability to return to previous screen
                     navigateBack = appState::navigateBack,
-
-                    // want ability to navigate to song player when song selected to play -- dependent on song list being on screen
                     navigateToPlayer = { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
-
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                 )
             }
@@ -229,19 +204,10 @@ fun MusicApp(
                     //keeping for now in case window class size becomes relevant
                     //windowSizeClass = adaptiveInfo.windowSizeClass,
 
-                    // want ability to return to previous screen
                     navigateBack = appState::navigateBack,
-
-                    // want ability to navigate to selected album details
-                    //navigateToAlbumDetails = { album ->
-                        //appState.navigateToAlbumDetails(album.id, backStackEntry)
-                    //},
-
-                    // want ability to navigate to song player when song selected to play -- dependent on song list being on screen
                     navigateToPlayer = { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
-
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                 )
             }
@@ -252,14 +218,10 @@ fun MusicApp(
                     //keeping for now in case window class size becomes relevant
                     //windowSizeClass = adaptiveInfo.windowSizeClass,
 
-                    // want ability to return to previous screen
                     navigateBack = appState::navigateBack,
-
-                    // want ability to navigate to song player when song selected to play -- dependent on song list being on screen
                     navigateToPlayer = { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
-
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                 )
             }

--- a/app/src/main/java/com/example/music/ui/MusicAppState.kt
+++ b/app/src/main/java/com/example/music/ui/MusicAppState.kt
@@ -32,6 +32,10 @@ sealed class Screen(val route: String) {
         fun createRoute(songId: Long) = "player/$songId"
     }
 
+    object PlayerV2 : Screen( "player2") {
+        fun createRoute() = "player2"
+    }
+
     object Search : Screen("search") {
         fun createRoute() = "search"
     }
@@ -165,6 +169,14 @@ class MusicAppState(
         if (from.lifecycleIsResumed()) {
             Log.i(TAG, "***************** SWITCHING TO PLAYER VIEW *****************")
             navController.navigate(Screen.Player.createRoute(songId))
+        }
+    }
+
+    fun navigateToPlayerV2(from: NavBackStackEntry) {
+        // In order to discard duplicated navigation events, we check the Lifecycle
+        if (from.lifecycleIsResumed()) {
+            Log.i(TAG, "***************** SWITCHING TO PLAYER V2 VIEW *****************")
+            navController.navigate(Screen.PlayerV2.createRoute())
         }
     }
 

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
@@ -1,5 +1,6 @@
 package com.example.music.ui.albumdetails
 
+import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring.StiffnessMediumLow
 import androidx.compose.animation.core.animateFloatAsState
@@ -147,12 +148,15 @@ import kotlinx.coroutines.launch
  * 7/22-23/2025 - Removed PlayerSong completely
  */
 
+private const val TAG = "Album Details Screen"
+
 /**
  * Stateful version of Album Details Screen
  */
 @Composable
 fun AlbumDetailsScreen(
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     //navigateToArtist: (ArtistInfo) -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
@@ -174,6 +178,7 @@ fun AlbumDetailsScreen(
                 selectSong = uiState.selectSong,
                 onAlbumAction = viewModel::onAlbumAction,
                 navigateToPlayer = navigateToPlayer,
+                navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
                 navigateBack = navigateBack,
                 showBackButton = showBackButton,
@@ -234,6 +239,7 @@ fun AlbumDetailsScreen(
     //onQueueSong: (SongInfo) -> Unit,
     onAlbumAction: (AlbumAction) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     showBackButton: Boolean,
@@ -381,9 +387,11 @@ fun AlbumDetailsScreen(
                         SongCountAndSortSelectButtons(
                             songs = songs,
                             onSelectClick = {
+                                Log.i(TAG, "Multi Select btn clicked")
                                 // open song selection screen
                             },
                             onSortClick = {
+                                Log.i(TAG, "Song Sort btn clicked")
                                 showBottomSheet = true
                                 showSortSheet = true
                             }
@@ -392,8 +400,16 @@ fun AlbumDetailsScreen(
 
                     fullWidthItem {
                         PlayShuffleButtons(
-                            onPlayClick = { onAlbumAction(AlbumAction.PlayAlbum(songs)) /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
-                            onShuffleClick = { onAlbumAction(AlbumAction.ShuffleAlbum(songs)) /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
+                            onPlayClick = {
+                                Log.i(TAG, "Play Album btn clicked")
+                                onAlbumAction(AlbumAction.PlayAlbum(songs))
+                                navigateToPlayerV2()
+                            },
+                            onShuffleClick = {
+                                Log.i(TAG, "Shuffle Album btn clicked")
+                                onAlbumAction(AlbumAction.ShuffleAlbum(songs))
+                                //navigateToPlayer(songs[1])
+                            },
                         )
                     }
 
@@ -401,10 +417,13 @@ fun AlbumDetailsScreen(
                     items(songs) { song -> // for each song in list:
                         SongListItem(
                                 song = song,
-                                onClick = { navigateToPlayer(song) },
-                                //onMoreOptionsClick = { song, context = "AlbumDetails", content = "SongInfo" }
-                                //or
+                                onClick = {
+                                    Log.i(TAG, "Song clicked: ${song.title}")
+                                    onAlbumAction(AlbumAction.SongClicked(song))
+                                    navigateToPlayerV2()
+                                },
                                 onMoreOptionsClick = {
+                                    Log.i(TAG, "Song More Option clicked: ${song.title}")
                                     onAlbumAction(AlbumAction.SongMoreOptionClicked(song))
                                     showBottomSheet = true
                                     showSongMoreOptions = true
@@ -532,6 +551,7 @@ fun AlbumDetailsScreen(
                     IconButton(
                         onClick = {
                             coroutineScope.launch {
+                                Log.i(TAG, "Scroll to Top btn clicked")
                                 listState.animateScrollToItem(0)
                             }
                         },
@@ -1211,6 +1231,7 @@ fun AlbumDetailsScreenPreview() {
 //            songs = getSongsInAlbum(307),
 
             navigateToPlayer = {},
+            navigateToPlayerV2 = {},
             navigateToSearch = {},
             navigateBack = {},
             showBackButton = true,

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
@@ -100,6 +100,7 @@ import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.min
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.media3.common.util.UnstableApi
 import com.example.music.R
 import com.example.music.designsys.component.AlbumImage
 import com.example.music.designsys.theme.Keyline1
@@ -153,6 +154,7 @@ private const val TAG = "Album Details Screen"
 /**
  * Stateful version of Album Details Screen
  */
+@androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 fun AlbumDetailsScreen(
     navigateToPlayer: (SongInfo) -> Unit,

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
@@ -128,10 +128,10 @@ class AlbumDetailsViewModel @Inject constructor(
     fun onAlbumAction(action: AlbumAction) {
         Log.i(TAG, "onAlbumAction - $action")
         when (action) {
+            //is AlbumAction.AddSongToPlaylist -> onAddToPlaylist(action.song)
+            //is AlbumAction.AddAlbumToPlaylist -> onAddToPlaylist(action.songs)
             is AlbumAction.QueueSong -> onQueueSong(action.song)
-            //is AlbumAction.QueueSongs -> onQueueSongs(action.songs)
-            //is AlbumAction.AddSongToPlaylist -> onAddToPlaylist(action.song) //QueueAlbum?
-            //is AlbumAction.AddAlbumToPlaylist -> onAddToPlaylist(action.songs) //AddToPlaylist?
+            is AlbumAction.QueueSongs -> onQueueSongs(action.songs)
             is AlbumAction.SongMoreOptionClicked -> onSongMoreOptionClick(action.song)
             is AlbumAction.ShuffleAlbum -> onShuffleAlbum(action.songs)
             is AlbumAction.PlayAlbum -> onPlayAlbum(action.songs)
@@ -140,41 +140,43 @@ class AlbumDetailsViewModel @Inject constructor(
     }
 
     private fun onQueueSong(song: SongInfo) {
-        Log.i(TAG, "onQueueSong - ${song.title}")
+        Log.i(TAG, "onQueueSong -> ${song.title}")
         songController.addToQueue(song)
-        //songPlayer.addToQueue(song.toPlayerSong())
     }
 
-    private fun onSongMoreOptionClick(song: SongInfo) {
-        Log.i(TAG, "onSongMoreOptionClick - ${song.title}")
-        selectedSong.value = song
+    private fun onQueueSongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onQueueSongs -> ${songs.size}")
+        songController.addToQueue(songs)
     }
 
     private fun onPlayAlbum(songs: List<SongInfo>) {
-        Log.i(TAG, "onPlayAlbum - ${songs.size}")
-        songController.setMediaItems(songs)
-        //songPlayer.addToQueue( songs.map { it.toPlayerSong() } )
+        Log.i(TAG, "onPlayAlbum -> ${songs.size}")
+        songController.play(songs)
     }
 
     private fun onShuffleAlbum(songs: List<SongInfo>) {
-        Log.i(TAG, "onShuffleAlbum - ${songs.size}")
-        songController.removeAllFromQueue()
+        Log.i(TAG, "onShuffleAlbum -> ${songs.size}")
         songController.shuffle(songs)
-        //songPlayer.shuffle( songs.map { it.toPlayerSong() } )
     }
 
     private fun onSongClicked(song: SongInfo) {
-        Log.i(TAG, "onSongClicked - ${song.title}")
-        songController.setMediaItem(song)
+        Log.i(TAG, "onSongClicked -> ${song.title}")
+        songController.play(song)
+    }
+
+    private fun onSongMoreOptionClick(song: SongInfo) {
+        Log.i(TAG, "onSongMoreOptionClick -> ${song.title}")
+        selectedSong.value = song
     }
 }
 
 sealed interface AlbumAction {
     data class QueueSong(val song: SongInfo) : AlbumAction
-    data class SongMoreOptionClicked(val song: SongInfo) : AlbumAction
+    data class QueueSongs(val songs: List<SongInfo>) : AlbumAction
     data class PlayAlbum(val songs: List<SongInfo>) : AlbumAction
     data class ShuffleAlbum(val songs: List<SongInfo>) : AlbumAction
     data class SongClicked(val song: SongInfo) : AlbumAction
+    data class SongMoreOptionClicked(val song: SongInfo) : AlbumAction
 }
 
 /**

--- a/app/src/main/java/com/example/music/ui/home/Home.kt
+++ b/app/src/main/java/com/example/music/ui/home/Home.kt
@@ -218,6 +218,7 @@ fun MainScreen(
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -231,6 +232,7 @@ fun MainScreen(
             navigateToPlaylistDetails = navigateToPlaylistDetails,
             navigateToLibrary = navigateToLibrary,
             navigateToPlayer = navigateToPlayer,
+            navigateToPlayerV2 = navigateToPlayerV2,
             navigateToSearch = navigateToSearch,
             navigateToSettings = navigateToSettings,
             viewModel = viewModel,
@@ -277,6 +279,7 @@ private fun HomeScreenReady(
     navigateToSettings: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     viewModel: HomeViewModel = hiltViewModel()
@@ -309,6 +312,7 @@ private fun HomeScreenReady(
                     navigateToPlaylistDetails = navigateToPlaylistDetails,
                     navigateToLibrary = navigateToLibrary,
                     navigateToPlayer = navigateToPlayer,
+                    navigateToPlayerV2 = navigateToPlayerV2,
                     navigateToSettings = navigateToSettings,
                     navigateToSearch = navigateToSearch,
                     modifier = Modifier.fillMaxSize()
@@ -359,6 +363,7 @@ private fun HomeScreen(
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     // Effect that changes the home category selection when there are no subscribed podcasts
@@ -437,6 +442,7 @@ private fun HomeScreen(
                     navigateToAlbumDetails = navigateToAlbumDetails,
                     navigateToPlaylistDetails = navigateToPlaylistDetails,
                     navigateToPlayer = navigateToPlayer,
+                    navigateToPlayerV2 = navigateToPlayerV2
                 )
             }
         }
@@ -498,6 +504,7 @@ private fun HomeContent(
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit
 ) {
     // Main Content on Home screen
     //logger.info { "Home Content function start" }
@@ -529,6 +536,7 @@ private fun HomeContent(
         navigateToAlbumDetails = navigateToAlbumDetails,
         navigateToPlaylistDetails = navigateToPlaylistDetails,
         navigateToPlayer = navigateToPlayer,
+        navigateToPlayerV2 = navigateToPlayerV2
     )
 
     if(showBottomSheet) {
@@ -554,6 +562,7 @@ private fun HomeContentGrid(
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
 ) {
     //logger.info { "Home Content Grid function start" }
     LazyVerticalGrid(
@@ -647,7 +656,10 @@ private fun HomeContentGrid(
                 Box(Modifier.padding(horizontal = 12.dp, vertical = 0.dp)) {
                     HomeSongListItem(
                         song = song,
-                        onClick = navigateToPlayer,
+                        onClick = {
+                            onHomeAction(HomeAction.SongClicked(song))
+                            navigateToPlayerV2()
+                        },
                         //onQueueSong = { },
                         onMoreOptionsClick = { onMoreOptionsClick(song) },
                         modifier = Modifier.fillMaxWidth(),
@@ -811,6 +823,7 @@ private fun PreviewHome() {
             navigateToAlbumDetails = {},
             navigateToPlaylistDetails = {},
             navigateToPlayer = {},
+            navigateToPlayerV2 = {},
         )
     }
 }

--- a/app/src/main/java/com/example/music/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/home/HomeViewModel.kt
@@ -12,6 +12,8 @@ import com.example.music.domain.model.PlaylistInfo
 import com.example.music.data.util.combine
 import com.example.music.domain.model.SongInfo
 import com.example.music.domain.usecases.GetTotalCountsV2
+import com.example.music.service.SongController
+import com.example.music.ui.albumdetails.AlbumAction
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -38,7 +40,7 @@ class HomeViewModel @Inject constructor(
     featuredLibraryItemsV2: FeaturedLibraryItemsV2,
     getTotalCountsV2: GetTotalCountsV2,
     //private val searchQueryV2: SearchQueryV2,
-    //private val songPlayer: SongPlayer
+    private val songController: SongController
 ) : ViewModel() {
     /* ------ Current running UI needs:  ------
         objects: FeaturedLibraryItemsFilterResult, which contains
@@ -155,17 +157,18 @@ class HomeViewModel @Inject constructor(
     fun onHomeAction(action: HomeAction) {
         Log.i(TAG, "onHomeAction - $action")
         when (action) {
-            //is HomeAction.ToggleNavMenu -> onNavigationViewMenu()
+            is HomeAction.EmptyLibraryView -> onEmptyPlaylistView()
             is HomeAction.LibraryAlbumSelected -> onLibraryAlbumSelected(action.album)
             //is HomeAction.LibraryPlaylistSelected -> onLibraryPlaylistSelected(action.playlist)
-            is HomeAction.EmptyLibraryView -> onEmptyPlaylistView()
             is HomeAction.QueueSong -> onQueueSong(action.song)
             //is HomeAction.SendQuery -> onQuerySearch(action.query)
+            is HomeAction.SongClicked -> onSongClicked(action.song)
+            is HomeAction.SongMoreOptionClicked -> onSongMoreOptionClick(action.song)
         }
     }
 
-    private fun onMoreOptionsBtnClicked(item: Any) {
-
+    private fun onEmptyPlaylistView() {
+        //featuredPlaylists = null
     }
 
     private fun onMoreBtnClicked(item: Any) {
@@ -175,27 +178,25 @@ class HomeViewModel @Inject constructor(
     //private fun onLibraryPlaylistSelected(playlist: PlaylistInfo) {
         //selectedLibraryPlaylist.value = playlist
     //}
+
     private fun onLibraryAlbumSelected(album: AlbumInfo) {
         selectedLibraryAlbum.value = album
     }
 
-    private fun onEmptyPlaylistView() {
-        //featuredPlaylists = null
-    }
-
     private fun onQueueSong(song: SongInfo) {
-        //songPlayer.addToQueue(song)
+        Log.i(TAG, "onQueueSong -> ${song.title}")
+        songController.addToQueue(song)
     }
 
-//    private fun onQuerySearch(query: String) {
-//        logger.info { query }
-//        viewModelScope.launch {
-//            searchResults.value = searchQueryV2(query)
-//            // now that I have the songs, artists, albums ... how do i get them onto the UI?
-//            //  or is this a case where I should have created a different 'screen' or 'activity' or 'fragment'
-//            //  and have that handle the result -> UI conversion?
-//        }
-//    }
+    private fun onSongClicked(song: SongInfo) {
+        Log.i(TAG, "onSongClicked -> ${song.title}")
+        songController.play(song)
+    }
+
+    private fun onSongMoreOptionClick(song: SongInfo) {
+        Log.i(TAG, "onSongMoreOptionClick -> ${song.title}")
+        // open bottom sheet for song more options
+    }
 }
 
 /**
@@ -213,7 +214,8 @@ sealed interface HomeAction {
     data class LibraryAlbumSelected(val album: AlbumInfo) : HomeAction
     //data class LibraryPlaylistSelected(val playlist: PlaylistInfo) : HomeAction
     data class QueueSong(val song: SongInfo) : HomeAction
-    //data class SendQuery(val query: String) : HomeAction
+    data class SongClicked(val song: SongInfo) : HomeAction
+    data class SongMoreOptionClicked(val song: SongInfo) : HomeAction
 }
 
 @Immutable
@@ -222,5 +224,4 @@ data class HomeScreenUiState(
     val errorMessage: String? = null,
     val featuredLibraryItemsFilterResult: FeaturedLibraryItemsFilterV2 = FeaturedLibraryItemsFilterV2(),
     val totals: List<Int> = emptyList(),
-    //val searchResults: SearchQueryFilterV2 = SearchQueryFilterV2(),
 )

--- a/app/src/main/java/com/example/music/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/player/PlayerViewModel.kt
@@ -1,25 +1,60 @@
 package com.example.music.ui.player
 
 import android.util.Log
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.core.content.res.TypedArrayUtils.getText
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.SavedStateHandleSaveableApi
+import androidx.lifecycle.viewmodel.compose.saveable
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaController
+import com.example.music.R
 import com.example.music.data.repository.RepeatType
 import com.example.music.data.util.combine
 import com.example.music.domain.model.SongInfo
+import com.example.music.domain.model.toSongInfo
+import com.example.music.domain.player.model.duration
+import com.example.music.domain.player.model.mediaUri
+import com.example.music.domain.player.model.title
+import com.example.music.domain.player.model.toMediaItem
+import com.example.music.domain.testing.getSongData
 import com.example.music.service.SongController
 import com.example.music.domain.usecases.GetSongDataV2
 import com.example.music.ui.Screen
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.lang.Thread.State
 import java.time.Duration
 import javax.inject.Inject
+import kotlin.math.log
+import kotlin.math.roundToLong
 
 /** Changelog:
  *
@@ -29,124 +64,179 @@ import javax.inject.Inject
 
 private const val TAG = "Player View Model"
 
+// possible v2 for PlayerUiState since all the details on the screen are actually reliant on SongController data
 data class PlayerUiState(
-    //val songControllerState: SongControllerState = SongControllerState()
     val isReady: Boolean = false,
     val errorMessage: String? = null,
-    //val _currentSong: MediaItem,
     val currentSong: SongInfo = SongInfo(),
-    val isPlaying: Boolean = false,
-    val isShuffled: Boolean = false,
-    val repeatState: RepeatType = RepeatType.OFF,
-    val timeElapsed: Duration = Duration.ZERO,
-    val hasNext: Boolean = false,
-    // put in there the variables that would be necessary for populating values to the view model
-    // make sure to remove as many dependencies from songController and its state as i can
 )
+
+interface PlayerState {
+    val currentMedia: MediaItem?
+    var isPlaying: Boolean
+    val player: Player?
+    var progress: Float
+    var position: Long
+}
+
+/**
+ * Tracks the current playback position as a fraction of the current duration.
+ */
+val SongController.progress
+    get() =
+        if (duration == C.TIME_UNSET || position == C.TIME_UNSET) -1f
+        else position / duration.toFloat()
 
 /**
  * ViewModel that handles the business logic and screen state of the Player screen
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class PlayerViewModel @Inject constructor(
-    //val mediaPlayer: Player,
-    //appPreferencesRepo: AppPreferencesRepo,
-    getSongDataV2: GetSongDataV2,
+    private val getSongDataV2: GetSongDataV2,
     private val songController: SongController,
-    savedStateHandle: SavedStateHandle,
-) : ViewModel() {
+    //savedStateHandle: SavedStateHandle,
+) : ViewModel(), PlayerState {
 
+    /* // ------- Intended idea with revised PlayerViewModel: ------
+    // Have PlayerScreen show the current values of SongController -> ie MediaService/MediaPlayer
+    // And to do so, want to be able to reference mutable state values that are coming directly from song controller
+    // Hopefully, by setting values through mutableStateOf that use songController values directly
+    // without a songControllerState will mean that it won't be setting PlayerVM with null/dead values */
+
+    private var _isPlaying by mutableStateOf(songController.isPlaying)
+    private var _position by mutableLongStateOf(songController.position)
+    private var _progress by mutableFloatStateOf(songController.progress)
+    //private var _isShuffled = MutableStateFlow(false)
+    //private val _repeatState = MutableStateFlow(0)
+
+    var currentSong by mutableStateOf(SongInfo())
+    val hasNext by mutableStateOf(songController.hasNext)
+
+    override var currentMedia: MediaItem? by mutableStateOf(songController.currentSong)
+    override val player: Player? get() = songController.player
+    override var isPlaying
+        get() = _isPlaying
+        set(value) {
+            if (value) songController.play(true)
+            else songController.pause()
+        }
+    override var progress: Float
+        get() = _progress
+        set(value) {
+            if (_progress !in 0f..1f) return // invalid state
+            _progress = value
+            val millis = (songController.duration * value).roundToLong()
+            songController.seekTo(millis)
+        }
+    override var position: Long
+        get() = _position
+        set(value) {
+            if (_position > songController.duration) return // invalid state
+            _position = value
+        }
+
+    private var timerJob: Job? = null
+
+    /* // OG method for getting SongInfo when navigating to PlayerScreen:
     // songId should always be present in the PlayerViewModel.
     // If that's not the case, fail crashing the app!
     private val _songId: String =
         savedStateHandle.get<String>(Screen.ARG_SONG_ID)!! //Uri.decode(savedStateHandle.get<String>(Screen.ARG_EPISODE_URI)!!)
     private val songId = _songId.toLong()
-
     private val getSongData = getSongDataV2(songId)
-        .shareIn(viewModelScope, SharingStarted.WhileSubscribed())
-    private var currentSong: SongInfo? = null
-
-    private val _state = MutableStateFlow(PlayerUiState())
+        .shareIn(viewModelScope, SharingStarted.WhileSubscribed()) */
 
     private val refreshing = MutableStateFlow(false)
 
-    val state: StateFlow<PlayerUiState>
-        get() = _state
-
     init {
-        Log.i(TAG, "songID: $songId")
+        Log.i(TAG, "init START")
+
         viewModelScope.launch {
-            Log.i(TAG, "init viewModelScope launch start")
-            //Note: using for comparison between SongToAlbum/SongInfo against PlayerSong for populating Player Screen
-            //songRepo.getSongAndAlbumBySongId(songId).flatMapConcat { //original code: used to get SongToAlbum to convert to PlayerSong,
-            //songPlayer.currentSong = it.toPlayerSong() //original code: used to set songPlayer.currentSong from SongToAlbum to PlayerSong
+            Log.i(TAG, "init viewModelScope START")
 
-            //here would need to take in songId and correlate it to Audio in MediaStore, retrieve data and populate a MediaItem to be a MediaSource for MediaService
-            // then populate queue and start play
+            // Use SongController events to generate or update the Player Screen as the Player object changes
+            songController.events.collect {
+                Log.d(TAG, "get SongController Player Event(s)")
 
-            combine(
-                refreshing,
-                getSongData,
-            ) {
-                refreshing,
-                songData, ->
-                Log.i(TAG, "PlayerUiState call")
-                Log.i(TAG, "getSongID: ${songData.id}")
-                Log.i(TAG, "getSongTitle: ${songData.title}")
-
-                currentSong = songData
-                songController.setMediaItem(songData)
-                //songController.play(songData)
-                Log.i(TAG, "is SongController available: ${songController.isConnected()}")
-                Log.i(TAG, "isReady?: ${!refreshing}")
-
-                PlayerUiState(
-                    isReady = !refreshing,
-                    currentSong = songData,
-                    isPlaying = songController.getIsPlaying(),
-                    isShuffled = songController.getIsShuffled(),
-                    repeatState = songController.getRepeatState(),
-                    timeElapsed = songController.getTimeElapsed(),
-                    hasNext = songController.getHasNext()
-                )
-                /* // previous version of getting song data to set PlayerUiState and songController
-                getSongDataV2(songId).flatMapConcat { item ->
-                    //this needs to start the song controller with the id
-                    // so it can set the player/mediaPlayer with the correct data to work on
-
-                    //the actual logic here might not actually apply to here but more so to media session but just for now to see if the problem of player not playing anything might be here
-                    // want to make sure that the controller can propagate the songId from PlayerScreen to mediaPlayer
-                    // so need to setMediaItem to item
-
-                    songController.setMediaItem(item)
-                    songController.currentSong = item.toMediaItem
-                    songController.playerState
+                // if events is empty, take these actions to generate the needed values for populating the Player Screen
+                if (it == null) {
+                    Log.d(TAG, "init: running start up events to initialize PlayerVM")
+                    //shuffle mode enabled changed goes here
+                    //repeat mode enabled changed goes here
+                    onPlayerEvent(event = Player.EVENT_IS_LOADING_CHANGED)
+                    onPlayerEvent(event = Player.EVENT_PLAY_WHEN_READY_CHANGED)
+                    onPlayerEvent(event = Player.EVENT_MEDIA_ITEM_TRANSITION)
+                    onPlayerEvent(event = Player.EVENT_IS_PLAYING_CHANGED)
+                    return@collect
                 }
-                */
-
-            }.catch { throwable ->
-                emit(
-                    PlayerUiState(
-                        isReady = true,
-                        errorMessage = throwable.message
-                    )
-                )
-            }.collect{
-                _state.value = it
+                // else, repeat the onPlayerEvent call to enact each event
+                repeat(it.size()) { index ->
+                    onPlayerEvent(it.get(index))
+                }
             }
-            /* // original version
-            songRepo.getSongById(songId).flatMapConcat {
-                songPlayer.currentSong = getSongDataUseCase(it).first() //getSongDataUseCase returns Flow<PlayerSong>, so use single() to retrieve the PlayerSong
-                songPlayer.playerState
-            }.map {
-                PlayerUiState(songPlayerState = it)
-            }.collect {
-                uiState = it
-            }*/
+            playWhenReady()
+            Log.i(TAG, "init viewModelScope END")
         }
-        refresh(force = false)
-        playWhenReady()
+        Log.i(TAG, "init END")
+    }
+
+    /**
+     * Subset of Player Events that impact the Player Screen, and so need to reference them
+     * to retrieve their changes accordingly.
+     */
+    private fun onPlayerEvent(event: Int) {
+        logPlayerEvent(event)
+        when (event) {
+            // Event for checking if the SongController is loaded and ready to read
+            Player.EVENT_IS_LOADING_CHANGED -> {
+                val loaded = songController.loaded
+                if (loaded.equals(true)) {
+                    refreshing.value = false
+                }
+                Log.d(TAG, "isPlaying set to $isPlaying")
+            }
+
+            // Event for checking if SongController is playing
+            Player.EVENT_IS_PLAYING_CHANGED -> {
+                _isPlaying = songController.isPlaying
+                Log.d(TAG, "isPlaying set to $isPlaying")
+            }
+
+            // Event for checking if the current media item has changed
+            Player.EVENT_MEDIA_ITEM_TRANSITION -> {
+                val mediaItem = songController.currentSong
+                viewModelScope.launch {
+                    var id = mediaItem?.mediaId
+                    while (id == null) {
+                        delay(100)
+                        id = mediaItem?.mediaId
+                    }
+                    currentSong = getSongDataV2(id.toLong())
+                }
+                Log.d(TAG, "Current Song set to ${currentSong.title}")
+            }
+
+            // Event for checking if play when ready has changed
+            Player.EVENT_PLAY_WHEN_READY_CHANGED -> {
+                _isPlaying = songController.playWhenReady
+                timerJob?.cancel()
+                if (!songController.playWhenReady)
+                    return
+                launchTimer(isPlaying)
+                Log.d(TAG, "Play When Ready set to $isPlaying")
+            }
+
+            // Event for checking if the current playback timer has changed
+            Player.EVENT_TIMELINE_CHANGED -> {
+                updateTimer()
+            }
+
+            // Event for checking if the repeat state has changed
+            //Player.EVENT_REPEAT_MODE_CHANGED -> {}
+
+            // Event for checking if the shuffle mode is enabled
+            //Player.EVENT_SHUFFLE_MODE_ENABLED_CHANGED -> {}
+        }
     }
 
     fun refresh(force: Boolean = true) {
@@ -166,72 +256,211 @@ class PlayerViewModel @Inject constructor(
     }
 
     /**
-     * Intent: to autoplay the loaded song when the screen is loaded and the songController has the selected song queued
+     * Begin the timerJob coroutine for tracking the position and progress of the current item
+     * playback. While play is true, keep updating every 1000ms.
      */
+    private fun launchTimer(play: Boolean = true) {
+        Log.i(TAG, "Start timer tracker coroutine")
+        timerJob = viewModelScope.launch {
+            while (play) {
+                _progress = songController.progress
+                _position = songController.position
+                delay(1000)
+            }
+        }
+    }
+
+    /**
+     * Update the progress and position of the current item playback. Does not
+     * change the timerJob itself.
+     */
+    private fun updateTimer() {
+        _progress = songController.progress
+        _position = songController.position
+    }
+
+    /**
+     * Stop the timerJob tracker.
+     */
+    private fun stopTimer() {
+        timerJob?.cancel()
+        timerJob = null
+    }
+
     fun playWhenReady() {
+        Log.i(TAG, "Preparing Player - play when ready")
         songController.preparePlayer()
-        //songController.play(currentSong!!)
     }
 
     fun onPlay() {
-        Log.i(TAG,"Hitting play on Player Screen.")
-        songController.play(currentSong!!)
-        //mediaPlayer.play()
+        Log.i(TAG,"Hit play btn on Player Screen.")
+        songController.play(true)
     }
 
     fun onPause() {
-        Log.i(TAG, "Hitting pause on Player Screen")
+        Log.i(TAG, "Hit pause btn on Player Screen")
         songController.pause()
-        //mediaPlayer.pause()
     }
 
     fun onStop() {
         Log.i(TAG, "Stop the Player Screen")
+        _isPlaying = false
+        stopTimer()
         songController.stop()
-        //mediaPlayer.stop()
     }
 
     fun onPrevious() {
-        Log.i(TAG, "Hitting previous button on Player Screen")
+        Log.i(TAG, "Hit previous btn on Player Screen")
         songController.previous()
-        //mediaPlayer.seekToPrevious()
+        updateTimer()
     }
 
     fun onNext() {
-        Log.i(TAG, "Hitting next button on Player Screen")
+        Log.i(TAG, "Hit next btn on Player Screen")
         songController.next()
-        //mediaPlayer.seekToNextMediaItem()
+        updateTimer()
     }
 
-    fun onSeekingStarted() {
-        songController.onSeekingStarted()
-        //mediaPlayer.seekToDefaultPosition()
-    }
-
-    fun onSeekingFinished(duration: Duration) {
-        songController.onSeekingFinished(duration)
-        //mediaPlayer.seekTo(duration.toMillis())
+    fun onSeek(position: Long) {
+        Log.i(TAG, "Seeking on Player Screen slider: new time -> $position")
+        songController.seekTo(position)
+        updateTimer()
     }
 
     fun onShuffle() {
-        Log.i(TAG, "Hitting shuffle button on Player Screen")
-        songController.onShuffle()
-        //mediaPlayer.shuffleModeEnabled
+        Log.i(TAG, "Hit shuffle btn on Player Screen")
+        //songController.onShuffle()
     }
 
     fun onRepeat() {
-        Log.i(TAG, "Hitting repeat button on Player Screen")
-        songController.onRepeat()
-        //mediaPlayer.repeatMode
-    }
-
-    fun setCurrSong(song: SongInfo) {
-        currentSong = song
+        Log.i(TAG, "Hit repeat btn on Player Screen")
+        //songController.onRepeat()
     }
 
     fun onDestroy() {
-        //onClose()
-        //mediaPlayer.release()
+        stopTimer()
+        player?.release()
     }
 
+    private fun logPlayerEvent(event: Int) {
+        var s = ""
+        when (event) {
+            Player.EVENT_TIMELINE_CHANGED -> {
+                s = "event timeline changed"
+            } // 0
+            Player.EVENT_MEDIA_ITEM_TRANSITION -> {
+                s = "event current media item changed or current item repeating"
+            } // 1
+            Player.EVENT_TRACKS_CHANGED -> {
+                s = "event tracks changed"
+            } // 2
+            Player.EVENT_IS_LOADING_CHANGED -> {
+                s = "event is loading changed"
+            } // 3
+            Player.EVENT_PLAYBACK_STATE_CHANGED -> {
+                s = "event playback state changed"
+            } // 4
+            Player.EVENT_PLAY_WHEN_READY_CHANGED -> {
+                s = "event play when ready changed"
+            } // 5
+            Player.EVENT_PLAYBACK_SUPPRESSION_REASON_CHANGED -> {
+                s = "event playback suppression reason changed"
+            } // 6
+            Player.EVENT_IS_PLAYING_CHANGED -> {
+                s = "event is playing changed"
+            } // 7
+            Player.EVENT_REPEAT_MODE_CHANGED -> {
+                s = "event repeat mode changed"
+            } // 8
+            Player.EVENT_SHUFFLE_MODE_ENABLED_CHANGED -> {
+                s = "event shuffle mode enabled changed"
+            } // 9
+            Player.EVENT_PLAYER_ERROR -> {
+                s = "event player error occurred"
+            } // 10
+            Player.EVENT_POSITION_DISCONTINUITY -> {
+                s = "event position discontinuity occurred"
+                /** Note:
+                 * A position discontinuity occurs when the playing period changes, the playback
+                 * position jumps within the period currently being played, or when the playing
+                 * period has been skipped or removed.
+                 * onEvents(Player, Player. Events) will also be called to report this event along
+                 * with other events that happen in the same Looper message queue iteration.
+                 */
+            } // 11
+            Player.EVENT_PLAYBACK_PARAMETERS_CHANGED -> {
+                s = "event playback parameters changed"
+            } // 12
+            Player.EVENT_AVAILABLE_COMMANDS_CHANGED -> {
+                s = "event player's command(s) availability changed"
+            } // 13
+            Player.EVENT_MEDIA_METADATA_CHANGED -> {
+                s = "event media metadata changed"
+            } // 14
+            Player.EVENT_PLAYLIST_METADATA_CHANGED -> {
+                s = "event playlist metadata changed"
+            } // 15
+            Player.EVENT_SEEK_BACK_INCREMENT_CHANGED -> {
+                s = "event seek back increment changed"
+            } // 16
+            Player.EVENT_SEEK_FORWARD_INCREMENT_CHANGED -> {
+                s = "event seek forward increment changed"
+            } // 17
+            Player.EVENT_MAX_SEEK_TO_PREVIOUS_POSITION_CHANGED -> {
+                s = "event max seek to previous position changed"
+            } // 18
+            Player.EVENT_TRACK_SELECTION_PARAMETERS_CHANGED -> {
+                s = "event track selection parameters changed"
+            } // 19
+            Player.EVENT_AUDIO_ATTRIBUTES_CHANGED -> {
+                s = "event audio attributes changed"
+            } // 20
+            Player.EVENT_AUDIO_SESSION_ID -> {
+                s = "event audio session id set"
+            } // 21
+            Player.EVENT_VOLUME_CHANGED -> {
+                s = "event volume changed"
+            } // 22
+            Player.EVENT_SKIP_SILENCE_ENABLED_CHANGED -> {
+                s = "event skip silence enabled changed"
+            } // 23
+            Player.EVENT_SURFACE_SIZE_CHANGED -> {
+                s = "event surface size changed"
+                /**
+                 * Note:
+                 * This is for video rendering, which is not a supported MIME type in the app.
+                 * So this shouldn't occur.
+                 */
+            } // 24
+            Player.EVENT_VIDEO_SIZE_CHANGED -> {
+                s = "event video size changed"
+                /**
+                 * Note:
+                 * This is for video rendering, which is not a supported MIME type in the app.
+                 * So this shouldn't occur.
+                 */
+            } // 25
+            Player.EVENT_RENDERED_FIRST_FRAME -> {
+                s = "event first frame rendered"
+                /**
+                 * Note:
+                 * This is for video rendering, which is not a supported MIME type in the app.
+                 * So this shouldn't occur.
+                 */
+            } // 26
+            Player.EVENT_CUES -> {
+                s = "event cues changed"
+            } // 27
+            Player.EVENT_METADATA -> {
+                s = "event metadata playback changed"
+            } // 28
+            Player.EVENT_DEVICE_INFO_CHANGED -> {
+                s = "event device info changed"
+            } // 29
+            Player.EVENT_DEVICE_VOLUME_CHANGED -> {
+                s = "event device volume changed"
+            } // 30
+        }
+        Log.d(TAG, "SongController onEvent: -> $event :: $s")
+    }
 }

--- a/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
+++ b/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
@@ -77,6 +77,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -1748,10 +1749,10 @@ fun BottomSheetFullPlayer(
 
                 //slider row
                 PlayerSlider(
-                    timeElapsed = Duration.ZERO,
+                    progress = 0f,
+                    timeElapsed = 0L,
                     songDuration = song.duration,
-                    onSeekingStarted = {},
-                    onSeekingFinished = {},
+                    onSeek = {},
                 )
             }
         }
@@ -1821,9 +1822,8 @@ fun BottomSheetPlayerButtons(
             contentScale = ContentScale.Inside,
             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onPrimaryContainer),
             modifier = sideButtonsModifier
-                .clickable(enabled = true, onClick = onNext)
-                //.clickable(enabled = hasNext, onClick = onNext)
-                //.alpha(if (hasNext) 1f else 0.25f)
+                .clickable(enabled = hasNext, onClick = onNext)
+                .alpha(if (hasNext) 1f else 0.25f)
         )
     }
 }

--- a/core/data/src/main/java/com/example/music/data/di/DataDiModule.kt
+++ b/core/data/src/main/java/com/example/music/data/di/DataDiModule.kt
@@ -1,6 +1,7 @@
 package com.example.music.data.di
 
 import android.content.Context
+import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
@@ -42,6 +43,7 @@ import kotlinx.coroutines.SupervisorJob
 import javax.inject.Singleton
 
 private const val APP_PREFERENCES = "app_preferences.pb"
+private const val TAG = "Data-DI-Module"
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -57,31 +59,29 @@ object DataDiModule {
     @Singleton
     fun provideMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
 
-//    @Provides
-//    @Singleton
-//    fun provideOkHttpClient(
-//        @ApplicationContext context: Context
-//    ): OkHttpClient = OkHttpClient.Builder()
-//        .cache(Cache(File(context.cacheDir, "http_cache"), (20 * 1024 * 1024).toLong()))
-//        .apply {
-//            if (BuildConfig.DEBUG) eventListenerFactory(LoggingEventListener.Factory())
-//        }
-//        .build() // Question: do i still need this if I do not want my app to rely on network calls?
+    /*@Provides
+    @Singleton
+    fun provideOkHttpClient(
+        @ApplicationContext context: Context
+    ): OkHttpClient = OkHttpClient.Builder()
+        .cache(Cache(File(context.cacheDir, "http_cache"), (20 * 1024 * 1024).toLong()))
+        .apply {
+            if (BuildConfig.DEBUG) eventListenerFactory(LoggingEventListener.Factory())
+        }
+        .build() // Question: do i still need this if I do not want my app to rely on network calls?*/
 
     @Provides
     @Singleton
     fun provideDatabase(
         @ApplicationContext context: Context
-    ): MusicDatabase =
-        Room.databaseBuilder(context, MusicDatabase::class.java, "music.db")
-            // This is not recommended for normal apps, but the goal of this sample isn't to
-            // showcase all of Room.
-            // Question: why is this not recommended for normal apps?
-
+    ): MusicDatabase {
+        Log.i(TAG, "Providing Music Database")
+        return Room.databaseBuilder(context, MusicDatabase::class.java, "music.db")
             .fallbackToDestructiveMigration()
             .createFromAsset("preview_data.db")
             //.fallbackToDestructiveMigration()
             .build()
+    }
 
     /* //coil image loader
     @Provides
@@ -97,21 +97,24 @@ object DataDiModule {
     @Singleton
     fun providePreferencesDataStore(
         @ApplicationContext appContext: Context
-    ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
-        /*corruptionHandler = ReplaceFileCorruptionHandler(
-            produceNewData = { emptyPreferences() }
-        ),
-        migrations = listOf(
-            object : DataMigration<Preferences> {
-                override suspend fun cleanUp() { TODO("clean up Not yet implemented") }
-                override suspend fun migrate(currentData: Preferences): Preferences { TODO("migrate Not yet implemented") }
-                override suspend fun shouldMigrate(currentData: Preferences): Boolean { TODO("should migrate Not yet implemented") }
-            },
-        ),*/
-        corruptionHandler = null,
-        scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
-        produceFile = { appContext.preferencesDataStoreFile(APP_PREFERENCES) }
-    )
+    ): DataStore<Preferences> {
+        Log.i(TAG, "Providing Preferences DataStore")
+        return PreferenceDataStoreFactory.create(
+            /*corruptionHandler = ReplaceFileCorruptionHandler(
+                produceNewData = { emptyPreferences() }
+            ),
+            migrations = listOf(
+                object : DataMigration<Preferences> {
+                    override suspend fun cleanUp() { TODO("clean up Not yet implemented") }
+                    override suspend fun migrate(currentData: Preferences): Preferences { TODO("migrate Not yet implemented") }
+                    override suspend fun shouldMigrate(currentData: Preferences): Boolean { TODO("should migrate Not yet implemented") }
+                },
+            ),*/
+            corruptionHandler = null,
+            scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+            produceFile = { appContext.preferencesDataStoreFile(APP_PREFERENCES) }
+        )
+    }
 
     @Provides
     @Singleton

--- a/core/domain/src/main/java/com/example/music/domain/di/DomainDiModule.kt
+++ b/core/domain/src/main/java/com/example/music/domain/di/DomainDiModule.kt
@@ -4,6 +4,8 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 
+private const val TAG = "Domain-DI-Module"
+
 @Module
 @InstallIn(SingletonComponent::class)
 object DomainDiModule {

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetSongDataV2.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetSongDataV2.kt
@@ -6,6 +6,7 @@ import com.example.music.domain.model.asExternalModel
 import com.example.music.data.mediaresolver.MediaRepo
 import com.example.music.data.mediaresolver.model.uri
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -21,19 +22,16 @@ class GetSongDataV2 @Inject constructor(
     private val mediaRepo: MediaRepo
 ) {
     // use to build SongInfo from an Audio id
-    operator fun invoke(songId: Long): Flow<SongInfo> {
+    suspend operator fun invoke(songId: Long): SongInfo {
         Log.i(TAG, "Fetching Data for single song - start\n" +
                 "songId: $songId")
-
-        return mediaRepo.getAudioFlow(songId)
-            .map {
-                Log.i(TAG, "Found file data for song $songId\n" +
-                        "Title: ${it.title}\n" +
-                        "Artist: ${it.artist}\n" +
-                        "Album: ${it.album}")
-                it.asExternalModel()
-                    .copy(artworkBitmap = mediaRepo.loadThumbnail(it.uri))
-            }
+        val audio = mediaRepo.getAudioFlow(songId).first()
+        Log.i(TAG, "Found file data for song $songId\n" +
+                "Title: ${audio.title}\n" +
+                "Artist: ${audio.artist}\n" +
+                "Album: ${audio.album}")
+        return audio.asExternalModel()
+            .copy(artworkBitmap = mediaRepo.loadThumbnail(audio.uri))
     }
 
     // use to build list of SongInfo from list of Audio ids


### PR DESCRIPTION
### Description: 
There were two main problems for why the Player Screen was unable to load correctly when the app plays songs. 

First was that the view model was never fully connected a player whose state it could read. It can get the initial status because that's from directly calling SongController and initializing it then. But after that, the Player View Model had no callbacks, no listeners, nothing. So instead of continuing decoupling the PlayerViewModel from SongController, I doubled down on making PlayerViewModel completely reliant on it so every screen property is based on it.

And second, is that SongController itself wasn't very good at providing the PlayerViewModel with Player states. I hadn't correctly injected the singleton Player object for either of them to access, which meant neither of them were ever going to be in lock step with MediaService. So now they're all mostly in line with each other.

### Changes Made: 
- to MediaService: added loggers for tracking events logic, cleaned up some comments
- to SongController: revised all properties and methods to connect Player and MediaController settings
- to PlayerScreen: revised all properties to be mutable states of SongController properties, use a timerJob to keep updating the PlayerSlider position
- to MusicApp navigation: added PlayerV2 navigation route as a secondary way to open PlayerScreen
- to HomeScreen: added PlayerV2 navigation route for testing new PlayerScreen and SongController functions
- to AlbumDetailsScreen: added PlayerV2 navigation route for testing new PlayerScreen and SongController functions
- to BottomModals: updated after adjusting Player Screen's Player Slider
- to Dependency Injector modules: added loggers to the UI, Data, Domain singleton modules
- to GetSongDataV2 use case: changed the get single song invoke function to be suspend and return SongInfo 

### Related Issues:
Fixes Issue #3 
Opens Issue #10 and #11 to address the onShuffle and onRepeat functions that were commented out.
Opens Issue #12 to address updating the rest of the UI screens to use "PlayerV2" navigation route to open Player Screen