### PR TITLE
Update UI screens to work with updated player screen

### DIFF
--- a/app/src/main/java/com/example/music/ui/MusicApp.kt
+++ b/app/src/main/java/com/example/music/ui/MusicApp.kt
@@ -131,6 +131,7 @@ fun MusicApp(
                     navigateToPlayer =  { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
+                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
                 )
             }
 
@@ -145,6 +146,7 @@ fun MusicApp(
                     navigateToPlayer =  { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
+                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
                     navigateToSettings = { appState.navigateToSettings(backStackEntry) },
                 )
             }
@@ -177,6 +179,7 @@ fun MusicApp(
                     navigateToPlayer = { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
+                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
 
                     //dependent on context, ie if showing in pane or as own screen
@@ -194,6 +197,7 @@ fun MusicApp(
                     navigateToPlayer = { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
+                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                 )
             }
@@ -208,6 +212,7 @@ fun MusicApp(
                     navigateToPlayer = { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
+                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                 )
             }
@@ -222,6 +227,7 @@ fun MusicApp(
                     navigateToPlayer = { song ->
                         appState.navigateToPlayer(song.id, backStackEntry)
                     },
+                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                 )
             }
@@ -229,15 +235,15 @@ fun MusicApp(
             composable(Screen.Search.route) { backStackEntry ->
                 SearchScreen(
                     navigateBack = appState::navigateBack,
-                    navigateToPlayer = { song ->
-                        appState.navigateToPlayer(song.id, backStackEntry)
-                    },
                     navigateToAlbumDetails = { album ->
                         appState.navigateToAlbumDetails(album.id, backStackEntry)
                     },
                     navigateToArtistDetails = { artist ->
                         appState.navigateToArtistDetails(artist.id, backStackEntry)
+                    },navigateToPlayer = { song ->
+                        appState.navigateToPlayer(song.id, backStackEntry)
                     },
+                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
                 )
             }
         }

--- a/app/src/main/java/com/example/music/ui/MusicApp.kt
+++ b/app/src/main/java/com/example/music/ui/MusicApp.kt
@@ -71,10 +71,7 @@ fun MusicApp(
                     navigateToPlaylistDetails = { playlist ->
                         appState.navigateToPlaylistDetails(playlist.id, backStackEntry)
                     },
-                    navigateToPlayer = { song ->
-                        appState.navigateToPlayer(song.id, backStackEntry)
-                    },
-                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
+                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSettings = { appState.navigateToSettings(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) }
                 )
@@ -82,18 +79,6 @@ fun MusicApp(
 
             //Player Screen Navigation Router
             composable(Screen.Player.route) { backStackEntry ->
-                PlayerScreen(
-                    windowSizeClass = adaptiveInfo.windowSizeClass, //needed for screens meant to use full screen
-                    displayFeatures = displayFeatures, //used to determine physical properties of display device to accommodate view accordingly
-                    navigateBack = appState::navigateBack, //navigation back button
-                    navigateToHome = { appState.navigateToHome(backStackEntry) },
-                    navigateToLibrary = { appState.navigateToLibrary(backStackEntry) },
-                    //navigateToSettings = { appState.navigateToSettings(backStackEntry) },
-                )
-            }
-
-            //Player Screen Navigation Router
-            composable(Screen.PlayerV2.route) { backStackEntry ->
                 PlayerScreen(
                     windowSizeClass = adaptiveInfo.windowSizeClass, //needed for screens meant to use full screen
                     displayFeatures = displayFeatures, //used to determine physical properties of display device to accommodate view accordingly
@@ -128,10 +113,7 @@ fun MusicApp(
                     navigateToPlaylistDetails = { playlist ->
                         appState.navigateToPlaylistDetails(playlist.id, backStackEntry)
                     },
-                    navigateToPlayer =  { song ->
-                        appState.navigateToPlayer(song.id, backStackEntry)
-                    },
-                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
+                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                 )
             }
 
@@ -143,10 +125,7 @@ fun MusicApp(
                     navigateBack = appState::navigateBack, //navigation back button
                     navigateToHome = { appState.navigateToHome(backStackEntry) },
                     navigateToLibrary = { appState.navigateToLibrary(backStackEntry) },
-                    navigateToPlayer =  { song ->
-                        appState.navigateToPlayer(song.id, backStackEntry)
-                    },
-                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
+                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSettings = { appState.navigateToSettings(backStackEntry) },
                 )
             }
@@ -156,10 +135,7 @@ fun MusicApp(
                 AlbumDetailsScreen(
                     //windowSizeClass = adaptiveInfo.windowSizeClass, //needed for screens meant to use full screen
                     navigateBack = appState::navigateBack,
-                    navigateToPlayer = { song ->
-                        appState.navigateToPlayer(song.id, backStackEntry)
-                    },
-                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
+                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
 
                     //dependent on context, ie if showing in pane or as own screen
@@ -176,10 +152,7 @@ fun MusicApp(
                     navigateToAlbumDetails = { album ->
                         appState.navigateToAlbumDetails(album.id, backStackEntry)
                     },
-                    navigateToPlayer = { song ->
-                        appState.navigateToPlayer(song.id, backStackEntry)
-                    },
-                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
+                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
 
                     //dependent on context, ie if showing in pane or as own screen
@@ -194,10 +167,7 @@ fun MusicApp(
                     //windowSizeClass = adaptiveInfo.windowSizeClass,
 
                     navigateBack = appState::navigateBack,
-                    navigateToPlayer = { song ->
-                        appState.navigateToPlayer(song.id, backStackEntry)
-                    },
-                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
+                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                 )
             }
@@ -209,10 +179,7 @@ fun MusicApp(
                     //windowSizeClass = adaptiveInfo.windowSizeClass,
 
                     navigateBack = appState::navigateBack,
-                    navigateToPlayer = { song ->
-                        appState.navigateToPlayer(song.id, backStackEntry)
-                    },
-                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
+                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                 )
             }
@@ -224,10 +191,7 @@ fun MusicApp(
                     //windowSizeClass = adaptiveInfo.windowSizeClass,
 
                     navigateBack = appState::navigateBack,
-                    navigateToPlayer = { song ->
-                        appState.navigateToPlayer(song.id, backStackEntry)
-                    },
-                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
+                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                 )
             }
@@ -240,10 +204,8 @@ fun MusicApp(
                     },
                     navigateToArtistDetails = { artist ->
                         appState.navigateToArtistDetails(artist.id, backStackEntry)
-                    },navigateToPlayer = { song ->
-                        appState.navigateToPlayer(song.id, backStackEntry)
                     },
-                    navigateToPlayerV2 = { appState.navigateToPlayerV2(backStackEntry) },
+                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                 )
             }
         }

--- a/app/src/main/java/com/example/music/ui/MusicAppState.kt
+++ b/app/src/main/java/com/example/music/ui/MusicAppState.kt
@@ -28,12 +28,8 @@ sealed class Screen(val route: String) {
         fun createRoute() = "library"
     }
 
