### PR TITLE
Fix shuffling logic

### DIFF
--- a/app/src/main/java/com/example/music/service/SongController.kt
+++ b/app/src/main/java/com/example/music/service/SongController.kt
@@ -66,6 +66,11 @@ interface SongController {
     val hasNext: Boolean
 
     /**
+     * If the queued media items list are in shuffled order.
+     */
+    val isShuffled: Boolean
+
+    /**
      * A reflection of the events occurring in Player
      */
     val events: Flow<Player.Events?>
@@ -182,7 +187,8 @@ interface SongController {
     fun previous()
 
     /**
-     * Use to change the shuffle mode
+     * Use to change the shuffle mode. This is from the Player screen when the user taps the
+     * Shuffle btn so the currently playing queue toggles the shuffle order.
      */
     fun onShuffle()
 

--- a/app/src/main/java/com/example/music/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/com/example/music/ui/player/PlayerScreen.kt
@@ -126,7 +126,7 @@ fun PlayerScreen(
     PlayerScreen(
         currentSong = viewModel.currentSong,
         isPlaying = viewModel.isPlaying,
-        isShuffled = false, //FixMe: update when isShuffled is fixed,
+        isShuffled = viewModel.isShuffled,
         repeatState = RepeatType.ON, //FixMe: update when repeatState is fixed,
         progress = viewModel.progress,
         timeElapsed = viewModel.position,
@@ -811,7 +811,6 @@ private fun PlayerButtons(
                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onPrimaryContainer),
                 modifier = sideButtonsModifier
                     .clickable(enabled = true, onClick = onShuffle)
-                    //.alpha(if (isPlaying) 1f else 0.25f) //likely change opacity if playing
             )
         } else {
             //determined that the current state IS NOT shuffled (isShuffled is false)

--- a/app/src/main/java/com/example/music/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/player/PlayerViewModel.kt
@@ -77,6 +77,7 @@ interface PlayerState {
     val player: Player?
     var progress: Float
     var position: Long
+    var isShuffled: Boolean
 }
 
 /**
@@ -106,7 +107,7 @@ class PlayerViewModel @Inject constructor(
     private var _isPlaying by mutableStateOf(songController.isPlaying)
     private var _position by mutableLongStateOf(songController.position)
     private var _progress by mutableFloatStateOf(songController.progress)
-    //private var _isShuffled = MutableStateFlow(false)
+    private var _isShuffled by mutableStateOf(songController.isShuffled)
     //private val _repeatState = MutableStateFlow(0)
 
     var currentSong by mutableStateOf(SongInfo())
@@ -135,6 +136,12 @@ class PlayerViewModel @Inject constructor(
             _position = value
         }
 
+    override var isShuffled: Boolean
+        get() = _isShuffled
+        set(value) {
+            _isShuffled = value
+        }
+
     private var timerJob: Job? = null
 
     /* // OG method for getting SongInfo when navigating to PlayerScreen:
@@ -161,7 +168,7 @@ class PlayerViewModel @Inject constructor(
                 // if events is empty, take these actions to generate the needed values for populating the Player Screen
                 if (it == null) {
                     Log.d(TAG, "init: running start up events to initialize PlayerVM")
-                    //shuffle mode enabled changed goes here
+                    onPlayerEvent(event = Player.EVENT_SHUFFLE_MODE_ENABLED_CHANGED)
                     //repeat mode enabled changed goes here
                     onPlayerEvent(event = Player.EVENT_IS_LOADING_CHANGED)
                     onPlayerEvent(event = Player.EVENT_PLAY_WHEN_READY_CHANGED)
@@ -235,7 +242,10 @@ class PlayerViewModel @Inject constructor(
             //Player.EVENT_REPEAT_MODE_CHANGED -> {}
 
             // Event for checking if the shuffle mode is enabled
-            //Player.EVENT_SHUFFLE_MODE_ENABLED_CHANGED -> {}
+            Player.EVENT_SHUFFLE_MODE_ENABLED_CHANGED -> {
+                _isShuffled = songController.isShuffled
+                Log.d(TAG, "isShuffled set to $isShuffled")
+            }
         }
     }
 
@@ -329,7 +339,7 @@ class PlayerViewModel @Inject constructor(
 
     fun onShuffle() {
         Log.i(TAG, "Hit shuffle btn on Player Screen")
-        //songController.onShuffle()
+        songController.onShuffle()
     }
 
     fun onRepeat() {

--- a/app/src/main/java/com/example/music/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/player/PlayerViewModel.kt
@@ -219,8 +219,8 @@ class PlayerViewModel @Inject constructor(
                         id = mediaItem?.mediaId
                     }
                     currentSong = getSongDataV2(id.toLong())
+                    Log.d(TAG, "Current Song set to ${currentSong.title}")
                 }
-                Log.d(TAG, "Current Song set to ${currentSong.title}")
             }
 
             // Event for checking if play when ready has changed


### PR DESCRIPTION
### Changes Made:
- added back isShuffled property to SongController
- fixed shuffle methods in SongController to cover playing a shuffled set of items, setting the current queue to be un-shuffled, and setting the current queue to be shuffled
- replaced RAND_SEED const variable with actual randomizer object Random  
- added a temporary property to SongController save playback items in a default order for toggling to when setting isShuffled to false
- fixed isShuffled property in PlayerViewModel to read from SongController
- removed temporary hardcoded isShuffled value in PlayerScreen
- uncommented onShuffle() method in PlayerViewModel

### Related Issues:
Addresses Issue #10, not completely but just the first part