-    object Player : Screen("player/{$ARG_SONG_ID}") {
-        fun createRoute(songId: Long) = "player/$songId"
-    }
-
-    object PlayerV2 : Screen( "player2") {
-        fun createRoute() = "player2"
+    object Player : Screen("player") {
+        fun createRoute() = "player"
     }
 
     object Search : Screen("search") {
@@ -164,19 +160,11 @@ class MusicAppState(
         }
     }
 
-    fun navigateToPlayer(songId: Long, from: NavBackStackEntry) {
+    fun navigateToPlayer(from: NavBackStackEntry) {
         // In order to discard duplicated navigation events, we check the Lifecycle
         if (from.lifecycleIsResumed()) {
             Log.i(TAG, "***************** SWITCHING TO PLAYER VIEW *****************")
-            navController.navigate(Screen.Player.createRoute(songId))
-        }
-    }
-
-    fun navigateToPlayerV2(from: NavBackStackEntry) {
-        // In order to discard duplicated navigation events, we check the Lifecycle
-        if (from.lifecycleIsResumed()) {
-            Log.i(TAG, "***************** SWITCHING TO PLAYER V2 VIEW *****************")
-            navController.navigate(Screen.PlayerV2.createRoute())
+            navController.navigate(Screen.Player.createRoute())
         }
     }
 

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
@@ -157,8 +157,7 @@ private const val TAG = "Album Details Screen"
 @androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 fun AlbumDetailsScreen(
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     //navigateToArtist: (ArtistInfo) -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
@@ -180,7 +179,6 @@ fun AlbumDetailsScreen(
                 selectSong = uiState.selectSong,
                 onAlbumAction = viewModel::onAlbumAction,
                 navigateToPlayer = navigateToPlayer,
-                navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
                 navigateBack = navigateBack,
                 showBackButton = showBackButton,
@@ -239,8 +237,7 @@ fun AlbumDetailsScreen(
     songs: List<SongInfo>,
     selectSong: SongInfo,
     onAlbumAction: (AlbumAction) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     showBackButton: Boolean,
@@ -403,13 +400,13 @@ fun AlbumDetailsScreen(
                         PlayShuffleButtons(
                             onPlayClick = {
                                 Log.i(TAG, "Play Album btn clicked")
-                                onAlbumAction(AlbumAction.PlayAlbum(songs))
-                                navigateToPlayerV2()
+                                onAlbumAction(AlbumAction.PlaySongs(songs))
+                                navigateToPlayer()
                             },
                             onShuffleClick = {
                                 Log.i(TAG, "Shuffle Album btn clicked")
-                                onAlbumAction(AlbumAction.ShuffleAlbum(songs))
-                                navigateToPlayerV2()
+                                onAlbumAction(AlbumAction.ShuffleSongs(songs))
+                                navigateToPlayer()
                             },
                         )
                     }
@@ -420,8 +417,8 @@ fun AlbumDetailsScreen(
                                 song = song,
                                 onClick = {
                                     Log.i(TAG, "Song clicked: ${song.title}")
-                                    onAlbumAction(AlbumAction.SongClicked(song))
-                                    navigateToPlayerV2()
+                                    onAlbumAction(AlbumAction.PlaySong(song))
+                                    navigateToPlayer()
                                 },
                                 onMoreOptionsClick = {
                                     Log.i(TAG, "Song More Option clicked: ${song.title}")
@@ -1232,7 +1229,6 @@ fun AlbumDetailsScreenPreview() {
 //            songs = getSongsInAlbum(307),
 
             navigateToPlayer = {},
-            navigateToPlayerV2 = {},
             navigateToSearch = {},
             navigateBack = {},
             showBackButton = true,

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
@@ -238,7 +238,6 @@ fun AlbumDetailsScreen(
     artist: ArtistInfo,
     songs: List<SongInfo>,
     selectSong: SongInfo,
-    //onQueueSong: (SongInfo) -> Unit,
     onAlbumAction: (AlbumAction) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
     navigateToPlayerV2: () -> Unit,
@@ -410,7 +409,7 @@ fun AlbumDetailsScreen(
                             onShuffleClick = {
                                 Log.i(TAG, "Shuffle Album btn clicked")
                                 onAlbumAction(AlbumAction.ShuffleAlbum(songs))
-                                //navigateToPlayer(songs[1])
+                                navigateToPlayerV2()
                             },
                         )
                     }

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
@@ -130,13 +130,23 @@ class AlbumDetailsViewModel @Inject constructor(
         when (action) {
             //is AlbumAction.AddSongToPlaylist -> onAddToPlaylist(action.song)
             //is AlbumAction.AddAlbumToPlaylist -> onAddToPlaylist(action.songs)
+            is AlbumAction.PlaySong -> onPlaySong(action.song)
+            is AlbumAction.PlaySongs -> onPlaySongs(action.songs)
             is AlbumAction.QueueSong -> onQueueSong(action.song)
             is AlbumAction.QueueSongs -> onQueueSongs(action.songs)
+            is AlbumAction.ShuffleSongs -> onShuffleSongs(action.songs)
             is AlbumAction.SongMoreOptionClicked -> onSongMoreOptionClick(action.song)
-            is AlbumAction.ShuffleAlbum -> onShuffleAlbum(action.songs)
-            is AlbumAction.PlayAlbum -> onPlayAlbum(action.songs)
-            is AlbumAction.SongClicked -> onSongClicked(action.song)
         }
+    }
+
+    private fun onPlaySong(song: SongInfo) {
+        Log.i(TAG, "onPlaySong -> ${song.title}")
+        songController.play(song)
+    }
+
+    private fun onPlaySongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onPlaySongs -> ${songs.size}")
+        songController.play(songs)
     }
 
     private fun onQueueSong(song: SongInfo) {
@@ -149,19 +159,9 @@ class AlbumDetailsViewModel @Inject constructor(
         songController.addToQueue(songs)
     }
 
-    private fun onPlayAlbum(songs: List<SongInfo>) {
-        Log.i(TAG, "onPlayAlbum -> ${songs.size}")
-        songController.play(songs)
-    }
-
-    private fun onShuffleAlbum(songs: List<SongInfo>) {
-        Log.i(TAG, "onShuffleAlbum -> ${songs.size}")
+    private fun onShuffleSongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onShuffleSongs -> ${songs.size}")
         songController.shuffle(songs)
-    }
-
-    private fun onSongClicked(song: SongInfo) {
-        Log.i(TAG, "onSongClicked -> ${song.title}")
-        songController.play(song)
     }
 
     private fun onSongMoreOptionClick(song: SongInfo) {
@@ -171,11 +171,11 @@ class AlbumDetailsViewModel @Inject constructor(
 }
 
 sealed interface AlbumAction {
+    data class PlaySong(val song: SongInfo) : AlbumAction
+    data class PlaySongs(val songs: List<SongInfo>) : AlbumAction
     data class QueueSong(val song: SongInfo) : AlbumAction
     data class QueueSongs(val songs: List<SongInfo>) : AlbumAction
-    data class PlayAlbum(val songs: List<SongInfo>) : AlbumAction
-    data class ShuffleAlbum(val songs: List<SongInfo>) : AlbumAction
-    data class SongClicked(val song: SongInfo) : AlbumAction
+    data class ShuffleSongs(val songs: List<SongInfo>) : AlbumAction
     data class SongMoreOptionClicked(val song: SongInfo) : AlbumAction
 }
 

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
@@ -1,5 +1,6 @@
 package com.example.music.ui.artistdetails
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
@@ -111,6 +112,8 @@ import kotlinx.coroutines.CoroutineScope
  *
  * 7/22-23/2025 - Removed PlayerSong completely
  */
+
+private const val TAG = "Artist Details Screen"
 
 /**
  * Stateful version of Artist Details Screen
@@ -425,8 +428,11 @@ fun ArtistDetailsScreen(
                     fullWidthItem {
                         SongCountAndSortSelectButtons(
                             songs = songs,
-                            onSelectClick = {},
+                            onSelectClick = {
+                                Log.i(TAG, "Multi Select btn clicked")
+                            },
                             onSortClick = {
+                                Log.i(TAG, "Song Sort btn clicked")
                                 showBottomSheet = true
                                 showSortSheet = true
                             },
@@ -435,8 +441,16 @@ fun ArtistDetailsScreen(
 
                     fullWidthItem {
                         PlayShuffleButtons(
-                            onPlayClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
-                            onShuffleClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
+                            onPlayClick = {
+                                Log.i(TAG, "Play Songs btn clicked")
+                                onArtistAction(ArtistAction.PlaySongs(songs))
+                                navigateToPlayerV2()
+                            },
+                            onShuffleClick = {
+                                Log.i(TAG, "Shuffle Songs btn clicked")
+                                onArtistAction(ArtistAction.ShuffleSongs(songs))
+                                navigateToPlayerV2()
+                            },
                         )
                     }
 
@@ -445,8 +459,13 @@ fun ArtistDetailsScreen(
                         Box(Modifier.padding(horizontal = 12.dp, vertical = 0.dp)) {
                             SongListItem(
                                 song = song,
-                                onClick = navigateToPlayer,
+                                onClick = {
+                                    Log.i(TAG, "Song clicked: ${song.title}")
+                                    onArtistAction(ArtistAction.PlaySong(song))
+                                    navigateToPlayerV2()
+                                },
                                 onMoreOptionsClick = {
+                                    Log.i(TAG, "Song More Option clicked: ${song.title}")
                                     onArtistAction( ArtistAction.SongMoreOptionClicked( song ) )
                                     showBottomSheet = true
                                     showSongMoreOptions = true

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
@@ -119,6 +119,7 @@ import kotlinx.coroutines.CoroutineScope
 fun ArtistDetailsScreen(
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     showBackButton: Boolean,
@@ -142,6 +143,7 @@ fun ArtistDetailsScreen(
                 //onQueueSong = viewModel::onQueueSong,
                 navigateToAlbumDetails = navigateToAlbumDetails,
                 navigateToPlayer = navigateToPlayer,
+                navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
                 navigateBack = navigateBack,
                 showBackButton = showBackButton,
@@ -204,6 +206,7 @@ fun ArtistDetailsScreen(
     //onQueueSong: (SongInfo) -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     showBackButton: Boolean,
@@ -974,6 +977,7 @@ fun ArtistDetailsScreenPreview() {
 
             navigateToAlbumDetails = {},
             navigateToPlayer = {},
+            navigateToPlayerV2 = {},
             navigateToSearch = {},
             navigateBack = {},
             showBackButton = true,

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
@@ -121,8 +121,7 @@ private const val TAG = "Artist Details Screen"
 @Composable
 fun ArtistDetailsScreen(
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     showBackButton: Boolean,
@@ -146,7 +145,6 @@ fun ArtistDetailsScreen(
                 //onQueueSong = viewModel::onQueueSong,
                 navigateToAlbumDetails = navigateToAlbumDetails,
                 navigateToPlayer = navigateToPlayer,
-                navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
                 navigateBack = navigateBack,
                 showBackButton = showBackButton,
@@ -208,8 +206,7 @@ fun ArtistDetailsScreen(
     onArtistAction: (ArtistAction) -> Unit,
     //onQueueSong: (SongInfo) -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     showBackButton: Boolean,
@@ -444,12 +441,12 @@ fun ArtistDetailsScreen(
                             onPlayClick = {
                                 Log.i(TAG, "Play Songs btn clicked")
                                 onArtistAction(ArtistAction.PlaySongs(songs))
-                                navigateToPlayerV2()
+                                navigateToPlayer()
                             },
                             onShuffleClick = {
                                 Log.i(TAG, "Shuffle Songs btn clicked")
                                 onArtistAction(ArtistAction.ShuffleSongs(songs))
-                                navigateToPlayerV2()
+                                navigateToPlayer()
                             },
                         )
                     }
@@ -462,7 +459,7 @@ fun ArtistDetailsScreen(
                                 onClick = {
                                     Log.i(TAG, "Song clicked: ${song.title}")
                                     onArtistAction(ArtistAction.PlaySong(song))
-                                    navigateToPlayerV2()
+                                    navigateToPlayer()
                                 },
                                 onMoreOptionsClick = {
                                     Log.i(TAG, "Song More Option clicked: ${song.title}")
@@ -996,7 +993,6 @@ fun ArtistDetailsScreenPreview() {
 
             navigateToAlbumDetails = {},
             navigateToPlayer = {},
-            navigateToPlayerV2 = {},
             navigateToSearch = {},
             navigateBack = {},
             showBackButton = true,

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsViewModel.kt
@@ -9,7 +9,9 @@ import com.example.music.domain.model.ArtistInfo
 import com.example.music.domain.model.SongInfo
 //import com.example.music.domain.player.SongPlayer
 import com.example.music.domain.usecases.GetArtistDetailsV2
+import com.example.music.service.SongController
 import com.example.music.ui.Screen
+import com.example.music.ui.albumdetails.AlbumAction
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -44,10 +46,13 @@ data class ArtistUiState (
     val selectSong: SongInfo = SongInfo()
 )
 
+/**
+ * ViewModel that handles the business logic and screen state of the Artist Details screen
+ */
 @HiltViewModel
 class ArtistDetailsViewModel @Inject constructor(
     getArtistDetailsV2: GetArtistDetailsV2,
-    //private val songPlayer: SongPlayer,
+    private val songController: SongController,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -86,6 +91,7 @@ class ArtistDetailsViewModel @Inject constructor(
                 Log.i(TAG, "artistDetailsFilterResult ID: ${artistDetailsFilterResult.artist.id}")
                 Log.i(TAG, "artistDetailsFilterResult albums: ${artistDetailsFilterResult.albums.size}")
                 Log.i(TAG, "artistDetailsFilterResult songs: ${artistDetailsFilterResult.songs.size}")
+                Log.i(TAG, "is SongController available: ${songController.isConnected()}")
                 Log.i(TAG, "isReady?: ${!refreshing}")
 
                 ArtistUiState(
@@ -132,6 +138,10 @@ class ArtistDetailsViewModel @Inject constructor(
         when (action) {
             is ArtistAction.AlbumMoreOptionClicked -> onAlbumMoreOptionClicked(action.album)
             is ArtistAction.QueueSong -> onQueueSong(action.song)
+            is ArtistAction.QueueSongs -> onQueueSongs(action.songs)
+            is ArtistAction.PlaySong -> onPlaySong(action.song)
+            is ArtistAction.PlaySongs -> onPlaySongs(action.songs)
+            is ArtistAction.ShuffleSongs -> onShuffleSongs(action.songs)
             is ArtistAction.SongMoreOptionClicked -> onSongMoreOptionClicked(action.song)
         }
     }
@@ -141,9 +151,29 @@ class ArtistDetailsViewModel @Inject constructor(
         selectedAlbum.value = album
     }
 
+    private fun onPlaySong(song: SongInfo) {
+        Log.i(TAG, "onPlaySong - ${song.title}")
+        songController.play(song)
+    }
+
+    private fun onPlaySongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onPlaySongs - ${songs.size}")
+        songController.play(songs)
+    }
+
     private fun onQueueSong(song: SongInfo) {
         Log.i(TAG, "onQueueSong - ${song.title}")
-        //songPlayer.addToQueue(song)
+        songController.addToQueue(song)
+    }
+
+    private fun onQueueSongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onQueueSongs - ${songs.size}")
+        songController.addToQueue(songs)
+    }
+
+    private fun onShuffleSongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onShuffleSongs - ${songs.size}")
+        songController.shuffle(songs)
     }
 
     private fun onSongMoreOptionClicked(song: SongInfo) {
@@ -154,7 +184,11 @@ class ArtistDetailsViewModel @Inject constructor(
 
 sealed interface ArtistAction {
     data class AlbumMoreOptionClicked(val album: AlbumInfo) : ArtistAction
+    data class PlaySong(val song: SongInfo) : ArtistAction
+    data class PlaySongs(val songs: List<SongInfo>) : ArtistAction
     data class QueueSong(val song: SongInfo) : ArtistAction
+    data class QueueSongs(val songs: List<SongInfo>) : ArtistAction
+    data class ShuffleSongs(val songs: List<SongInfo>) : ArtistAction
     data class SongMoreOptionClicked(val song: SongInfo) : ArtistAction
 }
 

--- a/app/src/main/java/com/example/music/ui/composerdetails/ComposerDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/composerdetails/ComposerDetailsScreen.kt
@@ -85,6 +85,7 @@ import com.example.music.util.quantityStringResource
 @Composable
 fun ComposerDetailsScreen(
     navigateToPlayer: (SongInfo) -> Unit = {},
+    navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit = {},
     //showBackButton: Boolean,
@@ -104,6 +105,7 @@ fun ComposerDetailsScreen(
                 songs = uiState.songs,
                 //onQueueSong = viewModel::onQueueSong,
                 navigateToPlayer = navigateToPlayer,
+                navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
                 navigateBack = navigateBack,
                 //showBackButton = showBackButton,
@@ -158,6 +160,7 @@ fun ComposerDetailsScreen(
     songs: List<SongInfo>,
     //onQueueSong: (SongInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     //showBackButton: Boolean,
@@ -502,6 +505,7 @@ fun ComposerDetailsScreenPreview() {
             songs = getSongsByComposer(PreviewComposers[1].id),
 
             navigateToPlayer = {},
+            navigateToPlayerV2 = {},
             navigateToSearch = {},
             navigateBack = {},
         )

--- a/app/src/main/java/com/example/music/ui/composerdetails/ComposerDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/composerdetails/ComposerDetailsScreen.kt
@@ -87,8 +87,7 @@ private const val TAG = "Composer Details Screen"
  */
 @Composable
 fun ComposerDetailsScreen(
-    navigateToPlayer: (SongInfo) -> Unit = {},
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit = {},
     //showBackButton: Boolean,
@@ -108,7 +107,6 @@ fun ComposerDetailsScreen(
                 songs = uiState.songs,
                 //onQueueSong = viewModel::onQueueSong,
                 navigateToPlayer = navigateToPlayer,
-                navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
                 navigateBack = navigateBack,
                 //showBackButton = showBackButton,
@@ -165,8 +163,7 @@ fun ComposerDetailsScreen(
     composer: ComposerInfo,
     songs: List<SongInfo>,
     //onQueueSong: (SongInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     //showBackButton: Boolean,
@@ -274,7 +271,7 @@ fun ComposerDetailsContent(
     composer: ComposerInfo,
     songs: List<SongInfo>,
     //onQueueSong: (SongInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayer: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyVerticalGrid(
@@ -311,12 +308,12 @@ fun ComposerDetailsContent(
                     onPlayClick = {
                         Log.i(TAG, "Play Songs btn clicked")
                         //onComposerAction(ComposerAction.PlaySongs(songs))
-                        //navigateToPlayerV2()
+                        //navigateToPlayer()
                     },
                     onShuffleClick = {
                         Log.i(TAG, "Shuffle Songs btn clicked")
                         //onComposerAction(ComposerAction.ShuffleSongs(songs))
-                        //navigateToPlayerV2()
+                        //navigateToPlayer()
                     },
                 )
             }
@@ -526,7 +523,6 @@ fun ComposerDetailsScreenPreview() {
             songs = getSongsByComposer(PreviewComposers[1].id),
 
             navigateToPlayer = {},
-            navigateToPlayerV2 = {},
             navigateToSearch = {},
             navigateBack = {},
         )

--- a/app/src/main/java/com/example/music/ui/composerdetails/ComposerDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/composerdetails/ComposerDetailsScreen.kt
@@ -1,5 +1,6 @@
 package com.example.music.ui.composerdetails
 
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -79,6 +80,8 @@ import com.example.music.util.quantityStringResource
  * 7/22-23/2025 - Removed PlayerSong completely
  */
 
+private const val TAG = "Composer Details Screen"
+
 /**
  * Stateful version of Composer Details Screen
  */
@@ -123,7 +126,10 @@ fun ComposerDetailsScreen(
  * Error Screen
  */
 @Composable
-private fun ComposerDetailsError(onRetry: () -> Unit, modifier: Modifier = Modifier) {
+private fun ComposerDetailsError(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Surface(modifier = modifier) {
         Column(
             verticalArrangement = Arrangement.Center,
@@ -302,8 +308,16 @@ fun ComposerDetailsContent(
 
             fullWidthItem {
                 PlayShuffleButtons(
-                    onPlayClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
-                    onShuffleClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
+                    onPlayClick = {
+                        Log.i(TAG, "Play Songs btn clicked")
+                        //onComposerAction(ComposerAction.PlaySongs(songs))
+                        //navigateToPlayerV2()
+                    },
+                    onShuffleClick = {
+                        Log.i(TAG, "Shuffle Songs btn clicked")
+                        //onComposerAction(ComposerAction.ShuffleSongs(songs))
+                        //navigateToPlayerV2()
+                    },
                 )
             }
 
@@ -312,9 +326,17 @@ fun ComposerDetailsContent(
                 Box(Modifier.padding(horizontal = 12.dp, vertical = 0.dp)) {
                     SongListItem(
                         song = song,
-                        onClick = navigateToPlayer,
-                        onMoreOptionsClick = {},
-                        //onClick = navigateToPlayerSong,
+                        onClick = {
+                            Log.i(TAG, "Song clicked: ${song.title}")
+                            //onComposerAction(ComposerAction.PlaySong(song))
+                            //navigateToPlayerV2()
+                        },
+                        onMoreOptionsClick = {
+                            Log.i(TAG, "Song More Option clicked: ${song.title}")
+                            //onComposerAction(ComposerAction.SongMoreOptionClicked(song))
+                            //showBottomSheet = true
+                            //showSongMoreOptions = true
+                        },
                         //onQueueSong = { },
                         modifier = Modifier.fillMaxWidth(),
                         isListEditable = false,
@@ -388,7 +410,6 @@ private fun SongCountAndSortSelectButtons(
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(8.dp).weight(1f, true)
         )
-        //Spacer(Modifier.weight(1f,true))
 
         // sort icon
         IconButton(

--- a/app/src/main/java/com/example/music/ui/composerdetails/ComposerDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/composerdetails/ComposerDetailsViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.music.domain.usecases.GetComposerDetailsUseCase
 import com.example.music.domain.model.ComposerInfo
 import com.example.music.domain.model.SongInfo
-//import com.example.music.domain.player.SongPlayer
+import com.example.music.service.SongController
 import com.example.music.ui.Screen
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -42,7 +42,7 @@ data class ComposerUiState (
 @HiltViewModel
 class ComposerDetailsViewModel @Inject constructor(
     getComposerDetailsUseCase: GetComposerDetailsUseCase,
-    //private val songPlayer: SongPlayer,
+    private val songController: SongController,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -72,6 +72,7 @@ class ComposerDetailsViewModel @Inject constructor(
                 Log.i(TAG, "ComposerUiState call")
                 Log.i(TAG, "composerDetailsFilterResult ID: ${composerDetailsFilterResult.composer.id}")
                 Log.i(TAG, "composerDetailsFilterResult songs: ${composerDetailsFilterResult.songs.size}")
+                Log.i(TAG, "is SongController available: ${songController.isConnected()}")
                 Log.i(TAG, "isReady?: ${!refreshing}")
 
                 ComposerUiState(
@@ -109,4 +110,55 @@ class ComposerDetailsViewModel @Inject constructor(
             refreshing.value = false
         }
     }
+
+    fun onComposerAction(action: ComposerAction) {
+        Log.i(TAG, "onComposerAction - $action")
+        when (action) {
+            is ComposerAction.PlaySong -> onPlaySong(action.song)
+            is ComposerAction.PlaySongs -> onPlaySongs(action.songs)
+            is ComposerAction.QueueSong -> onQueueSong(action.song)
+            is ComposerAction.QueueSongs -> onQueueSongs(action.songs)
+            is ComposerAction.ShuffleSongs -> onShuffleSongs(action.songs)
+            is ComposerAction.SongMoreOptionClicked -> onSongMoreOptionClick(action.song)
+        }
+    }
+
+    private fun onPlaySong(song: SongInfo) {
+        Log.i(TAG, "onPlaySong -> ${song.title}")
+        songController.play(song)
+    }
+
+    private fun onPlaySongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onPlaySongs -> ${songs.size}")
+        songController.play(songs)
+    }
+
+    private fun onQueueSong(song: SongInfo) {
+        Log.i(TAG, "onQueueSong -> ${song.title}")
+        songController.addToQueue(song)
+    }
+
+    private fun onQueueSongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onQueueSongs -> ${songs.size}")
+        songController.addToQueue(songs)
+    }
+
+    private fun onShuffleSongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onShuffleSongs -> ${songs.size}")
+        songController.shuffle(songs)
+    }
+
+    private fun onSongMoreOptionClick(song: SongInfo) {
+        Log.i(TAG, "onSongMoreOptionClick -> ${song.title}")
+        //selectedSong.value = song
+    }
+}
+
+sealed interface ComposerAction {
+    data class PlaySong(val song: SongInfo) : ComposerAction
+    data class PlaySongs(val songs: List<SongInfo>) : ComposerAction
+    data class QueueSong(val song: SongInfo) : ComposerAction
+    data class QueueSongs(val songs: List<SongInfo>) : ComposerAction
+    data class ShuffleSongs(val songs: List<SongInfo>) : ComposerAction
+    data class SongMoreOptionClicked(val song: SongInfo) : ComposerAction
 }

--- a/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsScreen.kt
@@ -87,8 +87,7 @@ private const val TAG = "Genre Details Screen"
 @Composable
 fun GenreDetailsScreen(
     //navigateToAlbumDetails: (AlbumInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     //modifier: Modifier = Modifier,
@@ -106,7 +105,6 @@ fun GenreDetailsScreen(
                 songs = uiState.songs,
                 onGenreAction = viewModel::onGenreAction,
                 navigateToPlayer = navigateToPlayer,
-                navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
                 navigateBack = navigateBack,
                 modifier = Modifier.fillMaxSize(),
@@ -162,8 +160,7 @@ fun GenreDetailsScreen(
     genre: GenreInfo,
     songs: List<SongInfo>,
     onGenreAction: (GenreAction) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     //showBackButton: Boolean,
@@ -204,7 +201,6 @@ fun GenreDetailsScreen(
                 songs = songs,
                 onGenreAction = onGenreAction,
                 navigateToPlayer = navigateToPlayer,
-                navigateToPlayerV2 = navigateToPlayerV2,
                 modifier = Modifier.padding(contentPadding)
             )
         }
@@ -266,8 +262,7 @@ fun GenreDetailsContent(
     genre: GenreInfo,
     songs: List<SongInfo>,
     onGenreAction: (GenreAction) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     modifier: Modifier = Modifier
 ) {
 
@@ -334,12 +329,12 @@ fun GenreDetailsContent(
                     onPlayClick = {
                         Log.i(TAG, "Play Songs btn clicked")
                         onGenreAction(GenreAction.PlaySongs(songs))
-                        navigateToPlayerV2()
+                        navigateToPlayer()
                     },
                     onShuffleClick = {
                         Log.i(TAG, "Shuffle Songs btn clicked")
                         onGenreAction(GenreAction.ShuffleSongs(songs))
-                        navigateToPlayerV2()
+                        navigateToPlayer()
                     },
                 )
             }
@@ -352,7 +347,7 @@ fun GenreDetailsContent(
                         onClick = {
                             Log.i(TAG, "Song clicked ${song.title}")
                             onGenreAction(GenreAction.PlaySong(song))
-                            navigateToPlayerV2()
+                            navigateToPlayer()
                         },
                         onMoreOptionsClick = {
                             Log.i(TAG, "Song More Option clicked ${song.title}")
@@ -551,7 +546,6 @@ fun GenreDetailsScreenPreview() {
 
             //navigateToAlbumDetails = {},
             navigateToPlayer = {},
-            navigateToPlayerV2 = {},
             navigateToSearch = {},
             navigateBack = {},
         )

--- a/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsScreen.kt
@@ -85,6 +85,7 @@ import com.example.music.util.quantityStringResource
 fun GenreDetailsScreen(
     //navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     //modifier: Modifier = Modifier,
@@ -104,6 +105,7 @@ fun GenreDetailsScreen(
                 //onQueueSong = viewModel::onQueueSong,
                 //navigateToAlbumDetails = navigateToAlbumDetails,
                 navigateToPlayer = navigateToPlayer,
+                navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
                 navigateBack = navigateBack,
                 modifier = Modifier.fillMaxSize(),
@@ -162,6 +164,7 @@ fun GenreDetailsScreen(
     //onQueueSong: (SongInfo) -> Unit,
     //navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     //showBackButton: Boolean,
@@ -535,6 +538,7 @@ fun GenreDetailsScreenPreview() {
 
             //navigateToAlbumDetails = {},
             navigateToPlayer = {},
+            navigateToPlayerV2 = {},
             navigateToSearch = {},
             navigateBack = {},
         )

--- a/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsScreen.kt
@@ -1,5 +1,6 @@
 package com.example.music.ui.genredetails
 
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -78,6 +79,8 @@ import com.example.music.util.quantityStringResource
  * 7/22-23/2025 - Removed PlayerSong completely
  */
 
+private const val TAG = "Genre Details Screen"
+
 /**
  * Stateful version of Genre Details Screen
  */
@@ -100,10 +103,8 @@ fun GenreDetailsScreen(
         if (uiState.isReady) {
             GenreDetailsScreen(
                 genre = uiState.genre,
-                //albums = uiState.albums.toPersistentList(),
                 songs = uiState.songs,
-                //onQueueSong = viewModel::onQueueSong,
-                //navigateToAlbumDetails = navigateToAlbumDetails,
+                onGenreAction = viewModel::onGenreAction,
                 navigateToPlayer = navigateToPlayer,
                 navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
@@ -155,14 +156,12 @@ private fun GenreDetailsLoadingScreen(
 /**
  * Stateless Composable for Genre Details Screen
  */
- @OptIn(ExperimentalLayoutApi::class)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun GenreDetailsScreen(
     genre: GenreInfo,
-    //albums: PersistentList<AlbumInfo>,
     songs: List<SongInfo>,
-    //onQueueSong: (SongInfo) -> Unit,
-    //navigateToAlbumDetails: (AlbumInfo) -> Unit,
+    onGenreAction: (GenreAction) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
     navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
@@ -202,16 +201,10 @@ fun GenreDetailsScreen(
         ) { contentPadding ->
             GenreDetailsContent(
                 genre = genre,
-                //albums = albums,
                 songs = songs,
-                /*onQueueSong = {
-                    coroutineScope.launch {
-                        snackbarHostState.showSnackbar(snackBarText)
-                    }
-                    onQueueSong(it)
-                },*/
-                //navigateToAlbumDetails = navigateToAlbumDetails,
+                onGenreAction = onGenreAction,
                 navigateToPlayer = navigateToPlayer,
+                navigateToPlayerV2 = navigateToPlayerV2,
                 modifier = Modifier.padding(contentPadding)
             )
         }
@@ -271,11 +264,10 @@ fun GenreDetailsTopAppBar(
 @Composable
 fun GenreDetailsContent(
     genre: GenreInfo,
-    //albums: PersistentList<AlbumInfo>,
     songs: List<SongInfo>,
-    //onQueueSong: (SongInfo) -> Unit,
-    //navigateToAlbumDetails: (AlbumInfo) -> Unit,
+    onGenreAction: (GenreAction) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     modifier: Modifier = Modifier
 ) {
 
@@ -326,8 +318,11 @@ fun GenreDetailsContent(
             fullWidthItem {
                 SongCountAndSortSelectButtons(
                     songs = songs,
-                    onSelectClick = {},
+                    onSelectClick = {
+                        Log.i(TAG, "Multi Select btn clicked")
+                    },
                     onSortClick = {
+                        Log.i(TAG, "Song Sort btn clicked")
                         //showBottomSheet = true
                         //showSortSheet = true
                     }
@@ -336,8 +331,16 @@ fun GenreDetailsContent(
 
             fullWidthItem {
                 PlayShuffleButtons(
-                    onPlayClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
-                    onShuffleClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
+                    onPlayClick = {
+                        Log.i(TAG, "Play Songs btn clicked")
+                        onGenreAction(GenreAction.PlaySongs(songs))
+                        navigateToPlayerV2()
+                    },
+                    onShuffleClick = {
+                        Log.i(TAG, "Shuffle Songs btn clicked")
+                        onGenreAction(GenreAction.ShuffleSongs(songs))
+                        navigateToPlayerV2()
+                    },
                 )
             }
 
@@ -346,8 +349,17 @@ fun GenreDetailsContent(
                 Box(Modifier.padding(horizontal = 12.dp, vertical = 0.dp)) {
                     SongListItem(
                         song = song,
-                        onClick = navigateToPlayer,
-                        onMoreOptionsClick = {},
+                        onClick = {
+                            Log.i(TAG, "Song clicked ${song.title}")
+                            onGenreAction(GenreAction.PlaySong(song))
+                            navigateToPlayerV2()
+                        },
+                        onMoreOptionsClick = {
+                            Log.i(TAG, "Song More Option clicked ${song.title}")
+                            onGenreAction(GenreAction.SongMoreOptionClicked(song))
+                            //showBottomSheet = true
+                            //showSongMoreOptions = true
+                        },
                         //onQueueSong = { },
                         isListEditable = false,
                         showArtistName = true,
@@ -535,6 +547,7 @@ fun GenreDetailsScreenPreview() {
             //JPop
             genre = PreviewGenres[3],
             songs = getSongsInGenre(3),
+            onGenreAction = {},
 
             //navigateToAlbumDetails = {},
             navigateToPlayer = {},

--- a/app/src/main/java/com/example/music/ui/home/Home.kt
+++ b/app/src/main/java/com/example/music/ui/home/Home.kt
@@ -217,8 +217,7 @@ fun MainScreen(
     navigateToSearch: () -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -232,7 +231,6 @@ fun MainScreen(
             navigateToPlaylistDetails = navigateToPlaylistDetails,
             navigateToLibrary = navigateToLibrary,
             navigateToPlayer = navigateToPlayer,
-            navigateToPlayerV2 = navigateToPlayerV2,
             navigateToSearch = navigateToSearch,
             navigateToSettings = navigateToSettings,
             viewModel = viewModel,
@@ -278,8 +276,7 @@ private fun HomeScreenReady(
     navigateToLibrary: () -> Unit,
     navigateToSettings: () -> Unit,
     navigateToSearch: () -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     viewModel: HomeViewModel = hiltViewModel()
@@ -312,7 +309,6 @@ private fun HomeScreenReady(
                     navigateToPlaylistDetails = navigateToPlaylistDetails,
                     navigateToLibrary = navigateToLibrary,
                     navigateToPlayer = navigateToPlayer,
-                    navigateToPlayerV2 = navigateToPlayerV2,
                     navigateToSettings = navigateToSettings,
                     navigateToSearch = navigateToSearch,
                     modifier = Modifier.fillMaxSize()
@@ -362,8 +358,7 @@ private fun HomeScreen(
     navigateToSearch: () -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     // Effect that changes the home category selection when there are no subscribed podcasts
@@ -442,7 +437,6 @@ private fun HomeScreen(
                     navigateToAlbumDetails = navigateToAlbumDetails,
                     navigateToPlaylistDetails = navigateToPlaylistDetails,
                     navigateToPlayer = navigateToPlayer,
-                    navigateToPlayerV2 = navigateToPlayerV2
                 )
             }
         }
@@ -503,8 +497,7 @@ private fun HomeContent(
     navigateToLibrary: () -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit
+    navigateToPlayer: () -> Unit,
 ) {
     // Main Content on Home screen
     //logger.info { "Home Content function start" }
@@ -536,7 +529,6 @@ private fun HomeContent(
         navigateToAlbumDetails = navigateToAlbumDetails,
         navigateToPlaylistDetails = navigateToPlaylistDetails,
         navigateToPlayer = navigateToPlayer,
-        navigateToPlayerV2 = navigateToPlayerV2
     )
 
     if(showBottomSheet) {
@@ -544,7 +536,7 @@ private fun HomeContent(
             onDismissRequest = { showBottomSheet = false },
             coroutineScope = coroutineScope,
             song = featuredLibraryItemsFilterResult.recentlyAddedSongs[0],
-            navigateToPlayer = navigateToPlayer
+            navigateToPlayer = navigateToPlayer //FixMe
         )
     }
 }
@@ -561,8 +553,7 @@ private fun HomeContentGrid(
     navigateToLibrary: () -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
 ) {
     //logger.info { "Home Content Grid function start" }
     LazyVerticalGrid(
@@ -658,7 +649,7 @@ private fun HomeContentGrid(
                         song = song,
                         onClick = {
                             onHomeAction(HomeAction.SongClicked(song))
-                            navigateToPlayerV2()
+                            navigateToPlayer()
                         },
                         //onQueueSong = { },
                         onMoreOptionsClick = { onMoreOptionsClick(song) },
@@ -823,7 +814,6 @@ private fun PreviewHome() {
             navigateToAlbumDetails = {},
             navigateToPlaylistDetails = {},
             navigateToPlayer = {},
-            navigateToPlayerV2 = {},
         )
     }
 }

--- a/app/src/main/java/com/example/music/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/home/HomeViewModel.kt
@@ -114,6 +114,7 @@ class HomeViewModel @Inject constructor(
                 //Log.i(TAG, "viewModelScope launch - combine - libraryItemsPlaylists: ${libraryItems.recentPlaylists.size}")
                 Log.i(TAG, "viewModelScope launch - combine - libraryItemsAlbums: ${libraryItems.recentAlbums.size}")
                 Log.i(TAG, "viewModelScope launch - combine - libraryItemsSongs: ${libraryItems.recentlyAddedSongs.size}")
+                Log.i(TAG, "is SongController available: ${songController.isConnected()}")
 
                 HomeScreenUiState(
                     isLoading = refreshing,

--- a/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
@@ -127,8 +127,7 @@ fun LibraryScreen(
     navigateToGenreDetails: (GenreInfo) -> Unit,
     navigateToComposerDetails: (ComposerInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     viewModel: LibraryViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -170,7 +169,6 @@ fun LibraryScreen(
             navigateToGenreDetails = navigateToGenreDetails,
             navigateToPlaylistDetails = navigateToPlaylistDetails,
             navigateToPlayer = navigateToPlayer,
-            navigateToPlayerV2 = navigateToPlayerV2,
             navigateToSearch = navigateToSearch,
             modifier = Modifier.fillMaxSize()
         )
@@ -229,8 +227,7 @@ private fun LibraryScreen(
     navigateToGenreDetails: (GenreInfo) -> Unit,
     navigateToComposerDetails: (ComposerInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -317,7 +314,6 @@ private fun LibraryScreen(
                     navigateToGenreDetails = navigateToGenreDetails,
                     navigateToPlaylistDetails = navigateToPlaylistDetails,
                     navigateToPlayer = navigateToPlayer,
-                    navigateToPlayerV2 = navigateToPlayerV2,
                 )
             }
         }
@@ -391,8 +387,7 @@ private fun LibraryContent(
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToGenreDetails: (GenreInfo) -> Unit,
     navigateToComposerDetails: (ComposerInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
 ) {
     val listState = rememberLazyGridState()
     val displayButton = remember { derivedStateOf { listState.firstVisibleItemIndex > 1 } }
@@ -504,7 +499,6 @@ private fun LibraryContent(
                         coroutineScope = coroutineScope,
                         onLibraryAction = onLibraryAction,
                         navigateToPlayer = navigateToPlayer,
-                        navigateToPlayerV2 = navigateToPlayerV2,
                     )
                 }
 
@@ -695,7 +689,6 @@ private fun PreviewLibrary() {
             navigateToGenreDetails = {},
             navigateToComposerDetails = {},
             navigateToPlayer = {},
-            navigateToPlayerV2 = {},
             navigateToSearch = {},
         )
     }

--- a/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
@@ -128,6 +128,7 @@ fun LibraryScreen(
     navigateToComposerDetails: (ComposerInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     viewModel: LibraryViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -169,6 +170,7 @@ fun LibraryScreen(
             navigateToGenreDetails = navigateToGenreDetails,
             navigateToPlaylistDetails = navigateToPlaylistDetails,
             navigateToPlayer = navigateToPlayer,
+            navigateToPlayerV2 = navigateToPlayerV2,
             navigateToSearch = navigateToSearch,
             modifier = Modifier.fillMaxSize()
         )
@@ -228,6 +230,7 @@ private fun LibraryScreen(
     navigateToComposerDetails: (ComposerInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -314,6 +317,7 @@ private fun LibraryScreen(
                     navigateToGenreDetails = navigateToGenreDetails,
                     navigateToPlaylistDetails = navigateToPlaylistDetails,
                     navigateToPlayer = navigateToPlayer,
+                    navigateToPlayerV2 = navigateToPlayerV2,
                 )
             }
         }
@@ -388,6 +392,7 @@ private fun LibraryContent(
     navigateToGenreDetails: (GenreInfo) -> Unit,
     navigateToComposerDetails: (ComposerInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
 ) {
     val listState = rememberLazyGridState()
     val displayButton = remember { derivedStateOf { listState.firstVisibleItemIndex > 1 } }
@@ -497,8 +502,9 @@ private fun LibraryContent(
                         //what would the songs screen need?
                         songs = librarySongs,
                         coroutineScope = coroutineScope,
+                        onLibraryAction = onLibraryAction,
                         navigateToPlayer = navigateToPlayer,
-                        //onQueueSong = { onLibraryAction(LibraryAction.QueueSong(it)) },
+                        navigateToPlayerV2 = navigateToPlayerV2,
                     )
                 }
 
@@ -689,6 +695,7 @@ private fun PreviewLibrary() {
             navigateToGenreDetails = {},
             navigateToComposerDetails = {},
             navigateToPlayer = {},
+            navigateToPlayerV2 = {},
             navigateToSearch = {},
         )
     }

--- a/app/src/main/java/com/example/music/ui/library/song/Songs.kt
+++ b/app/src/main/java/com/example/music/ui/library/song/Songs.kt
@@ -60,10 +60,9 @@ private const val TAG = "Library Songs"
 fun LazyListScope.songItems(
     songs: List<SongInfo>,
     coroutineScope: CoroutineScope,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    onLibraryAction: (LibraryAction) -> Unit,
+    navigateToPlayer: () -> Unit,
 ) {
-
     //section 1: header
     item {
         // ******** var  for modal remember here
@@ -111,62 +110,28 @@ fun LazyListScope.songItems(
     }
 
     item {
-        Row {
-            // shuffle btn
-            Button(
-                onClick = {
-                    /*coroutineScope.launch {
-                        sheetState.hide()
-                        showThemeSheet = false
-                    }*/
-                },
-                colors = buttonColors(
-                    //containerColor = MaterialTheme.colorScheme.primary,
-                    //contentColor = MaterialTheme.colorScheme.background,
-                ),
-                shape = MusicShapes.small,
-                modifier = Modifier
-                    .padding(10.dp).weight(0.5f)
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Shuffle,
-                    contentDescription = stringResource(R.string.icon_shuffle)
-                )
-                Text("SHUFFLE")
-            }
-
-            // play btn
-            Button(
-                onClick = {
-                    /*coroutineScope.launch {
-                        sheetState.hide()
-                        showThemeSheet = false
-                    }*/
-                },
-                colors = buttonColors(
-                    //containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    //contentColor = MaterialTheme.colorScheme.background,
-                ),
-                shape = MusicShapes.small,
-                modifier = Modifier
-                    .padding(10.dp).weight(0.5f)
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.PlayArrow,
-                    contentDescription = stringResource(R.string.icon_play)
-                )
-                Text("PLAY")
-            }
-        }
+        PlayShuffleButtons(
+            onPlayClick = {
+                onLibraryAction(LibraryAction.PlaySongs(songs))
+                navigateToPlayer()
+            },
+            onShuffleClick = {
+                onLibraryAction(LibraryAction.ShuffleSongs(songs))
+                navigateToPlayer()
+            },
+        )
     }
 
     items(
         items = songs,
-        //span = { GridItemSpan(maxLineSpan) }
     ) { song ->
         SongListItem(
             song = song,
-            onClick = { navigateToPlayer(song) },
+            onClick = {
+                Log.i(TAG, "Song clicked: ${song.title}")
+                onLibraryAction(LibraryAction.SongClicked(song))
+                navigateToPlayer()
+            },
             onMoreOptionsClick = {},
             //onQueueSong = {},
             isListEditable = false,
@@ -213,8 +178,7 @@ fun LazyGridScope.songItems(
     songs: List<SongInfo>,
     coroutineScope: CoroutineScope,
     onLibraryAction: (LibraryAction) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
 ) {
 
     //section 1: header
@@ -267,11 +231,11 @@ fun LazyGridScope.songItems(
         PlayShuffleButtons(
             onPlayClick = {
                 onLibraryAction(LibraryAction.PlaySongs(songs))
-                navigateToPlayerV2()
+                navigateToPlayer()
             },
             onShuffleClick = {
                 onLibraryAction(LibraryAction.ShuffleSongs(songs))
-                navigateToPlayerV2()
+                navigateToPlayer()
             },
         )
     }
@@ -286,7 +250,7 @@ fun LazyGridScope.songItems(
             onClick = {
                 Log.i(TAG, "Song clicked: ${song.title}")
                 onLibraryAction(LibraryAction.SongClicked(song))
-                navigateToPlayerV2()
+                navigateToPlayer()
             },
             onMoreOptionsClick = {},
             //onQueueSong = {},

--- a/app/src/main/java/com/example/music/ui/library/song/Songs.kt
+++ b/app/src/main/java/com/example/music/ui/library/song/Songs.kt
@@ -1,5 +1,6 @@
 package com.example.music.ui.library.song
 
+import android.util.Log
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -33,12 +34,15 @@ import androidx.compose.ui.unit.dp
 import com.example.music.R
 import com.example.music.designsys.theme.MusicShapes
 import com.example.music.domain.model.SongInfo
+import com.example.music.ui.library.LibraryAction
 import com.example.music.ui.shared.SongListItem
 import com.example.music.ui.library.LibraryCategory
 import com.example.music.ui.shared.LibrarySortSelectionBottomModal
 import com.example.music.util.fullWidthItem
 import com.example.music.util.quantityStringResource
 import kotlinx.coroutines.CoroutineScope
+
+private const val TAG = "Library Songs"
 
 /** Changelog:
  *
@@ -57,6 +61,7 @@ fun LazyListScope.songItems(
     songs: List<SongInfo>,
     coroutineScope: CoroutineScope,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
 ) {
 
     //section 1: header
@@ -207,7 +212,9 @@ fun LazyListScope.songItems(
 fun LazyGridScope.songItems(
     songs: List<SongInfo>,
     coroutineScope: CoroutineScope,
+    onLibraryAction: (LibraryAction) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
 ) {
 
     //section 1: header
@@ -258,8 +265,14 @@ fun LazyGridScope.songItems(
 
     fullWidthItem {
         PlayShuffleButtons(
-            onPlayClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
-            onShuffleClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
+            onPlayClick = {
+                onLibraryAction(LibraryAction.PlaySongs(songs))
+                navigateToPlayerV2()
+            },
+            onShuffleClick = {
+                onLibraryAction(LibraryAction.ShuffleSongs(songs))
+                navigateToPlayerV2()
+            },
         )
     }
 
@@ -270,7 +283,11 @@ fun LazyGridScope.songItems(
         //Box(Modifier.padding(horizontal = 12.dp, vertical = 0.dp)) {
         SongListItem(
             song = song,
-            onClick = { navigateToPlayer(song) },
+            onClick = {
+                Log.i(TAG, "Song clicked: ${song.title}")
+                onLibraryAction(LibraryAction.SongClicked(song))
+                navigateToPlayerV2()
+            },
             onMoreOptionsClick = {},
             //onQueueSong = {},
             isListEditable = false,

--- a/app/src/main/java/com/example/music/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/com/example/music/ui/player/PlayerScreen.kt
@@ -234,7 +234,7 @@ private fun PlayerScreen(
         // background function
         contentColor = MaterialTheme.colorScheme.onPrimaryContainer
     ) { contentPadding ->
-        if (currentSong != null) { // keeping this explicit check for now, don't want to lose context for the FullScreenLoading function below
+        if (currentSong.id != 0L) { // keeping this explicit check for now, don't want to lose context for the FullScreenLoading function below
             PlayerContentWithBackground(
                 currentSong = currentSong,
                 isPlaying = isPlaying,

--- a/app/src/main/java/com/example/music/ui/playlistdetails/PlaylistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/playlistdetails/PlaylistDetailsScreen.kt
@@ -94,8 +94,7 @@ private const val TAG = "Playlist Details Screen"
  */
 @Composable
 fun PlaylistDetailsScreen(
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     //modifier: Modifier = Modifier,
@@ -115,7 +114,6 @@ fun PlaylistDetailsScreen(
                 songs = uiState.songs,
                 onPlaylistAction = viewModel::onPlaylistAction,
                 navigateToPlayer = navigateToPlayer,
-                navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
                 navigateBack = navigateBack,
                 modifier = Modifier.fillMaxSize(),
@@ -194,8 +192,7 @@ private fun PlaylistDetailsScreen(
     playlist: PlaylistInfo,
     songs: List<SongInfo>,
     onPlaylistAction: (PlaylistAction) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     modifier: Modifier = Modifier
@@ -247,7 +244,6 @@ private fun PlaylistDetailsScreen(
                 },*/
                 onPlaylistAction = onPlaylistAction,
                 navigateToPlayer = navigateToPlayer,
-                navigateToPlayerV2 = navigateToPlayerV2,
                 modifier = Modifier.padding(contentPadding)//.padding(horizontal = 8.dp)
             )
         }
@@ -312,8 +308,7 @@ private fun PlaylistDetailsContent(
     playlist: PlaylistInfo,
     songs: List<SongInfo>,
     onPlaylistAction: (PlaylistAction) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     modifier: Modifier = Modifier
 ) { //determines content of details screen
     //logger.info { "Playlist Details Content function start" }
@@ -336,7 +331,9 @@ private fun PlaylistDetailsContent(
         fullWidthItem {
             if (songs.isEmpty()) {
                 PlaylistDetailsEmptyList(
-                    onClick = {}
+                    onClick = {
+                        Log.i(TAG, "Add to Empty Playlist btn clicked")
+                    }
                 )
             } else {
                 Column {
@@ -356,12 +353,12 @@ private fun PlaylistDetailsContent(
                         onPlayClick = {
                             Log.i(TAG, "Play Playlist btn clicked")
                             onPlaylistAction(PlaylistAction.PlaySongs(songs))
-                            navigateToPlayerV2()
+                            navigateToPlayer()
                         },
                         onShuffleClick = {
                             Log.i(TAG, "Shuffle Playlist btn clicked")
                             onPlaylistAction(PlaylistAction.ShuffleSongs(songs))
-                            navigateToPlayerV2()
+                            navigateToPlayer()
                         },
                     )
                 }
@@ -385,7 +382,7 @@ private fun PlaylistDetailsContent(
                     onClick = {
                         Log.i(TAG, "Song clicked ${song.title}")
                         onPlaylistAction(PlaylistAction.PlaySong(song))
-                        navigateToPlayerV2()
+                        navigateToPlayer()
                     },
                     onMoreOptionsClick = {},
                     //onQueueSong = onQueueSong,
@@ -715,7 +712,6 @@ fun PlaylistDetailsScreenPreview() {
 
             onPlaylistAction = {},
             navigateToPlayer = {},
-            navigateToPlayerV2 = {},
             navigateToSearch = {},
             navigateBack = {},
         )

--- a/app/src/main/java/com/example/music/ui/playlistdetails/PlaylistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/playlistdetails/PlaylistDetailsScreen.kt
@@ -1,6 +1,7 @@
 package com.example.music.ui.playlistdetails
 
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
@@ -94,6 +95,7 @@ private const val TAG = "Playlist Details Screen"
 @Composable
 fun PlaylistDetailsScreen(
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     //modifier: Modifier = Modifier,
@@ -113,6 +115,7 @@ fun PlaylistDetailsScreen(
                 songs = uiState.songs,
                 onQueueSong = viewModel::onQueueSong,
                 navigateToPlayer = navigateToPlayer,
+                navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
                 navigateBack = navigateBack,
                 modifier = Modifier.fillMaxSize(),
@@ -152,7 +155,10 @@ fun PlaylistDetailsScreen(
  * Error Screen
  */
 @Composable
-private fun PlaylistDetailsError(onRetry: () -> Unit, modifier: Modifier = Modifier) {
+private fun PlaylistDetailsError(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Surface(modifier = modifier) {
         Column(
             verticalArrangement = Arrangement.Center,
@@ -189,6 +195,7 @@ private fun PlaylistDetailsScreen(
     songs: List<SongInfo>,
     onQueueSong: (SongInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
     modifier: Modifier = Modifier
@@ -239,6 +246,7 @@ private fun PlaylistDetailsScreen(
                     onQueueSong(it)
                 },*/
                 navigateToPlayer = navigateToPlayer,
+                navigateToPlayerV2 = navigateToPlayerV2,
                 modifier = Modifier.padding(contentPadding)//.padding(horizontal = 8.dp)
             )
         }
@@ -304,6 +312,7 @@ private fun PlaylistDetailsContent(
     songs: List<SongInfo>,
     //onQueueSong: (SongInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     modifier: Modifier = Modifier
 ) { //determines content of details screen
     //logger.info { "Playlist Details Content function start" }
@@ -325,10 +334,23 @@ private fun PlaylistDetailsContent(
         // section 2: songs list
         fullWidthItem {
             if (songs.isEmpty()) {
-                PlaylistDetailsEmptyList(onClick = {})
+                PlaylistDetailsEmptyList(
+                    onClick = {}
+                )
             } else {
                 Column {
-                    SongCountAndAddSortSelectButtons( songs = songs, onAddClick = {}, onSelectClick = {}, onSortClick = {} )
+                    SongCountAndAddSortSelectButtons(
+                        songs = songs,
+                        onAddClick = {
+                            Log.i(TAG, "Add to Playlist btn clicked")
+                        },
+                        onSelectClick = {
+                            Log.i(TAG, "Multi-Select btn clicked")
+                        },
+                        onSortClick = {
+                            Log.i(TAG, "Song Sort btn clicked")
+                        }
+                    )
                     PlayShuffleButtons(
                         onPlayClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
                         onShuffleClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
@@ -680,6 +702,7 @@ fun PlaylistDetailsScreenPreview() {
 
             onQueueSong = {},
             navigateToPlayer = {},
+            navigateToPlayerV2 = {},
             navigateToSearch = {},
             navigateBack = {},
         )

--- a/app/src/main/java/com/example/music/ui/playlistdetails/PlaylistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/playlistdetails/PlaylistDetailsScreen.kt
@@ -113,7 +113,7 @@ fun PlaylistDetailsScreen(
             PlaylistDetailsScreen(
                 playlist = uiState.playlist,
                 songs = uiState.songs,
-                onQueueSong = viewModel::onQueueSong,
+                onPlaylistAction = viewModel::onPlaylistAction,
                 navigateToPlayer = navigateToPlayer,
                 navigateToPlayerV2 = navigateToPlayerV2,
                 navigateToSearch = navigateToSearch,
@@ -193,7 +193,7 @@ private fun PlaylistDetailsLoadingScreen(
 private fun PlaylistDetailsScreen(
     playlist: PlaylistInfo,
     songs: List<SongInfo>,
-    onQueueSong: (SongInfo) -> Unit,
+    onPlaylistAction: (PlaylistAction) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
     navigateToPlayerV2: () -> Unit,
     navigateToSearch: () -> Unit,
@@ -245,6 +245,7 @@ private fun PlaylistDetailsScreen(
                     }
                     onQueueSong(it)
                 },*/
+                onPlaylistAction = onPlaylistAction,
                 navigateToPlayer = navigateToPlayer,
                 navigateToPlayerV2 = navigateToPlayerV2,
                 modifier = Modifier.padding(contentPadding)//.padding(horizontal = 8.dp)
@@ -310,7 +311,7 @@ private fun PlaylistDetailsTopAppBar(
 private fun PlaylistDetailsContent(
     playlist: PlaylistInfo,
     songs: List<SongInfo>,
-    //onQueueSong: (SongInfo) -> Unit,
+    onPlaylistAction: (PlaylistAction) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
     navigateToPlayerV2: () -> Unit,
     modifier: Modifier = Modifier
@@ -352,8 +353,16 @@ private fun PlaylistDetailsContent(
                         }
                     )
                     PlayShuffleButtons(
-                        onPlayClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
-                        onShuffleClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
+                        onPlayClick = {
+                            Log.i(TAG, "Play Playlist btn clicked")
+                            onPlaylistAction(PlaylistAction.PlaySongs(songs))
+                            navigateToPlayerV2()
+                        },
+                        onShuffleClick = {
+                            Log.i(TAG, "Shuffle Playlist btn clicked")
+                            onPlaylistAction(PlaylistAction.ShuffleSongs(songs))
+                            navigateToPlayerV2()
+                        },
                     )
                 }
             }
@@ -373,7 +382,11 @@ private fun PlaylistDetailsContent(
                     //call the SongListItem function to display each one, include the data needed to display item in full,
                     //and should likely share context from where this call being made in case specific data needs to be shown / not shown
                     song = song,
-                    onClick = navigateToPlayer,
+                    onClick = {
+                        Log.i(TAG, "Song clicked ${song.title}")
+                        onPlaylistAction(PlaylistAction.PlaySong(song))
+                        navigateToPlayerV2()
+                    },
                     onMoreOptionsClick = {},
                     //onQueueSong = onQueueSong,
                     modifier = Modifier.fillMaxWidth(),
@@ -700,7 +713,7 @@ fun PlaylistDetailsScreenPreview() {
             playlist = PreviewPlaylists[2],
             songs = getPlaylistSongs(2),
 
-            onQueueSong = {},
+            onPlaylistAction = {},
             navigateToPlayer = {},
             navigateToPlayerV2 = {},
             navigateToSearch = {},

--- a/app/src/main/java/com/example/music/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/example/music/ui/search/SearchScreen.kt
@@ -107,6 +107,7 @@ fun SearchScreen(
             queryText = queryText,
             navigateBack = navigateBack,
             navigateToPlayer = navigateToPlayer,
+            navigateToPlayerV2 = navigateToPlayerV2,
             navigateToArtistDetails = navigateToArtistDetails,
             navigateToAlbumDetails = navigateToAlbumDetails,
             viewModel = viewModel,
@@ -151,6 +152,7 @@ fun SearchScreenReady(
 
     navigateBack: () -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToArtistDetails: (ArtistInfo) -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     viewModel: SearchQueryViewModel,
@@ -195,7 +197,10 @@ fun SearchScreenReady(
                 onSendQuery = { viewModel.sendQuery() },
 
                 // actions to do when user taps/clicks on results
-                onSongClicked = { item -> navigateToPlayer(item) },
+                onSongClicked = { item ->
+                    viewModel.onPlaySong(item)
+                    navigateToPlayerV2()
+                },
                 onArtistClicked = { item -> navigateToArtistDetails(item) },
                 onAlbumClicked = { item -> navigateToAlbumDetails(item) },
                 modifier = Modifier.padding(contentPadding),

--- a/app/src/main/java/com/example/music/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/example/music/ui/search/SearchScreen.kt
@@ -85,8 +85,7 @@ import com.example.music.ui.tooling.SystemLightPreview
 @Composable
 fun SearchScreen(
     navigateBack: () -> Unit = {},
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToArtistDetails: (ArtistInfo) -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     viewModel: SearchQueryViewModel = hiltViewModel(),
@@ -107,7 +106,6 @@ fun SearchScreen(
             queryText = queryText,
             navigateBack = navigateBack,
             navigateToPlayer = navigateToPlayer,
-            navigateToPlayerV2 = navigateToPlayerV2,
             navigateToArtistDetails = navigateToArtistDetails,
             navigateToAlbumDetails = navigateToAlbumDetails,
             viewModel = viewModel,
@@ -151,15 +149,14 @@ fun SearchScreenReady(
     queryText: String,
 
     navigateBack: () -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     navigateToArtistDetails: (ArtistInfo) -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     viewModel: SearchQueryViewModel,
 ) {
-//    val coroutineScope = rememberCoroutineScope()
+    //val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
-//    val snackBarText = stringResource(id = R.string.sbt_song_added_to_your_queue)
+    //val snackBarText = stringResource(id = R.string.sbt_song_added_to_your_queue)
 
     ScreenBackground(
         modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars)
@@ -199,7 +196,7 @@ fun SearchScreenReady(
                 // actions to do when user taps/clicks on results
                 onSongClicked = { item ->
                     viewModel.onPlaySong(item)
-                    navigateToPlayerV2()
+                    navigateToPlayer()
                 },
                 onArtistClicked = { item -> navigateToArtistDetails(item) },
                 onAlbumClicked = { item -> navigateToAlbumDetails(item) },

--- a/app/src/main/java/com/example/music/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/example/music/ui/search/SearchScreen.kt
@@ -86,6 +86,7 @@ import com.example.music.ui.tooling.SystemLightPreview
 fun SearchScreen(
     navigateBack: () -> Unit = {},
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     navigateToArtistDetails: (ArtistInfo) -> Unit,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
     viewModel: SearchQueryViewModel = hiltViewModel(),

--- a/app/src/main/java/com/example/music/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/search/SearchViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 //import com.example.music.domain.player.SongPlayer
 import com.example.music.domain.model.SearchQueryFilterV2
+import com.example.music.domain.model.SongInfo
 import com.example.music.domain.usecases.SearchQueryV2
+import com.example.music.service.SongController
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -29,7 +31,7 @@ private const val TAG = "Search View Model"
 @HiltViewModel
 class SearchQueryViewModel @Inject constructor(
     private val searchQueryV2: SearchQueryV2,
-    //private val songPlayer: SongPlayer,
+    private val songController: SongController,
 ) : ViewModel() {
 
     private val _searchFieldState: MutableStateFlow<SearchFieldState> =
@@ -124,6 +126,11 @@ class SearchQueryViewModel @Inject constructor(
             }
             resetFieldState()
         }
+    }
+
+    fun onPlaySong(song: SongInfo) {
+        Log.i(TAG, "onPlaySong -> ${song.title}")
+        songController.play(song)
     }
 
     private fun String.blankOrEmpty() = this.isBlank() || this.isEmpty()

--- a/app/src/main/java/com/example/music/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/settings/SettingsScreen.kt
@@ -93,8 +93,7 @@ fun SettingsScreen(
     navigateToHome: () -> Unit,
     navigateToLibrary: () -> Unit,
     navigateToSettings: () -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -115,7 +114,6 @@ fun SettingsScreen(
             navigateToLibrary = navigateToLibrary,
             navigateToSettings = navigateToSettings,
             navigateToPlayer = navigateToPlayer,
-            navigateToPlayerV2 = navigateToPlayerV2,
             modifier = Modifier.fillMaxSize()
         )
     }
@@ -161,8 +159,7 @@ private fun SettingsScreen(
     navigateToHome: () -> Unit,
     navigateToLibrary: () -> Unit,
     navigateToSettings: () -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToPlayerV2: () -> Unit,
+    navigateToPlayer: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
 
@@ -786,7 +783,6 @@ private fun PreviewSettings() {
                 navigateToLibrary = {},
                 navigateToSettings = {},
                 navigateToPlayer = {},
-                navigateToPlayerV2 = {},
             )
         }
     }

--- a/app/src/main/java/com/example/music/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/settings/SettingsScreen.kt
@@ -92,6 +92,7 @@ fun SettingsScreen(
     navigateToLibrary: () -> Unit,
     navigateToSettings: () -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -112,6 +113,7 @@ fun SettingsScreen(
             navigateToLibrary = navigateToLibrary,
             navigateToSettings = navigateToSettings,
             navigateToPlayer = navigateToPlayer,
+            navigateToPlayerV2 = navigateToPlayerV2,
             modifier = Modifier.fillMaxSize()
         )
     }
@@ -155,6 +157,7 @@ private fun SettingsScreen(
     navigateToLibrary: () -> Unit,
     navigateToSettings: () -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
+    navigateToPlayerV2: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
 
@@ -778,7 +781,7 @@ private fun PreviewSettings() {
                 navigateToLibrary = {},
                 navigateToSettings = {},
                 navigateToPlayer = {},
-                //navigateToPlayerSong = {},
+                navigateToPlayerV2 = {},
             )
         }
     }

--- a/app/src/main/java/com/example/music/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/settings/SettingsScreen.kt
@@ -75,6 +75,8 @@ import com.example.music.ui.tooling.SystemDarkPreview
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+private const val TAG = "Settings Screen"
+
 /** Changelog:
  *
  * 7/22-23/2025 - Deleted SongPlayer from domain layer.
@@ -123,7 +125,10 @@ fun SettingsScreen(
  * Error Screen
  */
 @Composable
-private fun SettingsScreenError(onRetry: () -> Unit, modifier: Modifier = Modifier) {
+private fun SettingsScreenError(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Surface(modifier = modifier) {
         Column(
             verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/example/music/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.music.data.repository.ShuffleType
 import com.example.music.domain.usecases.GetTotalCountsV2
+import com.example.music.service.SongController
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +21,7 @@ class SettingsViewModel @Inject constructor(
     //need to be able to access CurrentPreferencesDataStore
     //need own set of ScreenActions that trigger like onClick
     getTotalCountsV2: GetTotalCountsV2,
+    private val songController: SongController
 ) : ViewModel() {
 
     private val selectedShuffleType = MutableStateFlow(ShuffleType.ONCE)
@@ -86,6 +88,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun onSettingsAction(action: SettingsAction) {
+        Log.i(TAG, "onSettingsAction - $action")
         when(action){
             is SettingsAction.ShuffleTypeSelected -> onShuffleTypeSelected(action.shuffleType)
             is SettingsAction.ThemeModeSelected -> onThemeModeSelected(action.themeMode)

--- a/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
+++ b/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
@@ -379,7 +379,7 @@ fun SongMoreOptionsBottomModal(
 
     coroutineScope: CoroutineScope,
     song: SongInfo,
-    navigateToPlayer: (SongInfo) -> Unit = {},
+    navigateToPlayer: () -> Unit = {}, //FixMe
     // would likely need the other navigateTo screens here too
 
     //do i need a context variable? like if this was from PlaylistDetails, or ArtistDetails, or Home, or Library
@@ -409,7 +409,7 @@ fun SongMoreOptionsBottomModal(
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             val songActions = arrayListOf(
-                Pair(Actions.PlayItem) { navigateToPlayer(song) },
+                Pair(Actions.PlayItem) { navigateToPlayer() }, //FixMe
                 Pair(Actions.PlayItemNext) {},
                 Pair(Actions.AddToPlaylist) {},
                 Pair(Actions.AddToQueue) {},
@@ -491,7 +491,7 @@ fun AlbumMoreOptionsBottomModal(
     //AlbumDetails context? ArtistDetails context?
     //navigateToAlbumDetails: (AlbumInfo) -> Unit, //usage depends on content: if on library.albums, albumDetails, artistDetails. aka not necessary for moreOptions on albumDetails
     //navigateToArtistDetails: (ArtistInfo) -> Unit,
-    //navigateToPlayer: (SongInfo) -> Unit = {},
+    //navigateToPlayer: () -> Unit = {},
     //showBottomSheet: Boolean,
 ) {
     var showBottomSheet by remember { mutableStateOf(false) }
@@ -579,7 +579,7 @@ fun ArtistMoreOptionsBottomModal(
     coroutineScope: CoroutineScope,
     artist: ArtistInfo,
     navigateToArtistDetails: (ArtistInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit = {},
+    navigateToPlayer: () -> Unit = {},
     context: String = "",
     //showBottomSheet: Boolean,
 ) {


### PR DESCRIPTION
### Description:
The adjustments in #9 meant that app navigation that included navigateToPlayer needed to be changed so that
1. The navigateToPlayer function did not take songId as a parameter
2. The UI screen needs to call SongController to start the playback process

### Changes Made:
- Music App Navigation: changed Player object navigation route from "player/{songId}" to "player"
- UI viewModels: injected SongController to constructors, and unified functions for invoking SongController functions
- UI screens: removed songId parameter from navigateToPlayer, and uses encapsulated SongController functions to initiate song playback
- Screens and ViewModels that were updated: ArtistDetails, AlbumDetails, ComposerDetails, GenreDetails, PlaylistDetails, Home, Library, Search, Settings, BottomModals components

### Related Issues:
Fixes Issue #12 
Opens Intermittent Issue #14 where quickly switching in and out of Player Screen generates unexpected responses