### PR TITLE
Implemented more robust version of bottom sheet modals as More Options menu

### DIFF
--- a/app/src/main/java/com/example/music/service/MediaService.kt
+++ b/app/src/main/java/com/example/music/service/MediaService.kt
@@ -82,9 +82,9 @@ class MediaService : MediaSessionService(), Callback, Player.Listener {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     /**
-     *  A coroutine job that monitors the playback state and performs some actions based on it.
-     *  It saves the current playback position every 5 seconds and pauses the player if the sleep time is reached.
-     *  The job is cancelled when the service is destroyed or the playback is stopped.
+     * A coroutine job that monitors the playback state and performs some actions based on it.
+     * It saves the current playback position every 5 seconds and pauses the player if the sleep time is reached.
+     * The job is cancelled when the service is destroyed or the playback is stopped.
      */
     private var sessionMonitorJob: Job? = null
 

--- a/app/src/main/java/com/example/music/service/SongController.kt
+++ b/app/src/main/java/com/example/music/service/SongController.kt
@@ -5,7 +5,6 @@ import androidx.media3.common.Player
 import com.example.music.data.repository.RepeatType
 import com.example.music.domain.model.SongInfo
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.StateFlow
 import java.time.Duration
 
 /** Changelog:
@@ -66,14 +65,9 @@ interface SongController {
     val hasNext: Boolean
 
     /**
-     * If the queued media items list are in shuffled order.
+     * The media3 Player object that provides Player functionality to SongController
      */
-    val isShuffled: Boolean
-
-    /**
-     * If the queued media items list are will be repeated.
-     */
-    val repeatState: RepeatType
+    val player: Player?
 
     /**
      * A reflection of the events occurring in Player
@@ -86,14 +80,19 @@ interface SongController {
     val loaded: Flow<Boolean>
 
     /**
+     * If the queued media items list are in shuffled order.
+     */
+    val isShuffled: Boolean
+
+    /**
+     * If the queued media items list are will be repeated.
+     */
+    val repeatState: RepeatType
+
+    /**
      * The speed of which the player increments
      */
     //var playerSpeed: Duration
-
-    /**
-     * The media3 Player object that provides Player functionality to SongController
-     */
-    val player: Player?
 
     /**
      * Add song to end of queue
@@ -170,6 +169,8 @@ interface SongController {
      */
     fun pause()
 
+    fun shuffle(songs: List<SongInfo>)
+
     /**
      * Stops the currently playing song
      */
@@ -192,16 +193,16 @@ interface SongController {
     fun previous()
 
     /**
-     * Use to change the shuffle mode. This is from the Player screen when the user taps the
-     * Shuffle btn so the currently playing queue toggles the shuffle order.
-     */
-    fun onShuffle()
-
-    /**
      * Use to change the repeat mode. This is from the Player screen when the user taps the
      * Repeat btn so the current queue with not repeat, repeat one song, or repeat entire queue.
      */
     fun onRepeat()
+
+    /**
+     * Use to change the shuffle mode. This is from the Player screen when the user taps the
+     * Shuffle btn so the currently playing queue toggles the shuffle order.
+     */
+    fun onShuffle()
 
     /**
      * Increases the speed of Player playback by a given time specified in [Duration].
@@ -212,8 +213,6 @@ interface SongController {
      * Decreases the speed of Player playback by a given time specified in [Duration].
      */
     //fun decreaseSpeed(speed: Duration = Duration.ofMillis(500))
-
-    fun shuffle(songs: List<SongInfo>)
 
     fun isConnected() : Boolean
 

--- a/app/src/main/java/com/example/music/service/SongController.kt
+++ b/app/src/main/java/com/example/music/service/SongController.kt
@@ -216,4 +216,6 @@ interface SongController {
     fun shuffle(songs: List<SongInfo>)
 
     fun isConnected() : Boolean
+
+    fun logTrackNumber()
 }

--- a/app/src/main/java/com/example/music/service/SongControllerImpl.kt
+++ b/app/src/main/java/com/example/music/service/SongControllerImpl.kt
@@ -260,7 +260,8 @@ class SongControllerImpl @Inject constructor(
         Log.d(TAG, "Count of items to queue: ${songs.size} items.")
         mediaController.shuffleModeEnabled = true
         tempPlayOrder = songs
-        setMediaItems(songs.shuffled(Random))
+        setMediaItems(songs)
+        //setMediaItems(songs.shuffled(Random))
 
         Log.d(TAG, "Current media controller state before apply is ${mediaController.playbackState}.")
         mediaController.apply {
@@ -376,6 +377,27 @@ class SongControllerImpl @Inject constructor(
      */
     private fun unShuffleQueue() {
         Log.d(TAG, "in unShuffleQueue(): START")
+        /*
+            // Goal for now: to have the queue change back to it's original playback order,
+            // as well as keep the current media item untouched if it is currently
+            // playing. So that when the order changes, the current item's placement can shift,
+            // but it will still play.
+
+            // this can get real spicy to figure out how to achieve
+            // if i want it to work the same way the play music one works, it would need to keep
+            // the add to history intact, so that switching would just go from one to the other
+            // and hitting shuffle would just throw out a new shuffle order, no need to save it
+            // but to keep the un-shuffled order ... would it take a temporary playlist queue?
+            // and it would just have the songs' track number intrinsically?
+            // because i dunno about keeping a history as a side thing ...
+
+            // actually, if the queue can be manually reordered, then yeah it would be much better
+            // to just directly give the songs in queue their list order
+            // new concern: in play music, trying to reorder a song while un-shuffled did not keep
+            // that move after the queue was shuffled, then un-shuffled. it returned to its original
+            // placement when it was first added to the queue. maybe it really does use a history ...
+            // or keeps the original placement and reordering uses a temporary shift
+        */
         setMediaItems(tempPlayOrder)
         play(true)
         Log.d(TAG, "in unShuffleQueue(): END")
@@ -383,6 +405,12 @@ class SongControllerImpl @Inject constructor(
 
     override fun isConnected(): Boolean = mediaController?.connectedToken != null
 
+    override fun logTrackNumber() {
+        val mediaController = mediaController ?: return
+        val currTrack = mediaController.currentMediaItemIndex + 1 // returns the index of the item from its original, ordered context
+        val totalTrack = mediaController.mediaItemCount // total items in playback set
+        Log.d(TAG, "Playing Track #$currTrack of #$totalTrack")
+    }
     /**
      * Internal function to log the MediaController playback state.
      */

--- a/app/src/main/java/com/example/music/service/SongControllerImpl.kt
+++ b/app/src/main/java/com/example/music/service/SongControllerImpl.kt
@@ -15,7 +15,6 @@ import com.example.music.domain.model.SongInfo
 import com.example.music.domain.player.model.title
 import com.example.music.domain.player.model.toMediaItem
 import com.example.music.ui.shared.mediaItems
-import com.example.music.ui.shared.queue
 import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -28,7 +27,6 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import java.time.Duration
 import javax.inject.Inject
 import kotlin.random.Random
 import kotlin.reflect.KProperty
@@ -338,14 +336,6 @@ class SongControllerImpl @Inject constructor(
         Log.d(TAG, "in onRepeat(): END --- repeatState set to ${repeatState.name}")
     }
 
-    /*override fun increaseSpeed(speed: Duration) {
-        //_playerSpeed.value += speed
-    }
-
-    override fun decreaseSpeed(speed: Duration) {
-        //_playerSpeed.value -= speed
-    }*/
-
     override fun onShuffle() {
         val mediaController = mediaController ?: return
         Log.d(TAG, "in onShuffle(): START --- isShuffled is $isShuffled")
@@ -361,6 +351,14 @@ class SongControllerImpl @Inject constructor(
         }
         Log.d(TAG, "is onShuffle(): END --- isShuffled set to $isShuffled")
     }
+
+    /*override fun increaseSpeed(speed: Duration) {
+        //_playerSpeed.value += speed
+    }
+
+    override fun decreaseSpeed(speed: Duration) {
+        //_playerSpeed.value -= speed
+    }*/
 
     /**
      * Internal function to shuffle the MediaController queue.
@@ -411,24 +409,25 @@ class SongControllerImpl @Inject constructor(
         val totalTrack = mediaController.mediaItemCount // total items in playback set
         Log.d(TAG, "Playing Track #$currTrack of #$totalTrack")
     }
+
     /**
      * Internal function to log the MediaController playback state.
      */
     private fun playState() {
         val mediaController = mediaController ?: return
         when(mediaController.playbackState) {
-            Player.STATE_READY -> {
-                Log.e(TAG, "Playback State is READY")
-            }
             Player.STATE_IDLE -> {
                 Log.e(TAG, "Playback State is IDLE")
-            }
+            } // 1
             Player.STATE_BUFFERING -> {
                 Log.e(TAG, "Playback State is BUFFERING")
-            }
+            } // 2
+            Player.STATE_READY -> {
+                Log.e(TAG, "Playback State is READY")
+            } // 3
             Player.STATE_ENDED -> {
                 Log.e(TAG, "Playback State is ENDED")
-            }
+            } // 4
             else -> {
                 Log.e(TAG, "Playback State error")
             }

--- a/app/src/main/java/com/example/music/ui/MusicApp.kt
+++ b/app/src/main/java/com/example/music/ui/MusicApp.kt
@@ -105,8 +105,8 @@ fun MusicApp(
                     navigateToArtistDetails = { artistId ->
                         appState.navigateToArtistDetails(artistId, backStackEntry)
                     },
-                    navigateToGenreDetails = { genre ->
-                        appState.navigateToGenreDetails(genre.id, backStackEntry)
+                    navigateToGenreDetails = { genreId ->
+                        appState.navigateToGenreDetails(genreId, backStackEntry)
                     },
                     navigateToComposerDetails = { composer ->
                         appState.navigateToComposerDetails(composer.id, backStackEntry)

--- a/app/src/main/java/com/example/music/ui/MusicApp.kt
+++ b/app/src/main/java/com/example/music/ui/MusicApp.kt
@@ -192,6 +192,12 @@ fun MusicApp(
                     navigateBack = appState::navigateBack,
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
+                    navigateToAlbumDetails = { albumId ->
+                        appState.navigateToAlbumDetails(albumId, backStackEntry)
+                    },
+                    navigateToArtistDetails = { artistId ->
+                        appState.navigateToArtistDetails(artistId, backStackEntry)
+                    }
                 )
             }
 

--- a/app/src/main/java/com/example/music/ui/MusicApp.kt
+++ b/app/src/main/java/com/example/music/ui/MusicApp.kt
@@ -65,8 +65,8 @@ fun MusicApp(
 
                     navigateToHome = { appState.navigateToHome(backStackEntry) },
                     navigateToLibrary = { appState.navigateToLibrary(backStackEntry) },
-                    navigateToAlbumDetails = { album ->
-                        appState.navigateToAlbumDetails(album.id, backStackEntry)
+                    navigateToAlbumDetails = { albumId: Long ->
+                        appState.navigateToAlbumDetails(albumId, backStackEntry)
                     },
                     navigateToPlaylistDetails = { playlist ->
                         appState.navigateToPlaylistDetails(playlist.id, backStackEntry)
@@ -149,8 +149,8 @@ fun MusicApp(
                     //keeping for now in case window class size becomes relevant
                     //windowSizeClass = adaptiveInfo.windowSizeClass,
                     navigateBack = appState::navigateBack,
-                    navigateToAlbumDetails = { album ->
-                        appState.navigateToAlbumDetails(album.id, backStackEntry)
+                    navigateToAlbumDetails = { albumId ->
+                        appState.navigateToAlbumDetails(albumId, backStackEntry)
                     },
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },

--- a/app/src/main/java/com/example/music/ui/MusicApp.kt
+++ b/app/src/main/java/com/example/music/ui/MusicApp.kt
@@ -99,11 +99,11 @@ fun MusicApp(
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                     navigateToSettings = { appState.navigateToSettings(backStackEntry) },
-                    navigateToAlbumDetails = { album ->
-                        appState.navigateToAlbumDetails(album.id, backStackEntry)
+                    navigateToAlbumDetails = { albumId ->
+                        appState.navigateToAlbumDetails(albumId, backStackEntry)
                     },
-                    navigateToArtistDetails = { artist ->
-                        appState.navigateToArtistDetails(artist.id, backStackEntry)
+                    navigateToArtistDetails = { artistId ->
+                        appState.navigateToArtistDetails(artistId, backStackEntry)
                     },
                     navigateToGenreDetails = { genre ->
                         appState.navigateToGenreDetails(genre.id, backStackEntry)

--- a/app/src/main/java/com/example/music/ui/MusicApp.kt
+++ b/app/src/main/java/com/example/music/ui/MusicApp.kt
@@ -7,7 +7,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.window.layout.DisplayFeature
@@ -66,10 +65,12 @@ fun MusicApp(
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                     navigateToSettings = { appState.navigateToSettings(backStackEntry) },
-                    navigateToAlbumDetails = { albumId: Long ->
+                    navigateToAlbumDetails = { albumId ->
+                        Log.i(TAG, "id: $albumId")
                         appState.navigateToAlbumDetails(albumId, backStackEntry)
                     },
-                    navigateToArtistDetails = { artistId: Long ->
+                    navigateToArtistDetails = { artistId ->
+                        Log.i(TAG, "id: $artistId")
                         appState.navigateToArtistDetails(artistId, backStackEntry)
                     },
                     navigateToPlaylistDetails = { playlist ->
@@ -79,13 +80,11 @@ fun MusicApp(
             }
 
             //Player Screen Navigation Router
-            composable(Screen.Player.route) { backStackEntry ->
+            composable(Screen.Player.route) { _ ->
                 PlayerScreen(
                     windowSizeClass = adaptiveInfo.windowSizeClass, //needed for screens meant to use full screen
                     displayFeatures = displayFeatures, //used to determine physical properties of display device to accommodate view accordingly
                     navigateBack = appState::navigateBack, //navigation back button
-                    navigateToHome = { appState.navigateToHome(backStackEntry) },
-                    navigateToLibrary = { appState.navigateToLibrary(backStackEntry) },
                 )
             }
 
@@ -100,9 +99,11 @@ fun MusicApp(
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                     navigateToSettings = { appState.navigateToSettings(backStackEntry) },
                     navigateToAlbumDetails = { albumId ->
+                        Log.i(TAG, "id: $albumId")
                         appState.navigateToAlbumDetails(albumId, backStackEntry)
                     },
                     navigateToArtistDetails = { artistId ->
+                        Log.i(TAG, "id: $artistId")
                         appState.navigateToArtistDetails(artistId, backStackEntry)
                     },
                     navigateToGenreDetails = { genreId ->
@@ -122,9 +123,11 @@ fun MusicApp(
                 SearchScreen(
                     navigateBack = appState::navigateBack,
                     navigateToAlbumDetails = { album ->
+                        Log.i(TAG, "id: ${album.id}")
                         appState.navigateToAlbumDetails(album.id, backStackEntry)
                     },
                     navigateToArtistDetails = { artist ->
+                        Log.i(TAG, "id: ${artist.id}")
                         appState.navigateToArtistDetails(artist.id, backStackEntry)
                     },
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
@@ -150,6 +153,7 @@ fun MusicApp(
                     //windowSizeClass = adaptiveInfo.windowSizeClass, //needed for screens meant to use full screen
                     navigateBack = appState::navigateBack,
                     navigateToArtistDetails = { artistId ->
+                        Log.i(TAG, "id: $artistId")
                         appState.navigateToArtistDetails(artistId, backStackEntry)
                     },
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
@@ -164,6 +168,7 @@ fun MusicApp(
                     //windowSizeClass = adaptiveInfo.windowSizeClass,
                     navigateBack = appState::navigateBack,
                     navigateToAlbumDetails = { albumId ->
+                        Log.i(TAG, "id: $albumId")
                         appState.navigateToAlbumDetails(albumId, backStackEntry)
                     },
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
@@ -193,9 +198,11 @@ fun MusicApp(
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
                     navigateToAlbumDetails = { albumId ->
+                        Log.i(TAG, "id: $albumId")
                         appState.navigateToAlbumDetails(albumId, backStackEntry)
                     },
                     navigateToArtistDetails = { artistId ->
+                        Log.i(TAG, "id: $artistId")
                         appState.navigateToArtistDetails(artistId, backStackEntry)
                     }
                 )

--- a/app/src/main/java/com/example/music/ui/MusicApp.kt
+++ b/app/src/main/java/com/example/music/ui/MusicApp.kt
@@ -43,7 +43,6 @@ fun MusicApp(
     displayFeatures: List<DisplayFeature>,
     appState: MusicAppState = rememberMusicAppState()
 ) {
-
     Log.i(TAG, "navigation composable start")
     val adaptiveInfo = currentWindowAdaptiveInfo()
     /*val sizeClassText =
@@ -54,7 +53,6 @@ fun MusicApp(
             navController = appState.navController,
             startDestination = Screen.Home.route
         ) {
-
             // Home Navigation Router
             composable(Screen.Home.route) { backStackEntry ->
                 MainScreen(
@@ -65,15 +63,18 @@ fun MusicApp(
 
                     navigateToHome = { appState.navigateToHome(backStackEntry) },
                     navigateToLibrary = { appState.navigateToLibrary(backStackEntry) },
+                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
+                    navigateToSearch = { appState.navigateToSearch(backStackEntry) },
+                    navigateToSettings = { appState.navigateToSettings(backStackEntry) },
                     navigateToAlbumDetails = { albumId: Long ->
                         appState.navigateToAlbumDetails(albumId, backStackEntry)
+                    },
+                    navigateToArtistDetails = { artistId: Long ->
+                        appState.navigateToArtistDetails(artistId, backStackEntry)
                     },
                     navigateToPlaylistDetails = { playlist ->
                         appState.navigateToPlaylistDetails(playlist.id, backStackEntry)
                     },
-                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
-                    navigateToSettings = { appState.navigateToSettings(backStackEntry) },
-                    navigateToSearch = { appState.navigateToSearch(backStackEntry) }
                 )
             }
 
@@ -85,7 +86,6 @@ fun MusicApp(
                     navigateBack = appState::navigateBack, //navigation back button
                     navigateToHome = { appState.navigateToHome(backStackEntry) },
                     navigateToLibrary = { appState.navigateToLibrary(backStackEntry) },
-                    //navigateToSettings = { appState.navigateToSettings(backStackEntry) },
                 )
             }
 
@@ -96,8 +96,9 @@ fun MusicApp(
                     navigateBack = appState::navigateBack, //navigation back button
                     navigateToHome = { appState.navigateToHome(backStackEntry) },
                     navigateToLibrary = { appState.navigateToLibrary(backStackEntry) },
-                    navigateToSettings = { appState.navigateToSettings(backStackEntry) },
+                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
+                    navigateToSettings = { appState.navigateToSettings(backStackEntry) },
                     navigateToAlbumDetails = { album ->
                         appState.navigateToAlbumDetails(album.id, backStackEntry)
                     },
@@ -112,6 +113,19 @@ fun MusicApp(
                     },
                     navigateToPlaylistDetails = { playlist ->
                         appState.navigateToPlaylistDetails(playlist.id, backStackEntry)
+                    },
+                )
+            }
+
+            //Search Screen Navigation Router
+            composable(Screen.Search.route) { backStackEntry ->
+                SearchScreen(
+                    navigateBack = appState::navigateBack,
+                    navigateToAlbumDetails = { album ->
+                        appState.navigateToAlbumDetails(album.id, backStackEntry)
+                    },
+                    navigateToArtistDetails = { artist ->
+                        appState.navigateToArtistDetails(artist.id, backStackEntry)
                     },
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                 )
@@ -135,11 +149,11 @@ fun MusicApp(
                 AlbumDetailsScreen(
                     //windowSizeClass = adaptiveInfo.windowSizeClass, //needed for screens meant to use full screen
                     navigateBack = appState::navigateBack,
+                    navigateToArtistDetails = { artistId ->
+                        appState.navigateToArtistDetails(artistId, backStackEntry)
+                    },
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
-
-                    //dependent on context, ie if showing in pane or as own screen
-                    showBackButton = true
                 )
             }
 
@@ -154,9 +168,6 @@ fun MusicApp(
                     },
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
-
-                    //dependent on context, ie if showing in pane or as own screen
-                    showBackButton = true,
                 )
             }
 
@@ -193,19 +204,6 @@ fun MusicApp(
                     navigateBack = appState::navigateBack,
                     navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                     navigateToSearch = { appState.navigateToSearch(backStackEntry) },
-                )
-            }
-
-            composable(Screen.Search.route) { backStackEntry ->
-                SearchScreen(
-                    navigateBack = appState::navigateBack,
-                    navigateToAlbumDetails = { album ->
-                        appState.navigateToAlbumDetails(album.id, backStackEntry)
-                    },
-                    navigateToArtistDetails = { artist ->
-                        appState.navigateToArtistDetails(artist.id, backStackEntry)
-                    },
-                    navigateToPlayer = { appState.navigateToPlayer(backStackEntry) },
                 )
             }
         }

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
@@ -602,7 +602,7 @@ fun AlbumDetailsScreen(
                             showBottomSheet = false
                             showSongMoreOptions = false
                         },
-                        coroutineScope = coroutineScope,
+                        //coroutineScope = coroutineScope,
                         song = selectSong,
                         context = "AlbumDetails",
                         //onQueueSong = { action ->

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
@@ -2,10 +2,6 @@ package com.example.music.ui.albumdetails
 
 import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Spring.StiffnessMediumLow
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -33,9 +29,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsIgnoringVisibility
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -46,12 +40,8 @@ import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.KeyboardDoubleArrowUp
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Shuffle
-import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Search
-import androidx.compose.material3.BottomAppBarDefaults
-import androidx.compose.material3.BottomAppBarState
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -59,19 +49,13 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SearchBar
-import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarDefaults.TopAppBarExpandedHeight
-import androidx.compose.material3.TopAppBarDefaults.pinnedScrollBehavior
 import androidx.compose.material3.contentColorFor
-import androidx.compose.material3.rememberBottomAppBarState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -84,9 +68,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -95,7 +76,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.min
@@ -104,18 +84,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.util.UnstableApi
 import com.example.music.R
 import com.example.music.designsys.component.AlbumImage
-import com.example.music.designsys.theme.Keyline1
 import com.example.music.designsys.theme.MusicShapes
 import com.example.music.domain.testing.PreviewAlbums
-import com.example.music.domain.testing.getArtistData
 import com.example.music.domain.testing.getSongsInAlbum
 import com.example.music.domain.model.AlbumInfo
 import com.example.music.domain.model.ArtistInfo
 import com.example.music.domain.model.SongInfo
-import com.example.music.domain.testing.PreviewArtists
-import com.example.music.domain.testing.PreviewSongs
-import com.example.music.ui.albumdetails.AlbumAction.SongMoreOptionClicked
-import com.example.music.ui.artistdetails.ArtistAction
 import com.example.music.ui.shared.AlbumMoreOptionsBottomModal
 import com.example.music.ui.shared.DetailsSortSelectionBottomModal
 import com.example.music.ui.shared.Loading
@@ -123,14 +97,11 @@ import com.example.music.ui.shared.ScreenBackground
 import com.example.music.ui.shared.SongListItem
 import com.example.music.ui.shared.SongMoreOptionsBottomModal
 import com.example.music.ui.shared.formatStr
-import com.example.music.ui.shared.gridVerticalScrollbar
 import com.example.music.ui.theme.MusicTheme
-import com.example.music.ui.tooling.CompDarkPreview
 import com.example.music.ui.tooling.SystemDarkPreview
 import com.example.music.util.fullWidthItem
 import com.example.music.util.quantityStringResource
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 /** Changelog:
@@ -287,7 +258,6 @@ fun AlbumDetailsScreen(
                         }
                     },
                     navigationIcon = {
-                        //back button
                         IconButton(onClick = navigateBack) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -297,7 +267,7 @@ fun AlbumDetailsScreen(
                         }
                     },
                     actions = {
-                        // search btn
+                        // Search btn
                         IconButton( onClick = navigateToSearch ) {
                             Icon(
                                 imageVector = Icons.Outlined.Search,
@@ -306,6 +276,7 @@ fun AlbumDetailsScreen(
                             )
                         }
 
+                        // Album More Options btn
                         IconButton(
                             onClick = {
                                 showBottomSheet = true
@@ -408,25 +379,25 @@ fun AlbumDetailsScreen(
                     //section 2: songs list
                     items(songs) { song -> // for each song in list:
                         SongListItem(
-                                song = song,
-                                onClick = {
-                                    Log.i(TAG, "Song clicked: ${song.title}")
-                                    onAlbumAction(AlbumAction.PlaySong(song))
-                                    navigateToPlayer()
-                                },
-                                onMoreOptionsClick = {
-                                    Log.i(TAG, "Song More Option clicked: ${song.title}")
-                                    onAlbumAction(AlbumAction.SongMoreOptionClicked(song))
-                                    showBottomSheet = true
-                                    showSongMoreOptions = true
-                                },
-                                isListEditable = false,
-                                showAlbumImage = true,
-                                showArtistName = true,
-                                showAlbumTitle = false,
-                                showTrackNumber = true,
-                                modifier = Modifier.fillMaxWidth(),
-                            )
+                            song = song,
+                            onClick = {
+                                Log.i(TAG, "Song clicked: ${song.title}")
+                                onAlbumAction(AlbumAction.PlaySong(song))
+                                navigateToPlayer()
+                            },
+                            onMoreOptionsClick = {
+                                Log.i(TAG, "Song More Option clicked: ${song.title}")
+                                onAlbumAction(AlbumAction.SongMoreOptionClicked(song))
+                                showBottomSheet = true
+                                showSongMoreOptions = true
+                            },
+                            isListEditable = false,
+                            showAlbumImage = true,
+                            showArtistName = true,
+                            showAlbumTitle = false,
+                            showTrackNumber = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
                     }
                 }
 
@@ -493,7 +464,7 @@ fun AlbumDetailsScreen(
                                 }
                             }
                         },
-                        onSave = {
+                        onApply = {
                             coroutineScope.launch {
                                 Log.i(TAG, "Save sheet state - does nothing atm")
                                 sheetState.hide()
@@ -1079,7 +1050,7 @@ private fun SongCountAndSortSelectButtons(
         IconButton(
             onClick = onSortClick,
             modifier = Modifier.semantics(mergeDescendants = true) { }
-        ) { // showBottomSheet = true
+        ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.Sort,
                 contentDescription = stringResource(R.string.icon_sort),
@@ -1108,10 +1079,10 @@ private fun SongCountAndSortSelectButtons(
 private fun PlayShuffleButtons(
     onPlayClick: () -> Unit,
     onShuffleClick: () -> Unit,
-    //modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        Modifier.padding(bottom = 8.dp)
+        modifier.padding(bottom = 8.dp)
     ) {
         // play btn
         Button(

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
@@ -258,9 +258,9 @@ fun AlbumDetailsScreen(
     val displayButton = remember { derivedStateOf { listState.firstVisibleItemIndex > 0 } }
 
     val sheetState = rememberModalBottomSheetState(false,)
-    var showBottomSheet by remember { mutableStateOf(false) } // if bottom modal needs to be opened
-    var showSortSheet by remember { mutableStateOf(false) } // if bottom modal content is for sorting songs
-    var showAlbumMoreOptions by remember { mutableStateOf(false) } // if bottom modal content is for album details more options
+    var showBottomSheet by remember { mutableStateOf(false) }
+    var showSortSheet by remember { mutableStateOf(false) }
+    var showAlbumMoreOptions by remember { mutableStateOf(false) }
     var showSongMoreOptions by remember { mutableStateOf( false ) }
 
     ScreenBackground(
@@ -305,11 +305,11 @@ fun AlbumDetailsScreen(
                                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
                             )
                         }
-                        // more options btn // temporary placement till figure out if this should be part of header
+
                         IconButton(
                             onClick = {
                                 showBottomSheet = true
-                                showAlbumMoreOptions = true /* onMoreOptionsClick */
+                                showAlbumMoreOptions = true
                             }
                         ) {
                             Icon(
@@ -343,9 +343,7 @@ fun AlbumDetailsScreen(
                     navigateToPlayer = { navigateToPlayerSong(PreviewSongs[5]) },
                 )*/
             },
-            snackbarHost = { // setting the snackbar hoststate to the scaffold
-                SnackbarHost(hostState = snackbarHostState)
-            },
+            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
             modifier = modifier.nestedScroll(appBarScrollBehavior.nestedScrollConnection),
             containerColor = Color.Transparent,
             contentColor = contentColorFor(MaterialTheme.colorScheme.background) // MaterialTheme.colorScheme.inverseSurface //or onPrimaryContainer
@@ -514,10 +512,10 @@ fun AlbumDetailsScreen(
                             coroutineScope.launch {
                                 Log.i(TAG, "Album More Options Modal -> PlaySongs clicked")
                                 onAlbumAction(AlbumAction.PlaySongs(songs))
-                                navigateToPlayer()
                                 sheetState.hide()
+                                navigateToPlayer()
                             }.invokeOnCompletion {
-                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
                                 if(!sheetState.isVisible) {
                                     showBottomSheet = false
                                     showAlbumMoreOptions = false
@@ -526,8 +524,8 @@ fun AlbumDetailsScreen(
                         },
                         playNext = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked")
-                                onAlbumAction(AlbumAction.PlaySongNext(selectSong))
+                                Log.i(TAG, "Album More Options Modal -> PlaySongsNext clicked")
+                                onAlbumAction(AlbumAction.PlaySongsNext(songs))
                                 sheetState.hide()
                             }.invokeOnCompletion {
                                 Log.i(TAG, "set showBottomSheet to FALSE")
@@ -539,7 +537,7 @@ fun AlbumDetailsScreen(
                         },
                         shuffle = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Artist More Options Modal -> ShuffleSong clicked")
+                                Log.i(TAG, "Album More Options Modal -> ShuffleSongs clicked")
                                 onAlbumAction(AlbumAction.ShuffleSongs(songs))
                                 navigateToPlayer()
                                 sheetState.hide()
@@ -554,14 +552,14 @@ fun AlbumDetailsScreen(
                         //addToPlaylist = {},
                         addToQueue = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> QueueSong clicked")
-                                onAlbumAction(AlbumAction.QueueSong(selectSong))
+                                Log.i(TAG, "Album More Options Modal -> QueueSongs clicked")
+                                onAlbumAction(AlbumAction.QueueSongs(songs))
                                 sheetState.hide()
                             }.invokeOnCompletion {
                                 Log.i(TAG, "set showBottomSheet to FALSE")
                                 if(!sheetState.isVisible) {
                                     showBottomSheet = false
-                                    showSongMoreOptions = false
+                                    showAlbumMoreOptions = false
                                 }
                             }
                         },

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
@@ -548,7 +548,7 @@ fun AlbumDetailsScreen(
                         },
                         goToArtist = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Album More Options Modal -> GoToArtist clicked")
+                                Log.i(TAG, "Album More Options Modal -> GoToArtist clicked :: ${selectSong.artistId}")
                                 navigateToArtistDetails(selectSong.artistId)
                                 sheetState.hide()
                             }.invokeOnCompletion {
@@ -587,7 +587,7 @@ fun AlbumDetailsScreen(
                         song = selectSong,
                         play = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> PlaySong clicked")
+                                Log.i(TAG, "Song More Options Modal -> PlaySong clicked :: ${selectSong.id}")
                                 onAlbumAction(AlbumAction.PlaySong(selectSong))
                                 navigateToPlayer()
                                 sheetState.hide()
@@ -601,7 +601,7 @@ fun AlbumDetailsScreen(
                         },
                         playNext = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked")
+                                Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked :: ${selectSong.id}")
                                 onAlbumAction(AlbumAction.PlaySongNext(selectSong))
                                 sheetState.hide()
                             }.invokeOnCompletion {
@@ -615,7 +615,7 @@ fun AlbumDetailsScreen(
                         //addToPlaylist = {},
                         addToQueue = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> QueueSong clicked")
+                                Log.i(TAG, "Song More Options Modal -> QueueSong clicked :: ${selectSong.id}")
                                 onAlbumAction(AlbumAction.QueueSong(selectSong))
                                 sheetState.hide()
                             }.invokeOnCompletion {
@@ -628,7 +628,7 @@ fun AlbumDetailsScreen(
                         },
                         goToArtist = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> GoToArtist clicked")
+                                Log.i(TAG, "Song More Options Modal -> GoToArtist clicked :: ${selectSong.artistId}")
                                 navigateToArtistDetails(selectSong.artistId)
                                 sheetState.hide()
                             }.invokeOnCompletion {

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
@@ -493,6 +493,18 @@ fun AlbumDetailsScreen(
                                 }
                             }
                         },
+                        onSave = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Save sheet state - does nothing atm")
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showSortSheet = false
+                                }
+                            }
+                        },
                         content = "SongInfo",
                         context = "AlbumDetails",
                     )

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsScreen.kt
@@ -548,8 +548,8 @@ fun AlbumDetailsScreen(
                         },
                         goToArtist = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Album More Options Modal -> GoToArtist clicked :: ${selectSong.artistId}")
-                                navigateToArtistDetails(selectSong.artistId)
+                                Log.i(TAG, "Album More Options Modal -> GoToArtist clicked :: ${album.albumArtistId ?: "null id"}")
+                                navigateToArtistDetails(album.albumArtistId ?: 0L) // not a good check for if this is null
                                 sheetState.hide()
                             }.invokeOnCompletion {
                                 Log.i(TAG, "set showBottomSheet to FALSE")

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
@@ -71,9 +71,9 @@ class AlbumDetailsViewModel @Inject constructor(
         get() = _state
 
     init {
-        Log.i(TAG,"albumId: $albumId")
+        Log.i(TAG,"init START --- albumId: $albumId")
         viewModelScope.launch {
-            Log.i(TAG, "init viewModelScope launch start")
+            Log.i(TAG, "viewModelScope launch START")
             combine(
                 refreshing,
                 getAlbumDetailsData,
@@ -107,6 +107,7 @@ class AlbumDetailsViewModel @Inject constructor(
             }
         }
         refresh(force = false)
+        Log.i(TAG, "init END")
     }
 
     fun refresh(force: Boolean = true) {

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
@@ -83,7 +83,7 @@ class AlbumDetailsViewModel @Inject constructor(
                 albumDetailsFilterResult,
                 selectSong ->
                 Log.i(TAG, "AlbumUiState combine START\n" +
-                    "albumDetailsFilterResult ID: ${albumDetailsFilterResult.album.id}" +
+                    "albumDetailsFilterResult ID: ${albumDetailsFilterResult.album.id}\n" +
                     "albumDetailsFilterResult songs: ${albumDetailsFilterResult.songs.size}\n" +
                     "is SongController available: ${songController.isConnected()}\n" +
                     "isReady?: ${!refreshing}")

--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
@@ -82,7 +82,7 @@ class AlbumDetailsViewModel @Inject constructor(
                 refreshing,
                 albumDetailsFilterResult,
                 selectSong ->
-                Log.i(TAG, "AlbumUiState combine START" +
+                Log.i(TAG, "AlbumUiState combine START\n" +
                     "albumDetailsFilterResult ID: ${albumDetailsFilterResult.album.id}" +
                     "albumDetailsFilterResult songs: ${albumDetailsFilterResult.songs.size}\n" +
                     "is SongController available: ${songController.isConnected()}\n" +
@@ -105,7 +105,6 @@ class AlbumDetailsViewModel @Inject constructor(
             }.collect{
                 _state.value = it
             }
-            Log.i(TAG, "viewModelScope launch END")
         }
         refresh(force = false)
         Log.i(TAG, "init END")
@@ -133,21 +132,34 @@ class AlbumDetailsViewModel @Inject constructor(
             is AlbumAction.SongMoreOptionClicked -> onSongMoreOptionClick(action.song)
 
             is AlbumAction.PlaySong -> onPlaySong(action.song) // songMO-play
-            is AlbumAction.PlaySongNext -> onQueueSongNext(action.song) // songMO-playNext
+            is AlbumAction.PlaySongNext -> onPlaySongNext(action.song) // songMO-playNext
             //is AlbumAction.AddSongToPlaylist -> onAddToPlaylist(action.song) // songMO-addToPlaylist
             is AlbumAction.QueueSong -> onQueueSong(action.song) // songMO-addToQueue
 
             is AlbumAction.PlaySongs -> onPlaySongs(action.songs) // albumMO-play
-            is AlbumAction.PlaySongsNext -> onQueueSongsNext(action.songs) // albumMO-playNext
+            is AlbumAction.PlaySongsNext -> onPlaySongsNext(action.songs) // albumMO-playNext
             is AlbumAction.ShuffleSongs -> onShuffleSongs(action.songs) // albumMO-shuffle
             //is AlbumAction.AddAlbumToPlaylist -> onAddToPlaylist(action.songs) // albumMO-addToPlaylist
             is AlbumAction.QueueSongs -> onQueueSongs(action.songs) // albumMO-addToQueue
         }
     }
 
+    private fun onSongMoreOptionClick(song: SongInfo) {
+        Log.i(TAG, "onSongMoreOptionClick -> ${song.title}")
+        selectedSong.value = song
+    }
+
     private fun onPlaySong(song: SongInfo) {
         Log.i(TAG, "onPlaySong -> ${song.title}")
         songController.play(song)
+    }
+    private fun onPlaySongNext(song: SongInfo) {
+        Log.i(TAG, "onQueueSongNext -> ${song.title}")
+        songController.addToQueueNext(song)
+    }
+    private fun onQueueSong(song: SongInfo) {
+        Log.i(TAG, "onQueueSong -> ${song.title}")
+        songController.addToQueue(song)
     }
 
     private fun onPlaySongs(songs: List<SongInfo>) {
@@ -164,27 +176,14 @@ class AlbumDetailsViewModel @Inject constructor(
             showThemeSheet = false
         }*/
     }
-
-    private fun onQueueSong(song: SongInfo) {
-        Log.i(TAG, "onQueueSong -> ${song.title}")
-        songController.addToQueue(song)
+    private fun onPlaySongsNext(songs: List<SongInfo>) {
+        Log.i(TAG, "onQueueSongsNext - ${songs.size}")
+        songController.addToQueueNext(songs)
     }
-
-    private fun onQueueSongNext(song: SongInfo) {
-        Log.i(TAG, "onQueueSongNext -> ${song.title}")
-        songController.addToQueueNext(song)
-    }
-
     private fun onQueueSongs(songs: List<SongInfo>) {
         Log.i(TAG, "onQueueSongs -> ${songs.size}")
         songController.addToQueue(songs)
     }
-
-    private fun onQueueSongsNext(songs: List<SongInfo>) {
-        Log.i(TAG, "onQueueSongsNext - ${songs.size}")
-        songController.addToQueueNext(songs)
-    }
-
     private fun onShuffleSongs(songs: List<SongInfo>) {
         Log.i(TAG, "onShuffleSongs -> ${songs.size}")
         songController.shuffle(songs)
@@ -201,22 +200,19 @@ class AlbumDetailsViewModel @Inject constructor(
             showThemeSheet = false
         }*/
     }
-
-    private fun onSongMoreOptionClick(song: SongInfo) {
-        Log.i(TAG, "onSongMoreOptionClick -> ${song.title}")
-        selectedSong.value = song
-    }
 }
 
 sealed interface AlbumAction {
-    data class PlaySong(val song: SongInfo) : AlbumAction
-    data class PlaySongs(val songs: List<SongInfo>) : AlbumAction
-    data class PlaySongNext(val song: SongInfo) : AlbumAction
-    data class PlaySongsNext(val songs: List<SongInfo>) : AlbumAction
-    data class QueueSong(val song: SongInfo) : AlbumAction
-    data class QueueSongs(val songs: List<SongInfo>) : AlbumAction
-    data class ShuffleSongs(val songs: List<SongInfo>) : AlbumAction
     data class SongMoreOptionClicked(val song: SongInfo) : AlbumAction
+
+    data class PlaySong(val song: SongInfo) : AlbumAction
+    data class PlaySongNext(val song: SongInfo) : AlbumAction
+    data class QueueSong(val song: SongInfo) : AlbumAction
+
+    data class PlaySongs(val songs: List<SongInfo>) : AlbumAction
+    data class PlaySongsNext(val songs: List<SongInfo>) : AlbumAction
+    data class ShuffleSongs(val songs: List<SongInfo>) : AlbumAction
+    data class QueueSongs(val songs: List<SongInfo>) : AlbumAction
 }
 
 /**

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
@@ -240,8 +240,7 @@ fun ArtistDetailsScreen(
                         }
                     },
                     navigationIcon = {
-                        //back button
-                        IconButton( onClick = navigateBack ) {
+                        IconButton(onClick = navigateBack) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                                 contentDescription = stringResource(id = R.string.icon_back_nav),
@@ -250,7 +249,7 @@ fun ArtistDetailsScreen(
                         }
                     },
                     actions = {
-                        // search btn
+                        // Search btn
                         IconButton( onClick = navigateToSearch ) {
                             Icon(
                                 imageVector = Icons.Outlined.Search,
@@ -259,6 +258,7 @@ fun ArtistDetailsScreen(
                             )
                         }
 
+                        // Artist More Options btn
                         IconButton(
                             onClick = {
                                 showBottomSheet = true
@@ -284,7 +284,6 @@ fun ArtistDetailsScreen(
                     ),
                     scrollBehavior = appBarScrollBehavior,
                 )
-
                 //ArtistDetailsTopAppBar(
                     //navigateBack = navigateBack,
                 //)
@@ -449,7 +448,7 @@ fun ArtistDetailsScreen(
                                 }
                             }
                         },
-                        onSave = {
+                        onApply = {
                             coroutineScope.launch {
                                 Log.i(TAG, "Save sheet state - does nothing atm")
                                 sheetState.hide()

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
@@ -23,7 +23,11 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Sort
+import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -55,6 +59,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -62,6 +67,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.music.R
 import com.example.music.designsys.theme.Keyline1
+import com.example.music.designsys.theme.MusicShapes
 import com.example.music.domain.testing.PreviewArtists
 import com.example.music.domain.testing.getAlbumsByArtist
 import com.example.music.domain.testing.getSongsByArtist

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
@@ -477,7 +477,7 @@ fun ArtistDetailsScreen(
                         album = selectAlbum,
                         play = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Album More Options Modal -> Play Album clicked")
+                                Log.i(TAG, "Album More Options Modal -> Play Album clicked :: ${selectAlbum.id}")
                                 onArtistAction(ArtistAction.PlayAlbum(selectAlbum))
                                 sheetState.hide()
                                 navigateToPlayer()
@@ -491,7 +491,7 @@ fun ArtistDetailsScreen(
                         },
                         playNext = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Album More Options Modal -> Play Album Next clicked")
+                                Log.i(TAG, "Album More Options Modal -> Play Album Next clicked :: ${selectAlbum.id}")
                                 onArtistAction(ArtistAction.PlayAlbumNext(selectAlbum))
                                 sheetState.hide()
                             }.invokeOnCompletion {
@@ -504,7 +504,7 @@ fun ArtistDetailsScreen(
                         },
                         shuffle = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Album More Options Modal -> Shuffle Album clicked")
+                                Log.i(TAG, "Album More Options Modal -> Shuffle Album clicked :: ${selectAlbum.id}")
                                 onArtistAction(ArtistAction.ShuffleAlbum(selectAlbum))
                                 sheetState.hide()
                                 navigateToPlayer()
@@ -519,8 +519,21 @@ fun ArtistDetailsScreen(
                         //addToPlaylist = {},
                         addToQueue = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Album More Options Modal -> Queue Album clicked")
+                                Log.i(TAG, "Album More Options Modal -> Queue Album clicked :: ${selectAlbum.id}")
                                 onArtistAction(ArtistAction.QueueAlbum(selectAlbum))
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showAlbumMoreOptions = false
+                                }
+                            }
+                        },
+                        goToAlbum = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Album More Options Modal -> GoToAlbum clicked :: ${selectAlbum.id}")
+                                navigateToAlbumDetails(selectAlbum.id)
                                 sheetState.hide()
                             }.invokeOnCompletion {
                                 Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
@@ -558,7 +571,7 @@ fun ArtistDetailsScreen(
                         song = selectSong,
                         play = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> PlaySong clicked")
+                                Log.i(TAG, "Song More Options Modal -> PlaySong clicked :: ${selectSong.id}")
                                 onArtistAction(ArtistAction.PlaySong(selectSong))
                                 navigateToPlayer()
                                 sheetState.hide()
@@ -572,7 +585,7 @@ fun ArtistDetailsScreen(
                         },
                         playNext = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked")
+                                Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked :: ${selectSong.id}")
                                 onArtistAction(ArtistAction.PlaySongNext(selectSong))
                                 navigateToPlayer()
                                 sheetState.hide()
@@ -587,7 +600,7 @@ fun ArtistDetailsScreen(
                         //addToPlaylist = {},
                         addToQueue = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> QueueSong clicked")
+                                Log.i(TAG, "Song More Options Modal -> QueueSong clicked :: ${selectSong.id}")
                                 onArtistAction(ArtistAction.QueueSong(selectSong))
                                 sheetState.hide()
                             }.invokeOnCompletion {
@@ -600,7 +613,7 @@ fun ArtistDetailsScreen(
                         },
                         goToAlbum = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> GoToAlbum clicked")
+                                Log.i(TAG, "Song More Options Modal -> GoToAlbum clicked :: ${selectSong.albumId}")
                                 navigateToAlbumDetails(selectSong.albumId)
                                 sheetState.hide()
                             }.invokeOnCompletion {

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
@@ -595,7 +595,7 @@ fun ArtistDetailsScreen(
                             showBottomSheet = false
                             showSongMoreOptions = false
                         },
-                        coroutineScope = coroutineScope,
+                        //coroutineScope = coroutineScope,
                         song = selectSong,
                         context = "ArtistDetails",
                         //onQueueSong = { action ->

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
@@ -224,10 +224,10 @@ fun ArtistDetailsScreen(
     }
 
     val sheetState = rememberModalBottomSheetState(false,)
-    var showBottomSheet by remember { mutableStateOf(false) } // if bottom modal needs to be opened
-    var showSortSheet by remember { mutableStateOf(false) } // if bottom modal content is for sorting songs
-    var showAlbumMoreOptions by remember { mutableStateOf(false) } // if bottom modal content is for album details more options
-    var showArtistMoreOptions by remember { mutableStateOf(false) } // if bottom modal content is for album details more options
+    var showBottomSheet by remember { mutableStateOf(false) }
+    var showSortSheet by remember { mutableStateOf(false) }
+    var showAlbumMoreOptions by remember { mutableStateOf(false) }
+    var showArtistMoreOptions by remember { mutableStateOf(false) }
     var showSongMoreOptions by remember { mutableStateOf( false ) }
 
     ScreenBackground(
@@ -272,11 +272,11 @@ fun ArtistDetailsScreen(
                                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
                             )
                         }
-                        // more options btn // temporary placement till figure out if this should be part of header
+
                         IconButton(
                             onClick = {
                                 showBottomSheet = true
-                                showArtistMoreOptions = true /* onMoreOptionsClick */
+                                showArtistMoreOptions = true
                             }
                         ) {
                             Icon(
@@ -310,9 +310,7 @@ fun ArtistDetailsScreen(
                     navigateToPlayer = { navigateToPlayer(PreviewSongs[5]) },
                 )*/
             },
-            snackbarHost = {
-                SnackbarHost(hostState = snackbarHostState)
-            },
+            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
             modifier = modifier.nestedScroll(appBarScrollBehavior.nestedScrollConnection),
             containerColor = Color.Transparent,
             contentColor = contentColorFor(MaterialTheme.colorScheme.background) // MaterialTheme.colorScheme.inverseSurface //or onPrimaryContainer
@@ -362,7 +360,7 @@ fun ArtistDetailsScreen(
                         )
                     }
                     fullWidthItem {
-                        Column(modifier = modifier) {
+                        /*Column(modifier = modifier) {
                             BoxWithConstraints(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -397,19 +395,18 @@ fun ArtistDetailsScreen(
                                     )
                                 }
                             }
-                        }
-                        /*FeaturedAlbumsCarousel(
+                        }*/
+                        FeaturedAlbumsCarousel(
                             pagerState = pagerState,
                             items = albums,
                             navigateToAlbumDetails = navigateToAlbumDetails,
-                            onMoreOptionsClick = {
-                                onArtistAction( ArtistAction.AlbumMoreOptionClicked(it) )
-                                ArtistAction.AlbumMoreOptionClicked(it)
+                            onMoreOptionsClick = { album: AlbumInfo ->
+                                onArtistAction( ArtistAction.AlbumMoreOptionClicked(album) )
                                 showBottomSheet = true
                                 showAlbumMoreOptions = true
                             },
                             modifier = Modifier.fillMaxWidth()
-                        )*/
+                        )
                     }
                 }
 
@@ -446,8 +443,10 @@ fun ArtistDetailsScreen(
                     }
 
                     // songs list
-                    items(songs) { song -> // for each song in list:
-                        Box(Modifier.padding(horizontal = 12.dp, vertical = 0.dp)) {
+                    items(songs) { song ->
+                        Box(
+                            Modifier.padding(horizontal = 12.dp, vertical = 0.dp)
+                        ) {
                             SongListItem(
                                 song = song,
                                 onClick = {
@@ -457,7 +456,7 @@ fun ArtistDetailsScreen(
                                 },
                                 onMoreOptionsClick = {
                                     Log.i(TAG, "Song More Option clicked: ${song.title}")
-                                    onArtistAction( ArtistAction.SongMoreOptionClicked( song ) )
+                                    onArtistAction(ArtistAction.SongMoreOptionClicked(song))
                                     showBottomSheet = true
                                     showSongMoreOptions = true
                                 },
@@ -470,84 +469,6 @@ fun ArtistDetailsScreen(
                             )
                         }
                     }
-                    /*items(songs) { song ->
-                        Box(modifier = modifier.padding(/*horizontal = 12.dp, */vertical = 0.dp)) {
-                            Surface(
-                                shape = MaterialTheme.shapes.large,
-                                color = Color.Transparent,
-                                //color = MaterialTheme.colorScheme.surfaceContainer,
-                                onClick = { navigateToPlayer(song) },
-                            ) {
-                                Row(
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    modifier = Modifier
-                                        .padding(/*horizontal = 12.dp, */vertical = 8.dp)
-                                        .padding(start = 12.dp),
-                                ) {
-                                    AlbumImage(
-                                        albumImage = 1,
-                                        contentDescription = song.title,
-                                        modifier = Modifier
-                                            .size(56.dp)
-                                            .clip(MaterialTheme.shapes.small)
-                                    )
-
-                                    Column(modifier.weight(1f)) {
-                                        Text(
-                                            text = song.title,
-                                            maxLines = 1,
-                                            minLines = 1,
-                                            overflow = TextOverflow.Ellipsis,
-                                            style = MaterialTheme.typography.titleMedium,
-                                            modifier = Modifier.padding(vertical = 2.dp, horizontal = 10.dp)
-                                        )
-                                        Row(
-                                            modifier = modifier.padding(horizontal = 10.dp)
-                                        ) {
-                                            Text(
-                                                text = song.artistName,
-                                                maxLines = 1,
-                                                minLines = 1,
-                                                overflow = TextOverflow.Ellipsis,
-                                                style = MaterialTheme.typography.bodySmall,
-                                                modifier = Modifier.padding(vertical = 2.dp),
-                                            )
-                                            Text(
-                                                text = " • " + song.albumTitle,
-                                                maxLines = 1,
-                                                minLines = 1,
-                                                overflow = TextOverflow.Ellipsis,
-                                                style = MaterialTheme.typography.bodySmall,
-                                                modifier = Modifier.padding(vertical = 2.dp),
-                                            )
-                                            Text(
-                                                text = " • " + song.duration.formatStr(),
-                                                maxLines = 1,
-                                                minLines = 1,
-                                                style = MaterialTheme.typography.bodySmall,
-                                                modifier = Modifier.padding(vertical = 2.dp)//, horizontal = 8.dp),
-                                            )
-                                        }
-                                    }
-
-                                    IconButton( //more options button
-                                        //modifier = Modifier.padding(0.dp),
-                                        onClick = {
-                                            onArtistAction( ArtistAction.SongMoreOptionClicked( song ) )
-                                            showBottomSheet = true
-                                            showSongMoreOptions = true
-                                        }, // pretty sure I need this to be context dependent, might pass something within savedStateHandler? within viewModel??
-                                    ) {
-                                        Icon( //more options icon
-                                            imageVector = Icons.Default.MoreVert,
-                                            contentDescription = stringResource(R.string.icon_more),
-                                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }*/
                 }
             }
 
@@ -593,10 +514,10 @@ fun ArtistDetailsScreen(
                         album = selectAlbum,
                         play = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> PlaySongs clicked")
-                                onArtistAction(ArtistAction.PlaySongs(songs))
-                                navigateToPlayer()
+                                Log.i(TAG, "Album More Options Modal -> Play Album clicked")
+                                onArtistAction(ArtistAction.PlayAlbum(selectAlbum))
                                 sheetState.hide()
+                                navigateToPlayer()
                             }.invokeOnCompletion {
                                 Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
                                 if(!sheetState.isVisible) {
@@ -607,8 +528,8 @@ fun ArtistDetailsScreen(
                         },
                         playNext = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked")
-                                onArtistAction(ArtistAction.QueueSongs(songs))
+                                Log.i(TAG, "Album More Options Modal -> Play Album Next clicked")
+                                onArtistAction(ArtistAction.PlayAlbumNext(selectAlbum))
                                 sheetState.hide()
                             }.invokeOnCompletion {
                                 Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
@@ -618,15 +539,28 @@ fun ArtistDetailsScreen(
                                 }
                             }
                         },
-                        shuffle = {},
+                        shuffle = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Album More Options Modal -> Shuffle Album clicked")
+                                onArtistAction(ArtistAction.ShuffleAlbum(selectAlbum))
+                                sheetState.hide()
+                                navigateToPlayer()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showAlbumMoreOptions = false
+                                }
+                            }
+                        },
                         //addToPlaylist = {},
                         addToQueue = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Song More Options Modal -> QueueSongs clicked")
-                                onArtistAction(ArtistAction.QueueSongs(songs))
+                                Log.i(TAG, "Album More Options Modal -> Queue Album clicked")
+                                onArtistAction(ArtistAction.QueueAlbum(selectAlbum))
                                 sheetState.hide()
                             }.invokeOnCompletion {
-                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
                                 if(!sheetState.isVisible) {
                                     showBottomSheet = false
                                     showAlbumMoreOptions = false
@@ -769,7 +703,7 @@ fun ArtistDetailsScreen(
                         },
                         shuffle = {
                             coroutineScope.launch {
-                                Log.i(TAG, "Artist More Options Modal -> ShuffleSong clicked")
+                                Log.i(TAG, "Artist More Options Modal -> ShuffleSongs clicked")
                                 onArtistAction(ArtistAction.ShuffleSongs(songs))
                                 navigateToPlayer()
                                 sheetState.hide()

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
@@ -1,15 +1,12 @@
 package com.example.music.ui.artistdetails
 
 import android.util.Log
-import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -17,23 +14,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsIgnoringVisibility
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.Sort
-import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -62,39 +52,30 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.music.R
-import com.example.music.designsys.component.AlbumImage
 import com.example.music.designsys.theme.Keyline1
-import com.example.music.designsys.theme.MusicShapes
 import com.example.music.domain.testing.PreviewArtists
 import com.example.music.domain.testing.getAlbumsByArtist
 import com.example.music.domain.testing.getSongsByArtist
 import com.example.music.domain.model.AlbumInfo
 import com.example.music.domain.model.ArtistInfo
 import com.example.music.domain.model.SongInfo
-import com.example.music.ui.home.HomeAction
-
-
 import com.example.music.ui.shared.AlbumMoreOptionsBottomModal
 import com.example.music.ui.shared.ArtistMoreOptionsBottomModal
 import com.example.music.ui.shared.DetailsSortSelectionBottomModal
 import com.example.music.ui.shared.FeaturedAlbumsCarousel
-import com.example.music.ui.shared.FeaturedCarouselItem
 import com.example.music.ui.shared.Loading
 import com.example.music.ui.shared.ScreenBackground
 import com.example.music.ui.shared.SongListItem
 import com.example.music.ui.shared.SongMoreOptionsBottomModal
-import com.example.music.ui.shared.formatStr
 import com.example.music.ui.theme.MusicTheme
 import com.example.music.ui.tooling.LandscapePreview
 import com.example.music.ui.tooling.SystemDarkPreview
@@ -102,7 +83,6 @@ import com.example.music.util.fullWidthItem
 import com.example.music.util.quantityStringResource
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /** Changelog:
@@ -339,8 +319,7 @@ fun ArtistDetailsScreen(
                 columns = GridCells.Fixed(1),
                 modifier = modifier.padding(contentPadding)
                     .fillMaxSize()
-                // does not have the initial .padding(horizontal = 12.dp) so that
-                // Albums horizontal pager is not cut into
+                    // does not have .padding(horizontal = 12.dp) to account for the albums carousel
             ) {
                 // section 1: header item
                 // is within TopAppBar now
@@ -348,6 +327,7 @@ fun ArtistDetailsScreen(
                 //section 2: albums list
                 if (albums.isNotEmpty()) {
                     fullWidthItem {
+                        // this item is only for listing count of albums, so not using sorting or selection here
                         Text(
                             text = """\s[a-z]""".toRegex().replace(
                                 quantityStringResource(R.plurals.albums, albums.size, albums.size)
@@ -359,48 +339,14 @@ fun ArtistDetailsScreen(
                             modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
                         )
                     }
+
                     fullWidthItem {
-                        /*Column(modifier = modifier) {
-                            BoxWithConstraints(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .background(Color.Transparent)
-                            ) {
-                                val horizontalPadding = (this.maxWidth - 160.dp) / 2
-                                HorizontalPager(
-                                    state = pagerState,
-                                    contentPadding = PaddingValues(
-                                        horizontal = horizontalPadding,
-                                        vertical = 16.dp,
-                                    ),
-                                    pageSpacing = 24.dp,
-                                    pageSize = PageSize.Fixed(160.dp)
-                                ) { page ->
-                                    val album = albums[page]
-                                    FeaturedCarouselItem(
-                                        itemImage = album.artworkUri,
-                                        itemTitle = album.title,
-                                        itemSize = album.songCount,
-                                        onMoreOptionsClick = {
-                                            onArtistAction( ArtistAction.AlbumMoreOptionClicked(album) )
-                                            //ArtistAction.AlbumMoreOptionClicked(album)
-                                            showBottomSheet = true
-                                            showAlbumMoreOptions = true
-                                        },
-                                        modifier = Modifier
-                                            .fillMaxSize()
-                                            .clickable {
-                                                navigateToAlbumDetails(album.id)
-                                            }
-                                    )
-                                }
-                            }
-                        }*/
                         FeaturedAlbumsCarousel(
                             pagerState = pagerState,
                             items = albums,
                             navigateToAlbumDetails = navigateToAlbumDetails,
                             onMoreOptionsClick = { album: AlbumInfo ->
+                                Log.i(TAG, "Album More Options clicked: ${album.title}")
                                 onArtistAction( ArtistAction.AlbumMoreOptionClicked(album) )
                                 showBottomSheet = true
                                 showAlbumMoreOptions = true
@@ -488,6 +434,18 @@ fun ArtistDetailsScreen(
                         onClose = {
                             coroutineScope.launch {
                                 Log.i(TAG, "Hide sheet state")
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showSortSheet = false
+                                }
+                            }
+                        },
+                        onSave = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Save sheet state - does nothing atm")
                                 sheetState.hide()
                             }.invokeOnCompletion {
                                 Log.i(TAG, "set showBottomSheet to FALSE")
@@ -803,7 +761,6 @@ fun ArtistDetailsContent(
     artist: ArtistInfo,
     albums: PersistentList<AlbumInfo>,
     songs: List<SongInfo>,
-    coroutineScope: CoroutineScope,
     navigateToAlbumDetails: (Long) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
     modifier: Modifier = Modifier
@@ -831,8 +788,7 @@ fun ArtistDetailsContent(
     LazyVerticalGrid(
         columns = GridCells.Fixed(1),
         modifier = modifier.fillMaxSize(),
-        //does not have the initial .padding(horizontal = 12.dp) so that
-        // Albums horizontal pager is not cut into
+        // does not have .padding(horizontal = 12.dp) to account for the albums carousel
     ) {
         //section 1: header item
         fullWidthItem {
@@ -883,8 +839,8 @@ fun ArtistDetailsContent(
 
             fullWidthItem {
                 PlayShuffleButtons(
-                    onPlayClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
-                    onShuffleClick = { /* probably send call to controller, or is it songPlayer? since that's in viewModel */ },
+                    onPlayClick = {},
+                    onShuffleClick = {},
                 )
             }
 

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsScreen.kt
@@ -120,7 +120,7 @@ private const val TAG = "Artist Details Screen"
  */
 @Composable
 fun ArtistDetailsScreen(
-    navigateToAlbumDetails: (AlbumInfo) -> Unit,
+    navigateToAlbumDetails: (Long) -> Unit,
     navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
@@ -205,7 +205,7 @@ fun ArtistDetailsScreen(
     selectAlbum: AlbumInfo,
     onArtistAction: (ArtistAction) -> Unit,
     //onQueueSong: (SongInfo) -> Unit,
-    navigateToAlbumDetails: (AlbumInfo) -> Unit,
+    navigateToAlbumDetails: (Long) -> Unit,
     navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateBack: () -> Unit,
@@ -397,7 +397,7 @@ fun ArtistDetailsScreen(
                                         modifier = Modifier
                                             .fillMaxSize()
                                             .clickable {
-                                                navigateToAlbumDetails(album)
+                                                navigateToAlbumDetails(album.id)
                                             }
                                     )
                                 }
@@ -619,7 +619,7 @@ fun ArtistDetailsScreen(
                         coroutineScope = coroutineScope,
                         artist = artist,
                         context = "ArtistDetails",
-                        navigateToArtistDetails = {},
+                        //navigateToArtistDetails = {},
                         navigateToPlayer = navigateToPlayer,
                     )
                 }
@@ -684,7 +684,7 @@ fun ArtistDetailsContent(
     songs: List<SongInfo>,
     //onQueueSong: (SongInfo) -> Unit,
     coroutineScope: CoroutineScope,
-    navigateToAlbumDetails: (AlbumInfo) -> Unit,
+    navigateToAlbumDetails: (Long) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit,
     modifier: Modifier = Modifier
 ) {

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsViewModel.kt
@@ -4,9 +4,11 @@ import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.music.data.mediaresolver.model.Artist
 import com.example.music.domain.model.AlbumInfo
 import com.example.music.domain.model.ArtistInfo
 import com.example.music.domain.model.SongInfo
+import com.example.music.domain.usecases.GetAlbumDetailsV2
 //import com.example.music.domain.player.SongPlayer
 import com.example.music.domain.usecases.GetArtistDetailsV2
 import com.example.music.service.SongController
@@ -18,11 +20,10 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-private const val TAG = "Artist Details View Model"
 
 /** Changelog:
  * ---- TEST VERSION USING SAVEDSTATEHANDLE TO REPLICATE PLAYER SCREEN NAVIGATION
@@ -35,6 +36,8 @@ private const val TAG = "Artist Details View Model"
  *
  * 7/22-23/2025 - Deleted SongPlayer from domain layer.
  */
+
+private const val TAG = "Artist Details View Model"
 
 data class ArtistUiState (
     val isReady: Boolean = false,
@@ -52,6 +55,7 @@ data class ArtistUiState (
 @HiltViewModel
 class ArtistDetailsViewModel @Inject constructor(
     getArtistDetailsV2: GetArtistDetailsV2,
+    private val getAlbumDetailsV2: GetAlbumDetailsV2,
     private val songController: SongController,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -87,12 +91,12 @@ class ArtistDetailsViewModel @Inject constructor(
                 artistDetailsFilterResult,
                 selectSong,
                 selectAlbum ->
-                Log.i(TAG, "ArtistUiState call")
-                Log.i(TAG, "artistDetailsFilterResult ID: ${artistDetailsFilterResult.artist.id}")
-                Log.i(TAG, "artistDetailsFilterResult albums: ${artistDetailsFilterResult.albums.size}")
-                Log.i(TAG, "artistDetailsFilterResult songs: ${artistDetailsFilterResult.songs.size}")
-                Log.i(TAG, "is SongController available: ${songController.isConnected()}")
-                Log.i(TAG, "isReady?: ${!refreshing}")
+                Log.i(TAG, "ArtistUiState combine START\n" +
+                    "artistDetailsFilterResult ID: ${artistDetailsFilterResult.artist.id}\n" +
+                    "artistDetailsFilterResult albums: ${artistDetailsFilterResult.albums.size}\n" +
+                    "artistDetailsFilterResult songs: ${artistDetailsFilterResult.songs.size}\n" +
+                    "is SongController available: ${songController.isConnected()}\n" +
+                    "isReady?: ${!refreshing}")
 
                 ArtistUiState(
                     isReady = !refreshing,
@@ -136,20 +140,25 @@ class ArtistDetailsViewModel @Inject constructor(
     fun onArtistAction(action: ArtistAction) {
         Log.i(TAG, "onArtistAction - $action")
         when (action) {
-            is ArtistAction.AlbumMoreOptionClicked -> onAlbumMoreOptionClicked(action.album) // opens albumMO
-            is ArtistAction.SongMoreOptionClicked -> onSongMoreOptionClicked(action.song) // opens songMO
+            is ArtistAction.AlbumMoreOptionClicked -> onAlbumMoreOptionClicked(action.album) // selects albumMO
+            is ArtistAction.SongMoreOptionClicked -> onSongMoreOptionClicked(action.song) // selects songMO
 
             is ArtistAction.PlaySong -> onPlaySong(action.song) // songMO-play
-            is ArtistAction.PlaySongNext -> onQueueSongNext(action.song) // songMo-playNext
+            is ArtistAction.PlaySongNext -> onPlaySongNext(action.song) // songMo-playNext
             //is ArtistAction.AddSongToPlaylist -> songMO-addToPlaylist
             is ArtistAction.QueueSong -> onQueueSong(action.song) // songMO-addToQueue
 
-            is ArtistAction.PlaySongs -> onPlaySongs(action.songs) // artistMO-play; albumMO-play
-            is ArtistAction.PlaySongsNext -> onQueueSongsNext(action.songs) // artistMO-playNext; albumMO-playNext
-            is ArtistAction.ShuffleSongs -> onShuffleSongs(action.songs) // artistMo-shuffle; albumMO-shuffle
-            //is ArtistAction.AddAlbumToPlaylist // albumMO-addToPlaylist
+            is ArtistAction.PlaySongs -> onPlaySongs(action.songs) // artistMO-play
+            is ArtistAction.PlaySongsNext -> onPlaySongsNext(action.songs) // artistMO-playNext
+            is ArtistAction.ShuffleSongs -> onShuffleSongs(action.songs) // artistMo-shuffle
             //is ArtistAction.AddArtistToPlaylist // artistMO-addToPlaylist
-            is ArtistAction.QueueSongs -> onQueueSongs(action.songs) // artistMO-addToQueue; albumMo-addToQueue
+            is ArtistAction.QueueSongs -> onQueueSongs(action.songs) // artistMO-addToQueue
+
+            is ArtistAction.PlayAlbum -> onPlayAlbum(action.album) // albumMO-play
+            is ArtistAction.PlayAlbumNext -> onPlayAlbumNext(action.album) // albumMO-playNext
+            is ArtistAction.ShuffleAlbum -> onShuffleAlbum(action.album) // albumMO-shuffle
+            //is ArtistAction.AddAlbumToPlaylist // albumMO-addToPlaylist
+            is ArtistAction.QueueAlbum -> onQueueAlbum(action.album) // albumMo-addToQueue
         }
     }
 
@@ -157,58 +166,88 @@ class ArtistDetailsViewModel @Inject constructor(
         Log.i(TAG, "onAlbumMoreOptionClicked - ${album.title}")
         selectedAlbum.value = album
     }
+    private fun onSongMoreOptionClicked(song: SongInfo) {
+        Log.i(TAG, "onSongMoreOptionClick - ${song.title}")
+        selectedSong.value = song
+    }
 
     private fun onPlaySong(song: SongInfo) {
         Log.i(TAG, "onPlaySong - ${song.title}")
         songController.play(song)
+    }
+    private fun onPlaySongNext(song: SongInfo) {
+        Log.i(TAG, "onPlaySongNext - ${song.title}")
+        songController.addToQueueNext(song)
+    }
+    private fun onQueueSong(song: SongInfo) {
+        Log.i(TAG, "onQueueSong - ${song.title}")
+        songController.addToQueue(song)
     }
 
     private fun onPlaySongs(songs: List<SongInfo>) {
         Log.i(TAG, "onPlaySongs - ${songs.size}")
         songController.play(songs)
     }
-
-    private fun onQueueSong(song: SongInfo) {
-        Log.i(TAG, "onQueueSong - ${song.title}")
-        songController.addToQueue(song)
+    private fun onPlaySongsNext(songs: List<SongInfo>) {
+        Log.i(TAG, "onQueueSongsNext - ${songs.size}")
+        songController.addToQueueNext(songs)
     }
-
-    private fun onQueueSongNext(song: SongInfo) {
-        Log.i(TAG, "onQueueSongNext - ${song.title}")
-        songController.addToQueueNext(song)
+    private fun onShuffleSongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onShuffleSongs - ${songs.size}")
+        songController.shuffle(songs)
     }
-
     private fun onQueueSongs(songs: List<SongInfo>) {
         Log.i(TAG, "onQueueSongs - ${songs.size}")
         songController.addToQueue(songs)
     }
 
-    private fun onQueueSongsNext(songs: List<SongInfo>) {
-        Log.i(TAG, "onQueueSongsNext - ${songs.size}")
-        songController.addToQueueNext(songs)
+    private fun onPlayAlbum(album: AlbumInfo) {
+        Log.i(TAG, "onPlaySongs -> ${album.title}")
+        viewModelScope.launch {
+            val songs = getAlbumDetailsV2(album.id).first().songs
+            songController.play(songs)
+        }
     }
-
-    private fun onShuffleSongs(songs: List<SongInfo>) {
-        Log.i(TAG, "onShuffleSongs - ${songs.size}")
-        songController.shuffle(songs)
+    private fun onPlayAlbumNext(album: AlbumInfo) {
+        Log.i(TAG, "onPlayAlbumNext -> ${album.title}")
+        viewModelScope.launch {
+            val songs = getAlbumDetailsV2(album.id).first().songs
+            songController.addToQueueNext(songs)
+        }
     }
-
-    private fun onSongMoreOptionClicked(song: SongInfo) {
-        Log.i(TAG, "onSongMoreOptionClick - ${song.title}")
-        selectedSong.value = song
+    private fun onShuffleAlbum(album: AlbumInfo) {
+        Log.i(TAG, "onShuffleAlbum -> ${album.title}")
+        viewModelScope.launch {
+            val songs = getAlbumDetailsV2(album.id).first().songs
+            songController.shuffle(songs)
+        }
+    }
+    private fun onQueueAlbum(album: AlbumInfo) {
+        Log.i(TAG, "onQueueAlbum -> ${album.title}")
+        viewModelScope.launch {
+            val songs = getAlbumDetailsV2(album.id).first().songs
+            songController.addToQueue(songs)
+        }
     }
 }
 
 sealed interface ArtistAction {
     data class AlbumMoreOptionClicked(val album: AlbumInfo) : ArtistAction
+    data class SongMoreOptionClicked(val song: SongInfo) : ArtistAction
+
     data class PlaySong(val song: SongInfo) : ArtistAction
     data class PlaySongNext(val song: SongInfo) : ArtistAction
+    data class QueueSong(val song: SongInfo) : ArtistAction
+
     data class PlaySongs(val songs: List<SongInfo>) : ArtistAction
     data class PlaySongsNext(val songs: List<SongInfo>) : ArtistAction
-    data class QueueSong(val song: SongInfo) : ArtistAction
-    data class QueueSongs(val songs: List<SongInfo>) : ArtistAction
     data class ShuffleSongs(val songs: List<SongInfo>) : ArtistAction
-    data class SongMoreOptionClicked(val song: SongInfo) : ArtistAction
+    data class QueueSongs(val songs: List<SongInfo>) : ArtistAction
+
+    data class PlayAlbum(val album: AlbumInfo) : ArtistAction
+    data class PlayAlbumNext(val album: AlbumInfo) : ArtistAction
+    data class ShuffleAlbum(val album: AlbumInfo) : ArtistAction
+    data class QueueAlbum(val album: AlbumInfo) : ArtistAction
 }
 
 /**

--- a/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsScreen.kt
@@ -1,6 +1,7 @@
 package com.example.music.ui.genredetails
 
 import android.util.Log
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -19,6 +20,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Sort
@@ -31,15 +33,20 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -48,6 +55,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -62,6 +70,7 @@ import com.example.music.domain.testing.PreviewGenres
 import com.example.music.domain.testing.getSongsInGenre
 import com.example.music.domain.model.GenreInfo
 import com.example.music.domain.model.SongInfo
+import com.example.music.ui.albumdetails.AlbumDetailsHeader
 import com.example.music.ui.artistdetails.ArtistAction
 import com.example.music.ui.shared.AlbumMoreOptionsBottomModal
 import com.example.music.ui.shared.ArtistMoreOptionsBottomModal
@@ -169,7 +178,7 @@ private fun GenreDetailsLoadingScreen(
 /**
  * Stateless Composable for Genre Details Screen
  */
-@OptIn(ExperimentalLayoutApi::class)
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun GenreDetailsScreen(
     genre: GenreInfo,
@@ -187,16 +196,96 @@ fun GenreDetailsScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val snackBarText = stringResource(id = R.string.sbt_song_added_to_your_queue)
 
+    val appBarScrollBehavior = TopAppBarDefaults
+        .exitUntilCollapsedScrollBehavior(
+            rememberTopAppBarState()
+        )
+    val isCollapsed = remember {
+        derivedStateOf {
+            appBarScrollBehavior.state.collapsedFraction > 0.8
+        }
+    }
+
+    val listState = rememberLazyGridState()
+    val displayButton = remember { derivedStateOf { listState.firstVisibleItemIndex > 0 } }
+
+    val sheetState = rememberModalBottomSheetState(false)
+    var showBottomSheet by remember { mutableStateOf(false) }
+    var showSortSheet by remember { mutableStateOf(false) }
+    var showGenreMoreOptions by remember { mutableStateOf(false) }
+    var showSongMoreOptions by remember { mutableStateOf(false) }
+
     ScreenBackground(
         modifier = modifier.windowInsetsPadding(WindowInsets.navigationBars)
     ) {
         Scaffold(
             contentWindowInsets = WindowInsets.systemBarsIgnoringVisibility,
             topBar = {
-                GenreDetailsTopAppBar(
+                LargeTopAppBar(
+                    title = {
+                        // if true, bar is collapsed so use album title as title
+                        if ( isCollapsed.value ) {
+                            Text(
+                                text = genre.name,
+                                maxLines = 3,
+                                overflow = TextOverflow.Ellipsis,
+                                style = MaterialTheme.typography.headlineMedium,
+                                modifier = Modifier.basicMarquee()
+                            )
+                        } else {
+                            // if false, bar is expanded so use full header
+                            GenreDetailsHeaderItem(genre, modifier)
+                        }
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = navigateBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(id = R.string.icon_back_nav),
+                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                        }
+                    },
+                    actions = {
+                        // Search btn
+                        IconButton(onClick = navigateToSearch) {
+                            Icon(
+                                imageVector = Icons.Outlined.Search,
+                                contentDescription = stringResource(R.string.icon_search),
+                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                        }
+
+                        // Genre More Options btn
+                        IconButton(
+                            onClick = {
+                                showBottomSheet = true
+                                showGenreMoreOptions = true
+                            }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.MoreVert,
+                                contentDescription = stringResource(R.string.icon_more),
+                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                        }
+                    },
+                    collapsedHeight = 48.dp,//TopAppBarDefaults.LargeAppBarCollapsedHeight, // is 64.dp
+                    expandedHeight = 120.dp,//80.dp,//TopAppBarDefaults.LargeAppBarExpandedHeight,//200.dp, // for Header
+                    windowInsets = TopAppBarDefaults.windowInsets,
+                    colors = TopAppBarColors(
+                        containerColor = Color.Transparent,
+                        scrolledContainerColor = Color.Transparent,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        actionIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                    scrollBehavior = appBarScrollBehavior,
+                )
+                /*GenreDetailsTopAppBar(
                     navigateToSearch = navigateToSearch,
                     navigateBack = navigateBack,
-                )
+                )*/
             },
             bottomBar = {
                 /* //should show BottomBarPlayer here if a queue session is running or service is running
@@ -206,12 +295,14 @@ fun GenreDetailsScreen(
                 )*/
             },
             snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+            modifier = modifier.nestedScroll(appBarScrollBehavior.nestedScrollConnection),
             //modifier = modifier.fillMaxSize().systemBarsPadding(),
             containerColor = Color.Transparent,
             contentColor = contentColorFor(MaterialTheme.colorScheme.background) //selects the appropriate color to be the content color for the container using background color
             //contentColor = MaterialTheme.colorScheme.inverseSurface //or onPrimaryContainer
         ) { contentPadding ->
-            GenreDetailsContent(
+            // original content setter
+            /*GenreDetailsContent(
                 coroutineScope = coroutineScope,
                 genre = genre,
                 songs = songs,
@@ -221,7 +312,284 @@ fun GenreDetailsScreen(
                 navigateToAlbumDetails = navigateToAlbumDetails,
                 navigateToArtistDetails = navigateToArtistDetails,
                 modifier = Modifier.padding(contentPadding)
-            )
+            )*/
+
+            // GenreDetails Content
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(1),
+                modifier = modifier.padding(contentPadding)
+                    .fillMaxSize()
+                    .padding(horizontal = 12.dp)
+            ) {
+                fullWidthItem {
+                    SongCountAndSortSelectButtons(
+                        songs = songs,
+                        onSelectClick = {
+                            Log.i(TAG, "Multi Select btn clicked")
+                        },
+                        onSortClick = {
+                            Log.i(TAG, "Song Sort btn clicked")
+                            showBottomSheet = true
+                            showSortSheet = true
+                        }
+                    )
+                }
+
+                fullWidthItem {
+                    PlayShuffleButtons(
+                        onPlayClick = {
+                            Log.i(TAG, "Play Songs btn clicked")
+                            onGenreAction(GenreAction.PlaySongs(songs))
+                            navigateToPlayer()
+                        },
+                        onShuffleClick = {
+                            Log.i(TAG, "Shuffle Songs btn clicked")
+                            onGenreAction(GenreAction.ShuffleSongs(songs))
+                            navigateToPlayer()
+                        },
+                    )
+                }
+
+                // songs list
+                items(songs) { song ->
+                    SongListItem(
+                        song = song,
+                        onClick = {
+                            Log.i(TAG, "Song clicked ${song.title}")
+                            onGenreAction(GenreAction.PlaySong(song))
+                            navigateToPlayer()
+                        },
+                        onMoreOptionsClick = {
+                            Log.i(TAG, "Song More Option clicked ${song.title}")
+                            onGenreAction(GenreAction.SongMoreOptionClicked(song))
+                            showBottomSheet = true
+                            showSongMoreOptions = true
+                        },
+                        isListEditable = false,
+                        showArtistName = true,
+                        showAlbumImage = true,
+                        showAlbumTitle = true,
+                        showTrackNumber = false,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            // GenreDetails BottomSheet
+            if (showBottomSheet) {
+                Log.i(TAG, "GenreDetails Content -> showBottomSheet is TRUE")
+                // bottom sheet context - sort btn
+                if (showSortSheet) {
+                    Log.i(TAG, "GenreDetails Content -> Song Sort Modal is TRUE")
+                    DetailsSortSelectionBottomModal(
+                        onDismissRequest = {
+                            showBottomSheet = false
+                            showSortSheet = false
+                        },
+                        sheetState = sheetState,
+                        // need to show selection
+                        onClose = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Hide sheet state")
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showSortSheet = false
+                                }
+                            }
+                        },
+                        onApply = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Save sheet state - does nothing atm")
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showSortSheet = false
+                                }
+                            }
+                        },
+                        content = "SongInfo",
+                        context = "GenreDetails",
+                    )
+                }
+
+                // bottom sheet context - genre more option btn
+                else if (showGenreMoreOptions) {
+                    Log.i(TAG, "GenreDetails Content -> Genre More Options is TRUE")
+                    GenreMoreOptionsBottomModal(
+                        onDismissRequest = {
+                            showBottomSheet = false
+                            showGenreMoreOptions = false
+                        },
+                        sheetState = sheetState,
+                        genre = genre,
+                        play = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Genre More Options Modal -> Play Songs clicked")
+                                onGenreAction(GenreAction.PlaySongs(songs))
+                                sheetState.hide()
+                                navigateToPlayer()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showGenreMoreOptions = false
+                                }
+                            }
+                        },
+                        playNext = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Album More Options Modal -> Play Songs Next clicked")
+                                onGenreAction(GenreAction.PlaySongsNext(songs))
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showGenreMoreOptions = false
+                                }
+                            }
+                        },
+                        shuffle = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Genre More Options Modal -> Shuffle Songs clicked")
+                                onGenreAction(GenreAction.ShuffleSongs(songs))
+                                sheetState.hide()
+                                navigateToPlayer()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showGenreMoreOptions = false
+                                }
+                            }
+                        },
+                        //addToPlaylist = {},
+                        addToQueue = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Genre More Options Modal -> Queue Songs clicked")
+                                onGenreAction(GenreAction.QueueSongs(songs))
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showGenreMoreOptions = false
+                                }
+                            }
+                        },
+                        onClose = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Hide sheet state")
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showGenreMoreOptions = false
+                                }
+                            }
+                        },
+                        context = "GenreDetails",
+                    )
+                }
+
+                // bottom sheet context - song more option btn
+                else if (showSongMoreOptions) {
+                    Log.i(TAG, "GenreDetails Content -> Song More Options is TRUE")
+                    SongMoreOptionsBottomModal(
+                        onDismissRequest = {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        },
+                        sheetState = sheetState,
+                        song = selectSong,
+                        play = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Song More Options Modal -> PlaySong clicked")
+                                onGenreAction(GenreAction.PlaySong(selectSong))
+                                navigateToPlayer()
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showSongMoreOptions = false
+                                }
+                            }
+                        },
+                        playNext = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked")
+                                onGenreAction(GenreAction.PlaySongNext(selectSong))
+                                navigateToPlayer()
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showSongMoreOptions = false
+                                }
+                            }
+                        },
+                        //addToPlaylist = {},
+                        addToQueue = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Song More Options Modal -> QueueSong clicked")
+                                onGenreAction(GenreAction.QueueSong(selectSong))
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showSongMoreOptions = false
+                                }
+                            }
+                        },
+                        goToArtist = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Song More Options Modal -> GoToArtist clicked")
+                                navigateToArtistDetails(selectSong.artistId)
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                showBottomSheet = false
+                                showSongMoreOptions = false
+                            }
+                        },
+                        goToAlbum = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Song More Options Modal -> GoToAlbum clicked")
+                                navigateToAlbumDetails(selectSong.albumId)
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showSongMoreOptions = false
+                                }
+                            }
+                        },
+                        onClose = {
+                            coroutineScope.launch {
+                                Log.i(TAG, "Hide sheet state")
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                Log.i(TAG, "set showBottomSheet to FALSE")
+                                if(!sheetState.isVisible) {
+                                    showBottomSheet = false
+                                    showSongMoreOptions = false
+                                }
+                            }
+                        },
+                        context = "GenreDetails",
+                    )
+                }
+            }
         }
     }
 }
@@ -276,7 +644,7 @@ fun GenreDetailsTopAppBar(
 /**
  * Composable for Genre Details Screen's Content.
  */
-@OptIn(ExperimentalMaterial3Api::class)
+/*@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GenreDetailsContent(
     coroutineScope: CoroutineScope,
@@ -398,7 +766,7 @@ fun GenreDetailsContent(
                         }
                     }
                 },
-                onSave = {
+                onApply = {
                     coroutineScope.launch {
                         Log.i(TAG, "Save sheet state - does nothing atm")
                         sheetState.hide()
@@ -588,15 +956,13 @@ fun GenreDetailsContent(
             )
         }
     }
-}
+}*/
 
 @Composable
 fun GenreDetailsHeaderItem(
     genre: GenreInfo,
     modifier: Modifier = Modifier
 ) {
-    //FUTURE THOUGHT: choose if want 1 image or multi image view for genre header
-    // and for the 1 image, should it be the 1st album, or an image for externally of the genre?
     BoxWithConstraints(
         modifier = modifier.padding(Keyline1)
     ) {
@@ -607,14 +973,6 @@ fun GenreDetailsHeaderItem(
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            /*AlbumImage(
-                modifier = Modifier
-                    .size(widthConstraint, 200.dp)
-                    .fillMaxSize()
-                    .clip(MaterialTheme.shapes.large),
-                albumImage = R.drawable.bpicon,//album.artwork!!,//album.imageUrl or album.artwork when that is fixed
-                contentDescription = "genre Image"
-            )*/
             Text(
                 text = genre.name,
                 maxLines = 2,
@@ -639,7 +997,7 @@ private fun SongCountAndSortSelectButtons(
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp)
+        modifier = Modifier.fillMaxWidth()
     ) {
         Text(
             text = """\s[a-z]""".toRegex()
@@ -650,15 +1008,14 @@ private fun SongCountAndSortSelectButtons(
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(8.dp).weight(1f, true)
         )
-        //Spacer(Modifier.weight(1f,true))
 
         // sort icon
         IconButton(
             onClick = onSortClick,
             modifier = Modifier.semantics(mergeDescendants = true) { }
-        ) { // showBottomSheet = true
+        ) {
             Icon(
-                imageVector = Icons.AutoMirrored.Filled.Sort,//want this to be sort icon
+                imageVector = Icons.AutoMirrored.Filled.Sort,
                 contentDescription = stringResource(R.string.icon_sort),
                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
             )
@@ -670,7 +1027,7 @@ private fun SongCountAndSortSelectButtons(
             modifier = Modifier.semantics(mergeDescendants = true) { }
         ) {
             Icon(
-                imageVector = Icons.Filled.Checklist,//want this to be multi select icon
+                imageVector = Icons.Filled.Checklist,
                 contentDescription = stringResource(R.string.icon_multi_select),
                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
             )
@@ -687,20 +1044,12 @@ private fun PlayShuffleButtons(
     onShuffleClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(modifier.padding(horizontal = 12.dp).padding(bottom = 8.dp)) {
-        //Row(Modifier.padding(bottom = 8.dp)) { // original version for screens that don't have carousel / don't need to remove horizontal padding on lazyVerticalGrid
+    Row(
+        modifier.padding(bottom = 8.dp)
+    ) {
         // play btn
         Button(
-            onClick = onPlayClick, //what is the thing that would jump start this step process. would it go thru the viewModel??
-            //step 1: regardless of shuffle being on or off, set shuffle to off
-            //step 2: prepare the mediaPlayer with the new queue of items in order from playlist
-            //step 3: set the player to play the first item in queue
-            //step 4: navigateToPlayer(first item)
-            //step 5: start playing
-            /*coroutineScope.launch {
-                sheetState.hide()
-                showThemeSheet = false
-            }*/
+            onClick = onPlayClick,
             //did have colors set, colors = buttonColors( container -> primary, content -> background ) // coroutineScope.launch { sheetState.hide() showThemeSheet = false },
             shape = MusicShapes.small,
             modifier = Modifier
@@ -716,18 +1065,7 @@ private fun PlayShuffleButtons(
 
         // shuffle btn
         Button(
-            onClick = onShuffleClick, //what is the thing that would jump start this step process
-            //step 1: regardless of shuffle being on or off, set shuffle to on
-            //step 2?: confirm the shuffle type
-            //step 3: prepare the mediaPlayer with the new queue of items shuffled from playlist
-            //step 4: set the player to play the first item in queue
-            //step 5: navigateToPlayer(first item)
-            //step 6: start playing
-            //needs to take the songs in the playlist, shuffle the
-            /*coroutineScope.launch {
-                sheetState.hide()
-                showThemeSheet = false
-            }*/
+            onClick = onShuffleClick,
             //did have colors set, colors = buttonColors( container -> primary, content -> background )
             shape = MusicShapes.small,
             modifier = Modifier

--- a/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsScreen.kt
+++ b/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -37,10 +38,13 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -58,15 +62,23 @@ import com.example.music.domain.testing.PreviewGenres
 import com.example.music.domain.testing.getSongsInGenre
 import com.example.music.domain.model.GenreInfo
 import com.example.music.domain.model.SongInfo
+import com.example.music.ui.artistdetails.ArtistAction
+import com.example.music.ui.shared.AlbumMoreOptionsBottomModal
+import com.example.music.ui.shared.ArtistMoreOptionsBottomModal
+import com.example.music.ui.shared.DetailsSortSelectionBottomModal
+import com.example.music.ui.shared.GenreMoreOptionsBottomModal
 
 
 import com.example.music.ui.shared.Loading
 import com.example.music.ui.shared.ScreenBackground
 import com.example.music.ui.shared.SongListItem
+import com.example.music.ui.shared.SongMoreOptionsBottomModal
 import com.example.music.ui.theme.MusicTheme
 import com.example.music.ui.tooling.SystemLightPreview
 import com.example.music.util.fullWidthItem
 import com.example.music.util.quantityStringResource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /** Changelog:
  *
@@ -86,11 +98,11 @@ private const val TAG = "Genre Details Screen"
  */
 @Composable
 fun GenreDetailsScreen(
-    //navigateToAlbumDetails: (AlbumInfo) -> Unit,
+    navigateBack: () -> Unit,
     navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
-    navigateBack: () -> Unit,
-    //modifier: Modifier = Modifier,
+    navigateToAlbumDetails: (Long) -> Unit,
+    navigateToArtistDetails: (Long) -> Unit,
     viewModel: GenreDetailsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -103,10 +115,13 @@ fun GenreDetailsScreen(
             GenreDetailsScreen(
                 genre = uiState.genre,
                 songs = uiState.songs,
+                selectSong = uiState.selectSong,
                 onGenreAction = viewModel::onGenreAction,
+                navigateBack = navigateBack,
                 navigateToPlayer = navigateToPlayer,
                 navigateToSearch = navigateToSearch,
-                navigateBack = navigateBack,
+                navigateToAlbumDetails = navigateToAlbumDetails,
+                navigateToArtistDetails = navigateToArtistDetails,
                 modifier = Modifier.fillMaxSize(),
             )
         } else {
@@ -159,11 +174,13 @@ private fun GenreDetailsLoadingScreen(
 fun GenreDetailsScreen(
     genre: GenreInfo,
     songs: List<SongInfo>,
+    selectSong: SongInfo,
     onGenreAction: (GenreAction) -> Unit,
+    navigateBack: () -> Unit,
     navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
-    navigateBack: () -> Unit,
-    //showBackButton: Boolean,
+    navigateToAlbumDetails: (Long) -> Unit,
+    navigateToArtistDetails: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -188,19 +205,21 @@ fun GenreDetailsScreen(
                     navigateToPlayer = { navigateToPlayer(PreviewSongs[5]) },
                 )*/
             },
-            snackbarHost = {
-                SnackbarHost(hostState = snackbarHostState)
-            },
+            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
             //modifier = modifier.fillMaxSize().systemBarsPadding(),
             containerColor = Color.Transparent,
             contentColor = contentColorFor(MaterialTheme.colorScheme.background) //selects the appropriate color to be the content color for the container using background color
             //contentColor = MaterialTheme.colorScheme.inverseSurface //or onPrimaryContainer
         ) { contentPadding ->
             GenreDetailsContent(
+                coroutineScope = coroutineScope,
                 genre = genre,
                 songs = songs,
+                selectSong = selectSong,
                 onGenreAction = onGenreAction,
                 navigateToPlayer = navigateToPlayer,
+                navigateToAlbumDetails = navigateToAlbumDetails,
+                navigateToArtistDetails = navigateToArtistDetails,
                 modifier = Modifier.padding(contentPadding)
             )
         }
@@ -257,14 +276,25 @@ fun GenreDetailsTopAppBar(
 /**
  * Composable for Genre Details Screen's Content.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GenreDetailsContent(
+    coroutineScope: CoroutineScope,
     genre: GenreInfo,
     songs: List<SongInfo>,
+    selectSong: SongInfo,
     onGenreAction: (GenreAction) -> Unit,
     navigateToPlayer: () -> Unit,
+    navigateToAlbumDetails: (Long) -> Unit,
+    navigateToArtistDetails: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    Log.i(TAG, "GenreContent START")
+    val sheetState = rememberModalBottomSheetState(false)
+    var showBottomSheet by remember { mutableStateOf(false) }
+    var showSortSheet by remember { mutableStateOf(false) }
+    var showGenreMoreOptions by remember { mutableStateOf(false) }
+    var showSongMoreOptions by remember { mutableStateOf(false) }
 
     LazyVerticalGrid(
         columns = GridCells.Fixed(1),
@@ -282,33 +312,8 @@ fun GenreDetailsContent(
             )
         }
 
-        // section 2: albums list
-        /*if (!albums.isEmpty()) {
-            fullWidthItem {
-                Text(
-                    text = """\s[a-z]""".toRegex().replace(
-                        quantityStringResource(R.plurals.albums, albums.size, albums.size)
-                    ) {
-                        it.value.uppercase()
-                    },
-                    textAlign = TextAlign.Left,
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                )
-            }
-            fullWidthItem {
-                FeaturedAlbumsCarousel(
-                    pagerState = pagerState,
-                    items = albums,
-                    navigateToAlbumDetails = navigateToAlbumDetails,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        }*/
-
-        // section 3: songs list
-        if (songs.isNotEmpty()) { // this is just to make sure the songs list loaded
-
+        // section 2: songs list
+        if (songs.isNotEmpty()) {
             // songs header
             fullWidthItem {
                 SongCountAndSortSelectButtons(
@@ -318,8 +323,8 @@ fun GenreDetailsContent(
                     },
                     onSortClick = {
                         Log.i(TAG, "Song Sort btn clicked")
-                        //showBottomSheet = true
-                        //showSortSheet = true
+                        showBottomSheet = true
+                        showSortSheet = true
                     }
                 )
             }
@@ -352,8 +357,8 @@ fun GenreDetailsContent(
                         onMoreOptionsClick = {
                             Log.i(TAG, "Song More Option clicked ${song.title}")
                             onGenreAction(GenreAction.SongMoreOptionClicked(song))
-                            //showBottomSheet = true
-                            //showSongMoreOptions = true
+                            showBottomSheet = true
+                            showSongMoreOptions = true
                         },
                         //onQueueSong = { },
                         isListEditable = false,
@@ -365,6 +370,222 @@ fun GenreDetailsContent(
                     )
                 }
             }
+        }
+    }
+
+    // GenreDetails BottomSheet
+    if (showBottomSheet) {
+        Log.i(TAG, "GenreDetails Content -> showBottomSheet is TRUE")
+        // bottom sheet context - sort btn
+        if (showSortSheet) {
+            Log.i(TAG, "GenreDetails Content -> Song Sort Modal is TRUE")
+            DetailsSortSelectionBottomModal(
+                onDismissRequest = {
+                    showBottomSheet = false
+                    showSortSheet = false
+                },
+                sheetState = sheetState,
+                // need to show selection
+                onClose = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Hide sheet state")
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSortSheet = false
+                        }
+                    }
+                },
+                onSave = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Save sheet state - does nothing atm")
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSortSheet = false
+                        }
+                    }
+                },
+                content = "SongInfo",
+                context = "GenreDetails",
+            )
+        }
+
+        // bottom sheet context - genre more option btn
+        else if (showGenreMoreOptions) {
+            Log.i(TAG, "GenreDetails Content -> Genre More Options is TRUE")
+            GenreMoreOptionsBottomModal(
+                onDismissRequest = {
+                    showBottomSheet = false
+                    showGenreMoreOptions = false
+                },
+                sheetState = sheetState,
+                genre = genre,
+                play = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Genre More Options Modal -> Play Songs clicked")
+                        onGenreAction(GenreAction.PlaySongs(songs))
+                        sheetState.hide()
+                        navigateToPlayer()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showGenreMoreOptions = false
+                        }
+                    }
+                },
+                playNext = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Album More Options Modal -> Play Songs Next clicked")
+                        onGenreAction(GenreAction.PlaySongsNext(songs))
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showGenreMoreOptions = false
+                        }
+                    }
+                },
+                shuffle = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Genre More Options Modal -> Shuffle Songs clicked")
+                        onGenreAction(GenreAction.ShuffleSongs(songs))
+                        sheetState.hide()
+                        navigateToPlayer()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showGenreMoreOptions = false
+                        }
+                    }
+                },
+                //addToPlaylist = {},
+                addToQueue = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Genre More Options Modal -> Queue Songs clicked")
+                        onGenreAction(GenreAction.QueueSongs(songs))
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showGenreMoreOptions = false
+                        }
+                    }
+                },
+                onClose = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Hide sheet state")
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showGenreMoreOptions = false
+                        }
+                    }
+                },
+                context = "GenreDetails",
+            )
+        }
+
+        // bottom sheet context - song more option btn
+        else if (showSongMoreOptions) {
+            Log.i(TAG, "GenreDetails Content -> Song More Options is TRUE")
+            SongMoreOptionsBottomModal(
+                onDismissRequest = {
+                    showBottomSheet = false
+                    showSongMoreOptions = false
+                },
+                sheetState = sheetState,
+                song = selectSong,
+                play = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> PlaySong clicked")
+                        onGenreAction(GenreAction.PlaySong(selectSong))
+                        navigateToPlayer()
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                playNext = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked")
+                        onGenreAction(GenreAction.PlaySongNext(selectSong))
+                        navigateToPlayer()
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                //addToPlaylist = {},
+                addToQueue = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> QueueSong clicked")
+                        onGenreAction(GenreAction.QueueSong(selectSong))
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                goToArtist = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> GoToArtist clicked")
+                        navigateToArtistDetails(selectSong.artistId)
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        showBottomSheet = false
+                        showSongMoreOptions = false
+                    }
+                },
+                goToAlbum = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> GoToAlbum clicked")
+                        navigateToAlbumDetails(selectSong.albumId)
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                onClose = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Hide sheet state")
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                context = "GenreDetails",
+            )
         }
     }
 }
@@ -542,11 +763,13 @@ fun GenreDetailsScreenPreview() {
             //JPop
             genre = PreviewGenres[3],
             songs = getSongsInGenre(3),
-            onGenreAction = {},
+            selectSong = getSongsInGenre(3)[0],
 
-            //navigateToAlbumDetails = {},
+            onGenreAction = {},
             navigateToPlayer = {},
             navigateToSearch = {},
+            navigateToAlbumDetails = {},
+            navigateToArtistDetails = {},
             navigateBack = {},
         )
     }

--- a/app/src/main/java/com/example/music/ui/home/Home.kt
+++ b/app/src/main/java/com/example/music/ui/home/Home.kt
@@ -560,7 +560,7 @@ private fun HomeContent(
                 album = selectAlbum,
                 play = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> PlaySongs clicked")
+                        Log.i(TAG, "Album More Options Modal -> PlaySongs clicked :: ${selectAlbum.id}")
                         onHomeAction(HomeAction.PlaySongs(selectAlbum))
                         sheetState.hide()
                         navigateToPlayer()
@@ -574,7 +574,7 @@ private fun HomeContent(
                 },
                 playNext = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> PlaySongsNext clicked")
+                        Log.i(TAG, "Album More Options Modal -> PlaySongsNext clicked :: ${selectAlbum.id}")
                         onHomeAction(HomeAction.PlaySongsNext(selectAlbum))
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -587,7 +587,7 @@ private fun HomeContent(
                 },
                 shuffle = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> ShuffleSongs clicked")
+                        Log.i(TAG, "Album More Options Modal -> ShuffleSongs clicked :: ${selectAlbum.id}")
                         onHomeAction(HomeAction.ShuffleSongs(selectAlbum))
                         sheetState.hide()
                         navigateToPlayer()
@@ -602,7 +602,7 @@ private fun HomeContent(
                 //addToPlaylist = {},
                 addToQueue = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> QueueSongs clicked")
+                        Log.i(TAG, "Album More Options Modal -> QueueSongs clicked :: ${selectAlbum.id}")
                         onHomeAction(HomeAction.QueueSongs(selectAlbum))
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -615,7 +615,7 @@ private fun HomeContent(
                 },
                 goToArtist = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> GoToArtist clicked")
+                        Log.i(TAG, "Album More Options Modal -> GoToArtist clicked :: ${selectAlbum.albumArtistId ?: "null id"}")
                         sheetState.hide()
                         navigateToArtistDetails(selectAlbum.albumArtistId ?: 0) // this isn't a good catch for when an album doesn't have an album artist
                     }.invokeOnCompletion {
@@ -628,7 +628,7 @@ private fun HomeContent(
                 },
                 goToAlbum = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> GoToAlbum clicked")
+                        Log.i(TAG, "Album More Options Modal -> GoToAlbum clicked :: ${selectAlbum.id}")
                         sheetState.hide()
                         navigateToAlbumDetails(selectAlbum.id)
                     }.invokeOnCompletion {
@@ -665,7 +665,7 @@ private fun HomeContent(
                 song = selectSong,
                 play = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> PlaySong clicked")
+                        Log.i(TAG, "Song More Options Modal -> PlaySong clicked :: ${selectSong.id}")
                         onHomeAction(HomeAction.PlaySong(selectSong))
                         navigateToPlayer()
                         sheetState.hide()
@@ -679,7 +679,7 @@ private fun HomeContent(
                 },
                 playNext = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked")
+                        Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked :: ${selectSong.id}")
                         onHomeAction(HomeAction.PlaySongNext(selectSong))
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -693,7 +693,7 @@ private fun HomeContent(
                 //addToPlaylist = {},
                 addToQueue = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> QueueSong clicked")
+                        Log.i(TAG, "Song More Options Modal -> QueueSong clicked :: ${selectSong.id}")
                         onHomeAction(HomeAction.QueueSong(selectSong))
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -706,7 +706,7 @@ private fun HomeContent(
                 },
                 goToArtist = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> GoToArtist clicked")
+                        Log.i(TAG, "Song More Options Modal -> GoToArtist clicked :: ${selectSong.artistId}")
                         navigateToArtistDetails(selectSong.artistId)
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -719,7 +719,7 @@ private fun HomeContent(
                 },
                 goToAlbum = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> GoToAlbum clicked")
+                        Log.i(TAG, "Song More Options Modal -> GoToAlbum clicked :: ${selectSong.albumId}")
                         navigateToAlbumDetails(selectSong.albumId)
                         sheetState.hide()
                     }.invokeOnCompletion {

--- a/app/src/main/java/com/example/music/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/home/HomeViewModel.kt
@@ -4,19 +4,15 @@ import android.util.Log
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.music.data.database.model.Song
 import com.example.music.domain.usecases.FeaturedLibraryItemsV2
 import com.example.music.domain.model.FeaturedLibraryItemsFilterV2
 import com.example.music.domain.model.AlbumInfo
 import com.example.music.domain.model.PlaylistInfo
-//import com.example.music.domain.player.SongPlayer
 import com.example.music.data.util.combine
-import com.example.music.domain.model.AlbumDetailsFilterResult
 import com.example.music.domain.model.SongInfo
 import com.example.music.domain.usecases.GetAlbumDetailsV2
 import com.example.music.domain.usecases.GetTotalCountsV2
 import com.example.music.service.SongController
-import com.example.music.ui.albumdetails.AlbumAction
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -167,12 +163,12 @@ class HomeViewModel @Inject constructor(
             is HomeAction.SongMoreOptionClicked -> onSongMoreOptionClick(action.song)
 
             is HomeAction.PlaySong -> onPlaySong(action.song) // songMO-play
-            is HomeAction.PlaySongNext -> onQueueSongNext(action.song) // songMO-playNext
+            is HomeAction.PlaySongNext -> onPlaySongNext(action.song) // songMO-playNext
             //is HomeAction.AddSongToPlaylist -> onAddToPlaylist(action.song) // songMO-addToPlaylist
             is HomeAction.QueueSong -> onQueueSong(action.song) // songMO-addToQueue
 
             is HomeAction.PlaySongs -> onPlaySongs(action.album) // albumMO-play
-            is HomeAction.PlaySongsNext -> onQueueSongsNext(action.album) // albumMO-playNext
+            is HomeAction.PlaySongsNext -> onPlaySongsNext(action.album) // albumMO-playNext
             is HomeAction.ShuffleSongs -> onShuffleSongs(action.album) // albumMO-shuffle
             //is HomeAction.AddAlbumToPlaylist -> onAddToPlaylist(action.album) // albumMO-addToPlaylist
             is HomeAction.QueueSongs -> onQueueSongs(action.album) // albumMO-addToQueue
@@ -187,12 +183,10 @@ class HomeViewModel @Inject constructor(
         Log.i(TAG, "onAlbumMoreOptionClick -> ${album.title}")
         selectedAlbum.value = album
     }
-
     private fun onSongMoreOptionClick(song: SongInfo) {
         Log.i(TAG, "onSongMoreOptionClick -> ${song.title}")
         selectedSong.value = song
     }
-
     /*private fun onLibraryPlaylistSelected(playlist: PlaylistInfo) {
         selectedLibraryPlaylist.value = playlist
     }*/
@@ -201,21 +195,15 @@ class HomeViewModel @Inject constructor(
         Log.i(TAG, "onPlaySong -> ${song.title}")
         songController.play(song)
     }
+    private fun onPlaySongNext(song: SongInfo) {
+        Log.i(TAG, "onQueueSongNext -> ${song.title}")
+        songController.addToQueueNext(song)
+    }
+    private fun onQueueSong(song: SongInfo) {
+        Log.i(TAG, "onQueueSong -> ${song.title}")
+        songController.addToQueue(song)
+    }
 
-    /*private fun onPlaySongs(songs: List<SongInfo>) {
-        Log.i(TAG, "onPlaySongs -> ${songs.size}")
-        songController.play(songs)
-        /* //what is the thing that would jump start this step process. would it go thru the viewModel??
-        //step 1: regardless of shuffle being on or off, set shuffle to off
-        //step 2: prepare the mediaPlayer with the new queue of items in order from playlist
-        //step 3: set the player to play the first item in queue
-        //step 4: navigateToPlayer(first item)
-        //step 5: start playing
-        coroutineScope.launch {
-            sheetState.hide()
-            showThemeSheet = false
-        }*/
-    }*/
     private fun onPlaySongs(album: AlbumInfo) {
         Log.i(TAG, "onPlaySongs -> ${album.title}")
         viewModelScope.launch {
@@ -223,62 +211,25 @@ class HomeViewModel @Inject constructor(
             songController.play(songs)
         }
     }
-
-    private fun onQueueSong(song: SongInfo) {
-        Log.i(TAG, "onQueueSong -> ${song.title}")
-        songController.addToQueue(song)
-    }
-
-    private fun onQueueSongNext(song: SongInfo) {
-        Log.i(TAG, "onQueueSongNext -> ${song.title}")
-        songController.addToQueueNext(song)
-    }
-
-    /*private fun onQueueSongs(songs: List<SongInfo>) {
-        Log.i(TAG, "onQueueSongs -> ${songs.size}")
-        songController.addToQueue(songs)
-    }*/
-    private fun onQueueSongs(album: AlbumInfo) {
-        Log.i(TAG, "onQueueSongs -> ${album.title}")
-        viewModelScope.launch {
-            val songs = getAlbumDetailsV2(album.id).first().songs
-            songController.addToQueue(songs)
-        }
-    }
-
-    /*private fun onQueueSongsNext(songs: List<SongInfo>) {
-        Log.i(TAG, "onQueueSongsNext - ${songs.size}")
-        songController.addToQueueNext(songs)
-    }*/
-    private fun onQueueSongsNext(album: AlbumInfo) {
+    private fun onPlaySongsNext(album: AlbumInfo) {
         Log.i(TAG, "onQueueSongsNext -> ${album.title}")
         viewModelScope.launch {
             val songs = getAlbumDetailsV2(album.id).first().songs
             songController.addToQueueNext(songs)
         }
     }
-
-    /*private fun onShuffleSongs(songs: List<SongInfo>) {
-        Log.i(TAG, "onShuffleSongs -> ${songs.size}")
-        songController.shuffle(songs)
-        /* //what is the thing that would jump start this step process
-        //step 1: regardless of shuffle being on or off, set shuffle to on
-        //step 2?: confirm the shuffle type
-        //step 3: prepare the mediaPlayer with the new queue of items shuffled from playlist
-        //step 4: set the player to play the first item in queue
-        //step 5: navigateToPlayer(first item)
-        //step 6: start playing
-        //needs to take the songs in the playlist, shuffle the
-        coroutineScope.launch {
-            sheetState.hide()
-            showThemeSheet = false
-        }*/
-    }*/
     private fun onShuffleSongs(album: AlbumInfo) {
         Log.i(TAG, "onShuffleSongs -> ${album.title}")
         viewModelScope.launch {
             val songs = getAlbumDetailsV2(album.id).first().songs
             songController.shuffle(songs)
+        }
+    }
+    private fun onQueueSongs(album: AlbumInfo) {
+        Log.i(TAG, "onQueueSongs -> ${album.title}")
+        viewModelScope.launch {
+            val songs = getAlbumDetailsV2(album.id).first().songs
+            songController.addToQueue(songs)
         }
     }
 }
@@ -300,14 +251,11 @@ sealed interface HomeAction {
     //data class LibraryPlaylistSelected(val playlist: PlaylistInfo) : HomeAction
 
     data class PlaySong(val song: SongInfo) : HomeAction
-    //data class PlaySongs(val songs: List<SongInfo>) : HomeAction
-    data class PlaySongs(val album: AlbumInfo) : HomeAction
     data class PlaySongNext(val song: SongInfo) : HomeAction
-    //data class PlaySongsNext(val songs: List<SongInfo>) : HomeAction
-    data class PlaySongsNext(val album: AlbumInfo) : HomeAction
     data class QueueSong(val song: SongInfo) : HomeAction
-    //data class QueueSongs(val songs: List<SongInfo>) : HomeAction
-    data class QueueSongs(val album: AlbumInfo) : HomeAction
-    //data class ShuffleSongs(val songs: List<SongInfo>) : HomeAction
+
+    data class PlaySongs(val album: AlbumInfo) : HomeAction
+    data class PlaySongsNext(val album: AlbumInfo) : HomeAction
     data class ShuffleSongs(val album: AlbumInfo) : HomeAction
+    data class QueueSongs(val album: AlbumInfo) : HomeAction
 }

--- a/app/src/main/java/com/example/music/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/home/HomeViewModel.kt
@@ -4,13 +4,16 @@ import android.util.Log
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.music.data.database.model.Song
 import com.example.music.domain.usecases.FeaturedLibraryItemsV2
 import com.example.music.domain.model.FeaturedLibraryItemsFilterV2
 import com.example.music.domain.model.AlbumInfo
 import com.example.music.domain.model.PlaylistInfo
 //import com.example.music.domain.player.SongPlayer
 import com.example.music.data.util.combine
+import com.example.music.domain.model.AlbumDetailsFilterResult
 import com.example.music.domain.model.SongInfo
+import com.example.music.domain.usecases.GetAlbumDetailsV2
 import com.example.music.domain.usecases.GetTotalCountsV2
 import com.example.music.service.SongController
 import com.example.music.ui.albumdetails.AlbumAction
@@ -19,6 +22,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -52,7 +56,7 @@ class HomeViewModel @Inject constructor(
     //private val selectedLibraryPlaylist = MutableStateFlow<PlaylistInfo?>(null)
 
     // test version for using MediaStore, uses Album instead of playlist
-    private val selectedLibraryAlbum = MutableStateFlow<AlbumInfo?>(null)
+    private val selectedAlbum = MutableStateFlow<AlbumInfo?>(null)
 
     // original
     //private val featuredLibraryItems = featuredLibraryItemsUseCase() //returns Flow<FeaturedLibraryItemsFilterResult>
@@ -104,10 +108,12 @@ class HomeViewModel @Inject constructor(
                 refreshing,
                 featuredLibraryItems,
                 selectedSong,
+                selectedAlbum,
             ) {
                 refreshing,
                 libraryItems,
-                selectSong ->
+                selectSong,
+                selectAlbum ->
                 Log.i(TAG, "viewModelScope launch - combine start")
                 Log.i(TAG, "viewModelScope launch - combine - refreshing: $refreshing")
                 //Log.i(TAG, "viewModelScope launch - combine - libraryItemsPlaylists: ${libraryItems.recentPlaylists.size}")
@@ -120,6 +126,7 @@ class HomeViewModel @Inject constructor(
                     featuredLibraryItemsFilterResult = libraryItems,
                     totals = counts,
                     selectSong = selectSong ?: SongInfo(),
+                    selectAlbum = selectAlbum ?: AlbumInfo(),
                 )
             }.catch { throwable ->
                 emit(
@@ -178,7 +185,7 @@ class HomeViewModel @Inject constructor(
     //}
 
     private fun onLibraryAlbumSelected(album: AlbumInfo) {
-        selectedLibraryAlbum.value = album
+        selectedAlbum.value = album
     }
 
     private fun onQueueSong(song: SongInfo) {
@@ -223,4 +230,5 @@ data class HomeScreenUiState(
     val featuredLibraryItemsFilterResult: FeaturedLibraryItemsFilterV2 = FeaturedLibraryItemsFilterV2(),
     val totals: List<Int> = emptyList(),
     val selectSong: SongInfo = SongInfo(),
+    val selectAlbum: AlbumInfo = AlbumInfo(),
 )

--- a/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
@@ -446,11 +446,11 @@ private fun LibraryContent(
                         artistCount = libraryArtists.size,
                         state = listState,
                         navigateToArtistDetails = { artist: ArtistInfo ->
-                            Log.i(TAG, "Artist clicked: ${artist.name}")
+                            Log.i(TAG, "Artist clicked: ${artist.name} :: ${artist.id}")
                             navigateToArtistDetails(artist.id)
                         },
                         onArtistMoreOptionsClick = { artist: ArtistInfo ->
-                            Log.i(TAG, "Artist More Option Clicked: ${artist.name}")
+                            Log.i(TAG, "Artist More Option Clicked: ${artist.name} :: ${artist.id}")
                             selectedArtist = artist
                             showBottomSheet = true
                             showArtistMoreOptions = true
@@ -500,11 +500,11 @@ private fun LibraryContent(
                     genreItems(
                         genres = libraryGenres,
                         navigateToGenreDetails = { genre: GenreInfo ->
-                            Log.i(TAG, "Genre clicked: ${genre.name}")
+                            Log.i(TAG, "Genre clicked: ${genre.name} :: ${genre.id}")
                             navigateToGenreDetails(genre.id)
                         },
                         onGenreMoreOptionsClick = { genre: GenreInfo ->
-                            Log.i(TAG, "Genre More Option Clicked: ${genre.name}")
+                            Log.i(TAG, "Genre More Option Clicked: ${genre.name} :: ${genre.id}")
                             selectedGenre = genre
                             showBottomSheet = true
                             showGenreMoreOptions = true
@@ -524,12 +524,12 @@ private fun LibraryContent(
                     songItems(
                         songs = librarySongs,
                         navigateToPlayer = { song: SongInfo ->
-                            Log.i(TAG, "Song clicked: ${song.title}")
+                            Log.i(TAG, "Song clicked: ${song.title} :: ${song.id}")
                             onLibraryAction(LibraryAction.PlaySong(song))
                             navigateToPlayer()
                         },
                         onSongMoreOptionsClick = { song: SongInfo ->
-                            Log.i(TAG, "Song More Option Clicked: ${song.title}")
+                            Log.i(TAG, "Song More Option Clicked: ${song.title} :: ${song.id}")
                             selectedSong = song
                             showBottomSheet = true
                             showSongMoreOptions = true
@@ -560,11 +560,11 @@ private fun LibraryContent(
                     albumItems(
                         albums = libraryAlbums,
                         navigateToAlbumDetails = { album: AlbumInfo ->
-                            Log.i(TAG, "Album clicked: ${album.title}")
+                            Log.i(TAG, "Album clicked: ${album.title} :: ${album.id}")
                             navigateToAlbumDetails(album.id)
                         },
                         onAlbumMoreOptionsClick = { album: AlbumInfo ->
-                            Log.i(TAG, "Album More Option Clicked: ${album.title}")
+                            Log.i(TAG, "Album More Option Clicked: ${album.title} :: ${album.id}")
                             selectedAlbum = album
                             showBottomSheet = true
                             showAlbumMoreOptions = true
@@ -684,7 +684,7 @@ private fun LibraryContent(
                 album = selectedAlbum,
                 play = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> Play Album clicked")
+                        Log.i(TAG, "Album More Options Modal -> Play Album clicked :: ${selectedAlbum.id}")
                         onLibraryAction(LibraryAction.PlayAlbum(selectedAlbum))
                         sheetState.hide()
                         navigateToPlayer()
@@ -698,7 +698,7 @@ private fun LibraryContent(
                 },
                 playNext = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> Play Album Next clicked")
+                        Log.i(TAG, "Album More Options Modal -> Play Album Next clicked :: ${selectedAlbum.id}")
                         onLibraryAction(LibraryAction.PlayAlbumNext(selectedAlbum))
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -711,7 +711,7 @@ private fun LibraryContent(
                 },
                 shuffle = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> Shuffle Album clicked")
+                        Log.i(TAG, "Album More Options Modal -> Shuffle Album clicked :: ${selectedAlbum.id}")
                         onLibraryAction(LibraryAction.ShuffleAlbum(selectedAlbum))
                         sheetState.hide()
                         navigateToPlayer()
@@ -726,7 +726,7 @@ private fun LibraryContent(
                 //addToPlaylist = {},
                 addToQueue = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> Queue Album clicked")
+                        Log.i(TAG, "Album More Options Modal -> Queue Album clicked :: ${selectedAlbum.id}")
                         onLibraryAction(LibraryAction.QueueAlbum(selectedAlbum))
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -739,7 +739,7 @@ private fun LibraryContent(
                 },
                 goToArtist = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> Go To Artist clicked")
+                        Log.i(TAG, "Album More Options Modal -> GoToArtist clicked :: ${selectedAlbum.albumArtistId ?: "null id"}")
                         navigateToArtistDetails(selectedAlbum.albumArtistId ?: 0L) // not a good check, would break if bottom modal didn't have null check too
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -752,7 +752,7 @@ private fun LibraryContent(
                 },
                 goToAlbum = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Album More Options Modal -> Go To Album clicked")
+                        Log.i(TAG, "Album More Options Modal -> GoToAlbum clicked :: ${selectedAlbum.id}")
                         navigateToAlbumDetails(selectedAlbum.id)
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -791,7 +791,7 @@ private fun LibraryContent(
                 artist = selectedArtist,
                 play = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Artist More Options Modal -> Play Artist clicked")
+                        Log.i(TAG, "Artist More Options Modal -> Play Artist clicked :: ${selectedArtist.id}")
                         onLibraryAction(LibraryAction.PlayArtist(selectedArtist))
                         sheetState.hide()
                         navigateToPlayer()
@@ -805,7 +805,7 @@ private fun LibraryContent(
                 },
                 playNext = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Artist More Options Modal -> Play Artist Next clicked")
+                        Log.i(TAG, "Artist More Options Modal -> Play Artist Next clicked :: ${selectedArtist.id}")
                         onLibraryAction(LibraryAction.PlayArtistNext(selectedArtist))
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -818,7 +818,7 @@ private fun LibraryContent(
                 },
                 shuffle = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Artist More Options Modal -> Shuffle Artist clicked")
+                        Log.i(TAG, "Artist More Options Modal -> Shuffle Artist clicked :: ${selectedArtist.id}")
                         onLibraryAction(LibraryAction.ShuffleArtist(selectedArtist))
                         sheetState.hide()
                         navigateToPlayer()
@@ -833,7 +833,7 @@ private fun LibraryContent(
                 //addToPlaylist = {},
                 addToQueue = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Artist More Options Modal -> Queue Artist clicked")
+                        Log.i(TAG, "Artist More Options Modal -> Queue Artist clicked :: ${selectedArtist.id}")
                         onLibraryAction(LibraryAction.QueueArtist(selectedArtist))
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -846,8 +846,8 @@ private fun LibraryContent(
                 },
                 goToArtist = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Artist More Options Modal -> Go To Artist clicked")
-                        navigateToAlbumDetails(selectedArtist.id)
+                        Log.i(TAG, "Artist More Options Modal -> GoToArtist clicked :: ${selectedArtist.id}")
+                        navigateToArtistDetails(selectedArtist.id)
                         sheetState.hide()
                     }.invokeOnCompletion {
                         Log.i(TAG, "set showBottomSheet to FALSE; set ArtistMoreOptions to FALSE")
@@ -885,7 +885,7 @@ private fun LibraryContent(
                 genre = selectedGenre,
                 play = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Genre More Options Modal -> Play Genre clicked")
+                        Log.i(TAG, "Genre More Options Modal -> Play Genre clicked :: ${selectedGenre.id}")
                         onLibraryAction(LibraryAction.PlayGenre(selectedGenre))
                         sheetState.hide()
                         navigateToPlayer()
@@ -912,7 +912,7 @@ private fun LibraryContent(
                 },*/
                 shuffle = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Genre More Options Modal -> Shuffle Genre clicked")
+                        Log.i(TAG, "Genre More Options Modal -> Shuffle Genre clicked :: ${selectedGenre.id}")
                         onLibraryAction(LibraryAction.ShuffleGenre(selectedGenre))
                         sheetState.hide()
                         navigateToPlayer()
@@ -940,7 +940,7 @@ private fun LibraryContent(
                 },*/
                 goToGenre = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Genre More Options Modal -> Go To Genre clicked")
+                        Log.i(TAG, "Genre More Options Modal -> GoToGenre clicked :: ${selectedGenre.id}")
                         navigateToGenreDetails(selectedGenre.id)
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -979,7 +979,7 @@ private fun LibraryContent(
                 song = selectedSong,
                 play = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> PlaySong clicked")
+                        Log.i(TAG, "Song More Options Modal -> PlaySong clicked :: ${selectedSong.id}")
                         onLibraryAction(LibraryAction.PlaySong(selectedSong))
                         navigateToPlayer()
                         sheetState.hide()
@@ -993,7 +993,7 @@ private fun LibraryContent(
                 },
                 playNext = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked")
+                        Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked :: ${selectedSong.id}")
                         onLibraryAction(LibraryAction.PlaySongNext(selectedSong))
                         navigateToPlayer()
                         sheetState.hide()
@@ -1008,7 +1008,7 @@ private fun LibraryContent(
                 //addToPlaylist = {},
                 addToQueue = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> QueueSong clicked")
+                        Log.i(TAG, "Song More Options Modal -> QueueSong clicked :: ${selectedSong.id}")
                         onLibraryAction(LibraryAction.QueueSong(selectedSong))
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -1021,7 +1021,7 @@ private fun LibraryContent(
                 },
                 goToArtist = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> GoToArtist clicked")
+                        Log.i(TAG, "Song More Options Modal -> GoToArtist clicked :: ${selectedSong.artistId}")
                         navigateToArtistDetails(selectedSong.artistId)
                         sheetState.hide()
                     }.invokeOnCompletion {
@@ -1034,7 +1034,7 @@ private fun LibraryContent(
                 },
                 goToAlbum = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> GoToAlbum clicked")
+                        Log.i(TAG, "Song More Options Modal -> GoToAlbum clicked :: ${selectedSong.albumId}")
                         navigateToAlbumDetails(selectedSong.albumId)
                         sheetState.hide()
                     }.invokeOnCompletion {

--- a/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
@@ -657,7 +657,7 @@ private fun LibraryContent(
                         }
                     }
                 },
-                onSave = {
+                onApply = {
                     coroutineScope.launch {
                         Log.i(TAG, "Save sheet state - does nothing atm")
                         sheetState.hide()
@@ -873,7 +873,7 @@ private fun LibraryContent(
             )
         }
 
-        // bottom sheet context - artist more option btn
+        // bottom sheet context - genre more option btn
         else if (showGenreMoreOptions) {
             Log.i(TAG, "Library Content -> Genre More Options is TRUE")
             GenreMoreOptionsBottomModal(

--- a/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
@@ -93,13 +93,13 @@ import com.example.music.ui.library.playlist.playlistItems
 import com.example.music.ui.library.song.songItems
 import com.example.music.ui.shared.AlbumMoreOptionsBottomModal
 import com.example.music.ui.shared.ArtistMoreOptionsBottomModal
+import com.example.music.ui.shared.GenreMoreOptionsBottomModal
 import com.example.music.ui.shared.LibrarySortSelectionBottomModal
 import com.example.music.ui.shared.NavDrawer
 import com.example.music.ui.shared.ScreenBackground
 import com.example.music.ui.shared.SongMoreOptionsBottomModal
 import com.example.music.ui.theme.MusicTheme
 import com.example.music.util.fullWidthItem
-import com.example.music.util.isCompact
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -155,9 +155,6 @@ fun LibraryScreen(
             libraryPlaylists = uiState.libraryPlaylists,
             librarySongs = uiState.librarySongs,
             totals = uiState.totals,
-            selectSong = uiState.selectSong,
-            selectAlbum = uiState.selectAlbum,
-            selectArtist = uiState.selectArtist,
 
             onLibraryAction = viewModel::onLibraryAction,
             navigateToHome = navigateToHome,
@@ -216,9 +213,6 @@ private fun LibraryScreen(
     libraryGenres: List<GenreInfo>,
     libraryPlaylists: List<PlaylistInfo>,
     librarySongs: List<SongInfo>,
-    selectSong: SongInfo,
-    selectAlbum: AlbumInfo,
-    selectArtist: ArtistInfo,
 
     totals: List<Int>,
     onLibraryAction: (LibraryAction) -> Unit,
@@ -293,9 +287,6 @@ private fun LibraryScreen(
                     libraryGenres = libraryGenres,
                     libraryPlaylists = libraryPlaylists,
                     librarySongs = librarySongs,
-                    selectSong = selectSong,
-                    selectAlbum = selectAlbum,
-                    selectArtist = selectArtist,
 
                     modifier = Modifier.padding(contentPadding),
                     onLibraryAction = { action ->
@@ -356,8 +347,6 @@ private fun LibraryTopAppBar(
     }
 }
 
-private val FEATURED_ALBUM_IMAGE_SIZE_DP = 160.dp
-
 /**
  * Composable for Library Screen Content
  * Adjusted the library categories so that the selected category determines the grid view
@@ -377,10 +366,6 @@ private fun LibraryContent(
     libraryPlaylists: List<PlaylistInfo>,
     librarySongs: List<SongInfo>,
 
-    selectSong: SongInfo,
-    selectAlbum: AlbumInfo,
-    selectArtist: ArtistInfo,
-
     modifier: Modifier = Modifier,
     onLibraryAction: (LibraryAction) -> Unit,
 
@@ -399,8 +384,14 @@ private fun LibraryContent(
     var showBottomSheet by remember { mutableStateOf(false) }
     var showSortSheet by remember { mutableStateOf(false) }
     var showAlbumMoreOptions by remember { mutableStateOf(false) }
-    var showSongMoreOptions by remember { mutableStateOf( false ) }
     var showArtistMoreOptions by remember { mutableStateOf(false) }
+    var showGenreMoreOptions by remember { mutableStateOf(false) }
+    var showSongMoreOptions by remember { mutableStateOf(false) }
+
+    var selectedAlbum by remember { mutableStateOf(AlbumInfo()) }
+    var selectedArtist by remember { mutableStateOf(ArtistInfo()) }
+    var selectedGenre by remember { mutableStateOf(GenreInfo()) }
+    var selectedSong by remember { mutableStateOf(SongInfo()) }
 
     val groupedAlbumItems = libraryAlbums.groupBy { it.title.first() }
     val groupedArtistItems = libraryArtists.groupBy { it.name.first() }
@@ -460,7 +451,7 @@ private fun LibraryContent(
                         },
                         onArtistMoreOptionsClick = { artist: ArtistInfo ->
                             Log.i(TAG, "Artist More Option Clicked: ${artist.name}")
-                            onLibraryAction(LibraryAction.ArtistMoreOptionsClicked(artist))
+                            selectedArtist = artist
                             showBottomSheet = true
                             showArtistMoreOptions = true
                         },
@@ -477,11 +468,12 @@ private fun LibraryContent(
                     /*artistItems(
                         artists = libraryArtists,
                         navigateToArtistDetails = { artist: ArtistInfo ->
+                            Log.i(TAG, "Artist clicked: ${artist.name}")
                             navigateToArtistDetails(artist.id)
                         },
                         onArtistMoreOptionsClick = { artist: ArtistInfo ->
-                            Log.i(TAG, "Song More Option Clicked: ${artist.name}")
-                            onLibraryAction(LibraryAction.ArtistMoreOptionsClicked(artist))
+                            Log.i(TAG, "Artist More Option Clicked: ${artist.name}")
+                            selectedArtist = artist
                             showBottomSheet = true
                             showArtistMoreOptions = true
                         },
@@ -507,8 +499,24 @@ private fun LibraryContent(
                 LibraryCategory.Genres -> {
                     genreItems(
                         genres = libraryGenres,
-                        coroutineScope = coroutineScope,
-                        navigateToGenreDetails = navigateToGenreDetails,
+                        navigateToGenreDetails = { genre: GenreInfo ->
+                            Log.i(TAG, "Genre clicked: ${genre.name}")
+                            navigateToGenreDetails(genre)
+                        },
+                        onGenreMoreOptionsClick = { genre: GenreInfo ->
+                            Log.i(TAG, "Genre More Option Clicked: ${genre.name}")
+                            selectedGenre = genre
+                            showBottomSheet = true
+                            showGenreMoreOptions = true
+                        },
+                        onSortClick = {
+                            Log.i(TAG, "Genre Sort btn clicked")
+                            showBottomSheet = true
+                            showSortSheet = true
+                        },
+                        onSelectClick = {
+                            Log.i(TAG, "Genre Multi Select btn clicked")
+                        },
                     )
                 }
 
@@ -522,7 +530,7 @@ private fun LibraryContent(
                         },
                         onSongMoreOptionsClick = { song: SongInfo ->
                             Log.i(TAG, "Song More Option Clicked: ${song.title}")
-                            onLibraryAction(LibraryAction.SongMoreOptionsClicked(song))
+                            selectedSong = song
                             showBottomSheet = true
                             showSongMoreOptions = true
                         },
@@ -557,7 +565,7 @@ private fun LibraryContent(
                         },
                         onAlbumMoreOptionsClick = { album: AlbumInfo ->
                             Log.i(TAG, "Album More Option Clicked: ${album.title}")
-                            onLibraryAction(LibraryAction.AlbumMoreOptionsClicked(album))
+                            selectedAlbum = album
                             showBottomSheet = true
                             showAlbumMoreOptions = true
                         },
@@ -673,11 +681,11 @@ private fun LibraryContent(
                     showAlbumMoreOptions = false
                 },
                 sheetState = sheetState,
-                album = selectAlbum,
+                album = selectedAlbum,
                 play = {
                     coroutineScope.launch {
                         Log.i(TAG, "Album More Options Modal -> Play Album clicked")
-                        onLibraryAction(LibraryAction.PlayAlbum(selectAlbum))
+                        onLibraryAction(LibraryAction.PlayAlbum(selectedAlbum))
                         sheetState.hide()
                         navigateToPlayer()
                     }.invokeOnCompletion {
@@ -691,7 +699,7 @@ private fun LibraryContent(
                 playNext = {
                     coroutineScope.launch {
                         Log.i(TAG, "Album More Options Modal -> Play Album Next clicked")
-                        onLibraryAction(LibraryAction.PlayAlbumNext(selectAlbum))
+                        onLibraryAction(LibraryAction.PlayAlbumNext(selectedAlbum))
                         sheetState.hide()
                     }.invokeOnCompletion {
                         Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
@@ -704,7 +712,7 @@ private fun LibraryContent(
                 shuffle = {
                     coroutineScope.launch {
                         Log.i(TAG, "Album More Options Modal -> Shuffle Album clicked")
-                        onLibraryAction(LibraryAction.ShuffleAlbum(selectAlbum))
+                        onLibraryAction(LibraryAction.ShuffleAlbum(selectedAlbum))
                         sheetState.hide()
                         navigateToPlayer()
                     }.invokeOnCompletion {
@@ -719,107 +727,39 @@ private fun LibraryContent(
                 addToQueue = {
                     coroutineScope.launch {
                         Log.i(TAG, "Album More Options Modal -> Queue Album clicked")
-                        onLibraryAction(LibraryAction.QueueAlbum(selectAlbum))
+                        onLibraryAction(LibraryAction.QueueAlbum(selectedAlbum))
                         sheetState.hide()
                     }.invokeOnCompletion {
                         Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
                         if(!sheetState.isVisible) {
                             showBottomSheet = false
                             showAlbumMoreOptions = false
-                        }
-                    }
-                },
-                onClose = {
-                    coroutineScope.launch {
-                        Log.i(TAG, "Hide sheet state")
-                        sheetState.hide()
-                    }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
-                        if(!sheetState.isVisible) {
-                            showBottomSheet = false
-                            showAlbumMoreOptions = false
-                        }
-                    }
-                },
-                context = "Library",
-            )
-        }
-
-        // bottom sheet context - song more option btn
-        else if (showSongMoreOptions) {
-            Log.i(TAG, "Library Content -> Song More Options is TRUE")
-            SongMoreOptionsBottomModal(
-                onDismissRequest = {
-                    showBottomSheet = false
-                    showSongMoreOptions = false
-                },
-                sheetState = sheetState,
-                song = selectSong,
-                play = {
-                    coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> PlaySong clicked")
-                        onLibraryAction(LibraryAction.PlaySong(selectSong))
-                        navigateToPlayer()
-                        sheetState.hide()
-                    }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE")
-                        if(!sheetState.isVisible) {
-                            showBottomSheet = false
-                            showSongMoreOptions = false
-                        }
-                    }
-                },
-                playNext = {
-                    coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked")
-                        onLibraryAction(LibraryAction.PlaySongNext(selectSong))
-                        navigateToPlayer()
-                        sheetState.hide()
-                    }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE")
-                        if(!sheetState.isVisible) {
-                            showBottomSheet = false
-                            showSongMoreOptions = false
-                        }
-                    }
-                },
-                //addToPlaylist = {},
-                addToQueue = {
-                    coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> QueueSong clicked")
-                        onLibraryAction(LibraryAction.QueueSong(selectSong))
-                        sheetState.hide()
-                    }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE")
-                        if(!sheetState.isVisible) {
-                            showBottomSheet = false
-                            showSongMoreOptions = false
                         }
                     }
                 },
                 goToArtist = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> GoToArtist clicked")
-                        navigateToArtistDetails(selectSong.artistId)
+                        Log.i(TAG, "Album More Options Modal -> Go To Artist clicked")
+                        navigateToArtistDetails(selectedAlbum.albumArtistId ?: 0L) // not a good check, would break if bottom modal didn't have null check too
                         sheetState.hide()
                     }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
                         if(!sheetState.isVisible) {
                             showBottomSheet = false
-                            showSongMoreOptions = false
+                            showAlbumMoreOptions = false
                         }
                     }
                 },
                 goToAlbum = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Song More Options Modal -> GoToAlbum clicked")
-                        navigateToAlbumDetails(selectSong.albumId)
+                        Log.i(TAG, "Album More Options Modal -> Go To Album clicked")
+                        navigateToAlbumDetails(selectedAlbum.id)
                         sheetState.hide()
                     }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
                         if(!sheetState.isVisible) {
                             showBottomSheet = false
-                            showSongMoreOptions = false
+                            showAlbumMoreOptions = false
                         }
                     }
                 },
@@ -828,10 +768,10 @@ private fun LibraryContent(
                         Log.i(TAG, "Hide sheet state")
                         sheetState.hide()
                     }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
                         if(!sheetState.isVisible) {
                             showBottomSheet = false
-                            showSongMoreOptions = false
+                            showAlbumMoreOptions = false
                         }
                     }
                 },
@@ -848,15 +788,15 @@ private fun LibraryContent(
                     showArtistMoreOptions = false
                 },
                 sheetState = sheetState,
-                artist = selectArtist,
+                artist = selectedArtist,
                 play = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Artist More Options Modal -> PlayArtist clicked")
-                        onLibraryAction(LibraryAction.PlayArtist(selectArtist))
-                        navigateToPlayer()
+                        Log.i(TAG, "Artist More Options Modal -> Play Artist clicked")
+                        onLibraryAction(LibraryAction.PlayArtist(selectedArtist))
                         sheetState.hide()
+                        navigateToPlayer()
                     }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        Log.i(TAG, "set showBottomSheet to FALSE; set ArtistMoreOptions to FALSE")
                         if(!sheetState.isVisible) {
                             showBottomSheet = false
                             showArtistMoreOptions = false
@@ -865,11 +805,11 @@ private fun LibraryContent(
                 },
                 playNext = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Artist More Options Modal -> PlayArtistNext clicked")
-                        onLibraryAction(LibraryAction.PlayArtistNext(selectArtist))
+                        Log.i(TAG, "Artist More Options Modal -> Play Artist Next clicked")
+                        onLibraryAction(LibraryAction.PlayArtistNext(selectedArtist))
                         sheetState.hide()
                     }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        Log.i(TAG, "set showBottomSheet to FALSE; set ArtistMoreOptions to FALSE")
                         if(!sheetState.isVisible) {
                             showBottomSheet = false
                             showArtistMoreOptions = false
@@ -878,12 +818,12 @@ private fun LibraryContent(
                 },
                 shuffle = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Artist More Options Modal -> ShuffleArtist clicked")
-                        onLibraryAction(LibraryAction.ShuffleArtist(selectArtist))
-                        navigateToPlayer()
+                        Log.i(TAG, "Artist More Options Modal -> Shuffle Artist clicked")
+                        onLibraryAction(LibraryAction.ShuffleArtist(selectedArtist))
                         sheetState.hide()
+                        navigateToPlayer()
                     }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        Log.i(TAG, "set showBottomSheet to FALSE; set ArtistMoreOptions to FALSE")
                         if(!sheetState.isVisible) {
                             showBottomSheet = false
                             showArtistMoreOptions = false
@@ -893,11 +833,24 @@ private fun LibraryContent(
                 //addToPlaylist = {},
                 addToQueue = {
                     coroutineScope.launch {
-                        Log.i(TAG, "Artist More Options Modal -> QueueArtist clicked")
-                        onLibraryAction(LibraryAction.QueueArtist(selectArtist))
+                        Log.i(TAG, "Artist More Options Modal -> Queue Artist clicked")
+                        onLibraryAction(LibraryAction.QueueArtist(selectedArtist))
                         sheetState.hide()
                     }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        Log.i(TAG, "set showBottomSheet to FALSE; set ArtistMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showArtistMoreOptions = false
+                        }
+                    }
+                },
+                goToArtist = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Artist More Options Modal -> Go To Artist clicked")
+                        navigateToAlbumDetails(selectedArtist.id)
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set ArtistMoreOptions to FALSE")
                         if(!sheetState.isVisible) {
                             showBottomSheet = false
                             showArtistMoreOptions = false
@@ -909,14 +862,202 @@ private fun LibraryContent(
                         Log.i(TAG, "Hide sheet state")
                         sheetState.hide()
                     }.invokeOnCompletion {
-                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        Log.i(TAG, "set showBottomSheet to FALSE; set ArtistMoreOptions to FALSE")
                         if(!sheetState.isVisible) {
                             showBottomSheet = false
                             showArtistMoreOptions = false
                         }
                     }
                 },
-                context = "ArtistDetails",
+                context = "Library",
+            )
+        }
+
+        // bottom sheet context - artist more option btn
+        else if (showGenreMoreOptions) {
+            Log.i(TAG, "Library Content -> Genre More Options is TRUE")
+            GenreMoreOptionsBottomModal(
+                onDismissRequest = {
+                    showBottomSheet = false
+                    showGenreMoreOptions = false
+                },
+                sheetState = sheetState,
+                genre = selectedGenre,
+                play = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Genre More Options Modal -> Play Genre clicked")
+                        onLibraryAction(LibraryAction.PlayGenre(selectedGenre))
+                        sheetState.hide()
+                        navigateToPlayer()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showGenreMoreOptions = false
+                        }
+                    }
+                },
+                /*playNext = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Artist More Options Modal -> Play Artist Next clicked")
+                        onLibraryAction(LibraryAction.PlayArtistNext(selectedArtist))
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set ArtistMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showArtistMoreOptions = false
+                        }
+                    }
+                },*/
+                shuffle = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Genre More Options Modal -> Shuffle Genre clicked")
+                        onLibraryAction(LibraryAction.ShuffleGenre(selectedGenre))
+                        sheetState.hide()
+                        navigateToPlayer()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showGenreMoreOptions = false
+                        }
+                    }
+                },
+                //addToPlaylist = {},
+                /*addToQueue = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Artist More Options Modal -> Queue Artist clicked")
+                        onLibraryAction(LibraryAction.QueueArtist(selectedArtist))
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set ArtistMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showArtistMoreOptions = false
+                        }
+                    }
+                },*/
+                goToGenre = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Genre More Options Modal -> Go To Genre clicked")
+                        navigateToGenreDetails(selectedGenre)
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showGenreMoreOptions = false
+                        }
+                    }
+                },
+                onClose = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Hide sheet state")
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showGenreMoreOptions = false
+                        }
+                    }
+                },
+                context = "Library",
+            )
+        }
+
+        // bottom sheet context - song more option btn
+        else if (showSongMoreOptions) {
+            Log.i(TAG, "Library Content -> Song More Options is TRUE")
+            SongMoreOptionsBottomModal(
+                onDismissRequest = {
+                    showBottomSheet = false
+                    showSongMoreOptions = false
+                },
+                sheetState = sheetState,
+                song = selectedSong,
+                play = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> PlaySong clicked")
+                        onLibraryAction(LibraryAction.PlaySong(selectedSong))
+                        navigateToPlayer()
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                playNext = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked")
+                        onLibraryAction(LibraryAction.PlaySongNext(selectedSong))
+                        navigateToPlayer()
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                //addToPlaylist = {},
+                addToQueue = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> QueueSong clicked")
+                        onLibraryAction(LibraryAction.QueueSong(selectedSong))
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                goToArtist = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> GoToArtist clicked")
+                        navigateToArtistDetails(selectedSong.artistId)
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                goToAlbum = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> GoToAlbum clicked")
+                        navigateToAlbumDetails(selectedSong.albumId)
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                onClose = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Hide sheet state")
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                context = "Library",
             )
         }
     }
@@ -1019,10 +1160,6 @@ private fun PreviewLibrary() {
                 PreviewArtists.size,
                 PreviewAlbums.size,
                 PreviewPlaylists.size),
-
-            selectSong = PreviewSongs[0],
-            selectAlbum = PreviewAlbums[1],
-            selectArtist = PreviewArtists[0],
 
             onLibraryAction = {},
             navigateToHome = {},

--- a/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -50,6 +51,7 @@ import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.rememberDrawerState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -89,15 +91,17 @@ import com.example.music.ui.library.composer.composerItems
 import com.example.music.ui.library.genre.genreItems
 import com.example.music.ui.library.playlist.playlistItems
 import com.example.music.ui.library.song.songItems
+import com.example.music.ui.shared.AlbumMoreOptionsBottomModal
+import com.example.music.ui.shared.ArtistMoreOptionsBottomModal
+import com.example.music.ui.shared.LibrarySortSelectionBottomModal
 import com.example.music.ui.shared.NavDrawer
 import com.example.music.ui.shared.ScreenBackground
+import com.example.music.ui.shared.SongMoreOptionsBottomModal
 import com.example.music.ui.theme.MusicTheme
 import com.example.music.util.fullWidthItem
 import com.example.music.util.isCompact
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-
-private const val TAG = "Library Screen"
 
 /** Changelog:
  *
@@ -109,6 +113,8 @@ private const val TAG = "Library Screen"
  *
  * 7/22-23/2025 - Removed PlayerSong completely
  */
+
+private const val TAG = "Library Screen"
 
 /**
  * Stateful Composable for the Library Screen of the app. Contains windowSizeClass,
@@ -122,10 +128,10 @@ fun LibraryScreen(
     navigateToLibrary: () -> Unit,
     navigateToSettings: () -> Unit,
     navigateToSearch: () -> Unit,
-    navigateToAlbumDetails: (AlbumInfo) -> Unit,
-    navigateToArtistDetails: (ArtistInfo) -> Unit,
-    navigateToGenreDetails: (GenreInfo) -> Unit,
+    navigateToAlbumDetails: (Long) -> Unit,
+    navigateToArtistDetails: (Long) -> Unit,
     navigateToComposerDetails: (ComposerInfo) -> Unit,
+    navigateToGenreDetails: (GenreInfo) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: () -> Unit,
     viewModel: LibraryViewModel = hiltViewModel()
@@ -138,12 +144,10 @@ fun LibraryScreen(
     }
     Surface {
         LibraryScreen(
-            //for now so I can see anything load in emulator, gonna put some preview values
             windowSizeClass = windowSizeClass,
             isLoading = uiState.isLoading,
             libraryCategories = uiState.libraryCategories,
             selectedLibraryCategory = uiState.selectedLibraryCategory,
-            //would probably load in the preferences data store around here to collect what sorting used to view screens
             libraryAlbums = uiState.libraryAlbums,
             libraryArtists = uiState.libraryArtists,
             libraryComposers = uiState.libraryComposers,
@@ -151,25 +155,21 @@ fun LibraryScreen(
             libraryPlaylists = uiState.libraryPlaylists,
             librarySongs = uiState.librarySongs,
             totals = uiState.totals,
+            selectSong = uiState.selectSong,
+            selectAlbum = uiState.selectAlbum,
+            selectArtist = uiState.selectArtist,
+
             onLibraryAction = viewModel::onLibraryAction,
-            /*navigateToAlbumDetails = { //was navigateToPodcastDetails,
-               //  then navigateToPlaylistDetails but uiState
-               //  doesn't share playlistInfo, but it can
-               //  share genre, album, song infos
-               //  could make this navigateToAlbumDetails. would need an albumInfo that
-               //  can encapsulate the type of properties needed that Podcast has
-                navigator.navigateTo(SupportingPaneScaffoldRole.Supporting, it.id.toString())
-            },*/
             navigateToHome = navigateToHome,
             navigateToLibrary = navigateToLibrary,
+            navigateToPlayer = navigateToPlayer,
+            navigateToSearch = navigateToSearch,
             navigateToSettings = navigateToSettings,
             navigateToAlbumDetails = navigateToAlbumDetails,
             navigateToArtistDetails = navigateToArtistDetails,
             navigateToComposerDetails = navigateToComposerDetails,
             navigateToGenreDetails = navigateToGenreDetails,
             navigateToPlaylistDetails = navigateToPlaylistDetails,
-            navigateToPlayer = navigateToPlayer,
-            navigateToSearch = navigateToSearch,
             modifier = Modifier.fillMaxSize()
         )
     }
@@ -216,19 +216,22 @@ private fun LibraryScreen(
     libraryGenres: List<GenreInfo>,
     libraryPlaylists: List<PlaylistInfo>,
     librarySongs: List<SongInfo>,
+    selectSong: SongInfo,
+    selectAlbum: AlbumInfo,
+    selectArtist: ArtistInfo,
+
     totals: List<Int>,
     onLibraryAction: (LibraryAction) -> Unit,
-    //navigateBack: () -> Unit,
     navigateToHome: () -> Unit,
     navigateToLibrary: () -> Unit,
-    navigateToSettings: () -> Unit,
-    navigateToAlbumDetails: (AlbumInfo) -> Unit,
-    navigateToArtistDetails: (ArtistInfo) -> Unit,
-    navigateToGenreDetails: (GenreInfo) -> Unit,
-    navigateToComposerDetails: (ComposerInfo) -> Unit,
-    navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: () -> Unit,
     navigateToSearch: () -> Unit,
+    navigateToSettings: () -> Unit,
+    navigateToAlbumDetails: (Long) -> Unit,
+    navigateToArtistDetails: (Long) -> Unit,
+    navigateToComposerDetails: (ComposerInfo) -> Unit,
+    navigateToGenreDetails: (GenreInfo) -> Unit,
+    navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -236,13 +239,6 @@ private fun LibraryScreen(
     val snackBarText = stringResource(id = R.string.sbt_song_added_to_your_queue) //FixMe: update the snackBar selection to properly convey action taken
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
 
-    //moved to using listState and visible within LibraryContent()
-    //val listState = rememberLazyListState()
-    // The FAB is initially shown. Upon scrolling past the first item we hide the FAB by using a
-    // remembered derived state to minimize unnecessary compositions.
-    //val fabVisible by remember { derivedStateOf { listState.firstVisibleItemIndex == 0 } }
-
-    //library screen seeing if navDrawer acts differently if placed before ScreenBackground
     NavDrawer(
         "Library",
         totals,
@@ -282,9 +278,7 @@ private fun LibraryScreen(
                         navigateToPlayerSong = { navigateToPlayerSong(PreviewPlayerSongs[5]) },
                     )*/
                 },
-                snackbarHost = {
-                    SnackbarHost(hostState = snackbarHostState)
-                },
+                snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
                 containerColor = Color.Transparent,
                 contentColor = contentColorFor(MaterialTheme.colorScheme.background) //selects the appropriate color to be the content color for the container using background color
             ) { contentPadding ->
@@ -299,6 +293,10 @@ private fun LibraryScreen(
                     libraryGenres = libraryGenres,
                     libraryPlaylists = libraryPlaylists,
                     librarySongs = librarySongs,
+                    selectSong = selectSong,
+                    selectAlbum = selectAlbum,
+                    selectArtist = selectArtist,
+
                     modifier = Modifier.padding(contentPadding),
                     onLibraryAction = { action ->
                         if (action is LibraryAction.QueueSong) {
@@ -345,7 +343,6 @@ private fun LibraryTopAppBar(
             )
         }
 
-        //right align objects after this space
         Spacer(Modifier.weight(1f))
 
         // search btn
@@ -366,6 +363,7 @@ private val FEATURED_ALBUM_IMAGE_SIZE_DP = 160.dp
  * Adjusted the library categories so that the selected category determines the grid view
  * new version: want to make a singular vertical grid that has dynamic layout based on tab chosen
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LibraryContent(
     coroutineScope: CoroutineScope,
@@ -379,32 +377,30 @@ private fun LibraryContent(
     libraryPlaylists: List<PlaylistInfo>,
     librarySongs: List<SongInfo>,
 
+    selectSong: SongInfo,
+    selectAlbum: AlbumInfo,
+    selectArtist: ArtistInfo,
+
     modifier: Modifier = Modifier,
     onLibraryAction: (LibraryAction) -> Unit,
 
-    navigateToAlbumDetails: (AlbumInfo) -> Unit,
-    navigateToArtistDetails: (ArtistInfo) -> Unit,
-    navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
-    navigateToGenreDetails: (GenreInfo) -> Unit,
+    navigateToAlbumDetails: (Long) -> Unit,
+    navigateToArtistDetails: (Long) -> Unit,
     navigateToComposerDetails: (ComposerInfo) -> Unit,
+    navigateToGenreDetails: (GenreInfo) -> Unit,
+    navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: () -> Unit,
 ) {
+    Log.i(TAG, "LibraryContent START")
     val listState = rememberLazyGridState()
     val displayButton = remember { derivedStateOf { listState.firstVisibleItemIndex > 1 } }
-    //derived state is useful when the evaluated expression's value changes are less often than the item's own value changing
-    //     so that recomposition only occurs when the evaluated result changes.
-    //     the emitted state/value doesn't have to be updated with every change in the given item
-    //     ALSO good for form validation -> updating a button/field error or disable state when an input is valid/invalid
-    //     if there's something that could be used in viewModel/nonComposable, it can still be with derivedStateOf, just won't need remember
 
-    //so to make use of derived state for changing the sticky headers,
-    //     would need way to select those out of the groupedBy maps and have those items be the deciders
-
-    //if i want to make sticky headers, seems like that would need to be
-    //     defined before the items set creation since it will
-    //     be dependent on the sort order before using groupBy
-    //     might be fine to use as init version, but if there's a defined
-    //     sort order later, need to reference that instead
+    val sheetState = rememberModalBottomSheetState(false,)
+    var showBottomSheet by remember { mutableStateOf(false) }
+    var showSortSheet by remember { mutableStateOf(false) }
+    var showAlbumMoreOptions by remember { mutableStateOf(false) }
+    var showSongMoreOptions by remember { mutableStateOf( false ) }
+    var showArtistMoreOptions by remember { mutableStateOf(false) }
 
     val groupedAlbumItems = libraryAlbums.groupBy { it.title.first() }
     val groupedArtistItems = libraryArtists.groupBy { it.name.first() }
@@ -416,11 +412,8 @@ private fun LibraryContent(
     groupedArtistItems.forEach { (letter, artist) ->
         Log.i(TAG, "Output for groupedArtists Letter: $letter, artist: $artist")
     }
-    //if artists, composers, genres, songs -> column fixed to 1 -> LazyVerticalGrid(columns = GridCells.Fixed(1), modifier = Modifier.padding(horizontal = 12.dp))
-    //if playlists, albums -> column fixed, but to whatever the max amount of columns can be shown
 
-    // can this section be done on a span basis? so that if i set the column to be some number X,
-    // i can then make the adaptive ones be span1 and the other be spanX?
+    // screen sizing parameters for generating LazyGrid columns
     val config = LocalConfiguration.current
     val screenWidth = config.screenWidthDp
     val horizontalPadding = 12
@@ -443,7 +436,7 @@ private fun LibraryContent(
                 LibraryCategoryTabs(
                     libraryCategories = libraryCategories,
                     selectedLibraryCategory = selectedLibraryCategory,
-                    onLibraryCategorySelected = { //selectedLibraryCategory.value = it
+                    onLibraryCategorySelected = {
                         onLibraryAction(
                             LibraryAction.LibraryCategorySelected(
                                 it
@@ -460,23 +453,51 @@ private fun LibraryContent(
                     artistItems(
                         mappedArtists = groupedArtistItems,
                         artistCount = libraryArtists.size,
-                        coroutineScope = coroutineScope,
                         state = listState,
-                        navigateToArtistDetails = navigateToArtistDetails,
+                        navigateToArtistDetails = { artist: ArtistInfo ->
+                            Log.i(TAG, "Artist clicked: ${artist.name}")
+                            navigateToArtistDetails(artist.id)
+                        },
+                        onArtistMoreOptionsClick = { artist: ArtistInfo ->
+                            Log.i(TAG, "Artist More Option Clicked: ${artist.name}")
+                            onLibraryAction(LibraryAction.ArtistMoreOptionsClicked(artist))
+                            showBottomSheet = true
+                            showArtistMoreOptions = true
+                        },
+                        onSortClick = {
+                            Log.i(TAG, "Artist Sort btn clicked")
+                            showBottomSheet = true
+                            showSortSheet = true
+                        },
+                        onSelectClick = {
+                            Log.i(TAG, "Artist Multi Select btn clicked")
+                        }
                     )
-
-                    /** original version **/
+                    /** original version, not using sticky headers **/
                     /*artistItems(
-                        //what would the artists screen need?
                         artists = libraryArtists,
-                        coroutineScope = coroutineScope,
-                        navigateToArtistDetails = navigateToArtistDetails,
+                        navigateToArtistDetails = { artist: ArtistInfo ->
+                            navigateToArtistDetails(artist.id)
+                        },
+                        onArtistMoreOptionsClick = { artist: ArtistInfo ->
+                            Log.i(TAG, "Song More Option Clicked: ${artist.name}")
+                            onLibraryAction(LibraryAction.ArtistMoreOptionsClicked(artist))
+                            showBottomSheet = true
+                            showArtistMoreOptions = true
+                        },
+                        onSortClick = {
+                            Log.i(TAG, "Artist Sort btn clicked")
+                            showBottomSheet = true
+                            showSortSheet = true
+                        },
+                        onSelectClick = {
+                            Log.i(TAG, "Artist Multi Select btn clicked")
+                        }
                     )*/
                 }
 
                 LibraryCategory.Composers -> {
                     composerItems(
-                        //what would the composers screen need?
                         composers = libraryComposers,
                         coroutineScope = coroutineScope,
                         navigateToComposerDetails = navigateToComposerDetails,
@@ -485,7 +506,6 @@ private fun LibraryContent(
 
                 LibraryCategory.Genres -> {
                     genreItems(
-                        //what would the genres screen need?
                         genres = libraryGenres,
                         coroutineScope = coroutineScope,
                         navigateToGenreDetails = navigateToGenreDetails,
@@ -494,31 +514,70 @@ private fun LibraryContent(
 
                 LibraryCategory.Songs -> {
                     songItems(
-                        //what would the songs screen need?
                         songs = librarySongs,
-                        coroutineScope = coroutineScope,
-                        onLibraryAction = onLibraryAction,
-                        navigateToPlayer = navigateToPlayer,
+                        navigateToPlayer = { song: SongInfo ->
+                            Log.i(TAG, "Song clicked: ${song.title}")
+                            onLibraryAction(LibraryAction.PlaySong(song))
+                            navigateToPlayer()
+                        },
+                        onSongMoreOptionsClick = { song: SongInfo ->
+                            Log.i(TAG, "Song More Option Clicked: ${song.title}")
+                            onLibraryAction(LibraryAction.SongMoreOptionsClicked(song))
+                            showBottomSheet = true
+                            showSongMoreOptions = true
+                        },
+                        onSortClick = {
+                            Log.i(TAG, "Song Sort btn clicked")
+                            showBottomSheet = true
+                            showSortSheet = true
+                        },
+                        onSelectClick = {
+                            Log.i(TAG, "Song Multi Select btn clicked")
+                        },
+                        onPlayClick = {
+                            Log.i(TAG, "Play Songs btn clicked")
+                            onLibraryAction(LibraryAction.PlaySongs(librarySongs))
+                            navigateToPlayer()
+                        },
+                        onShuffleClick = {
+                            Log.i(TAG, "Shuffle Songs btn clicked")
+                            onLibraryAction(LibraryAction.ShuffleSongs(librarySongs))
+                            navigateToPlayer()
+                        },
                     )
                 }
 
                 /** adaptive columns section **/
                 LibraryCategory.Albums -> {
                     albumItems(
-                        //what would the albums screen need?
                         albums = libraryAlbums,
-                        coroutineScope = coroutineScope,
-                        navigateToAlbumDetails = navigateToAlbumDetails,
+                        navigateToAlbumDetails = { album: AlbumInfo ->
+                            Log.i(TAG, "Album clicked: ${album.title}")
+                            navigateToAlbumDetails(album.id)
+                        },
+                        onAlbumMoreOptionsClick = { album: AlbumInfo ->
+                            Log.i(TAG, "Album More Option Clicked: ${album.title}")
+                            onLibraryAction(LibraryAction.AlbumMoreOptionsClicked(album))
+                            showBottomSheet = true
+                            showAlbumMoreOptions = true
+                        },
+                        onSortClick = {
+                            Log.i(TAG, "Album Sort btn clicked")
+                            showBottomSheet = true
+                            showSortSheet = true
+                        },
+                        onSelectClick = {
+                            Log.i(TAG, "Album Multi Select btn clicked")
+                        },
                     )
                 }
 
                 LibraryCategory.Playlists -> {
                     playlistItems(
-                        //what would the playlist screen need?
                         playlists = libraryPlaylists,
                         navigateToPlaylistDetails = navigateToPlaylistDetails,
                         coroutineScope = coroutineScope,
-                        modifier = modifier//.align(Alignment.CenterHorizontally),
+                        modifier = modifier
                     )
                 }
             }
@@ -563,6 +622,304 @@ private fun LibraryContent(
             }
         }
     }
+
+    // Library BottomSheet
+    if (showBottomSheet) {
+        Log.i(TAG, "Library Content -> showBottomSheet is TRUE")
+        // bottom sheet context - sort btn
+        if (showSortSheet) {
+            Log.i(TAG, "Library Content -> $selectedLibraryCategory Sort Modal is TRUE")
+            LibrarySortSelectionBottomModal(
+                onDismissRequest = {
+                    showBottomSheet = false
+                    showSortSheet = false
+                },
+                sheetState = sheetState,
+                libraryCategory = selectedLibraryCategory,
+                // need to show selection
+                onClose = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Hide sheet state")
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSortSheet = false
+                        }
+                    }
+                },
+                onSave = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Save sheet state - does nothing atm")
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSortSheet = false
+                        }
+                    }
+                },
+            )
+        }
+
+        // bottom sheet context - album more option btn
+        else if (showAlbumMoreOptions) {
+            Log.i(TAG, "Library Content -> Album More Options is TRUE")
+            AlbumMoreOptionsBottomModal(
+                onDismissRequest = {
+                    showBottomSheet = false
+                    showAlbumMoreOptions = false
+                },
+                sheetState = sheetState,
+                album = selectAlbum,
+                play = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Album More Options Modal -> Play Album clicked")
+                        onLibraryAction(LibraryAction.PlayAlbum(selectAlbum))
+                        sheetState.hide()
+                        navigateToPlayer()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showAlbumMoreOptions = false
+                        }
+                    }
+                },
+                playNext = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Album More Options Modal -> Play Album Next clicked")
+                        onLibraryAction(LibraryAction.PlayAlbumNext(selectAlbum))
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showAlbumMoreOptions = false
+                        }
+                    }
+                },
+                shuffle = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Album More Options Modal -> Shuffle Album clicked")
+                        onLibraryAction(LibraryAction.ShuffleAlbum(selectAlbum))
+                        sheetState.hide()
+                        navigateToPlayer()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showAlbumMoreOptions = false
+                        }
+                    }
+                },
+                //addToPlaylist = {},
+                addToQueue = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Album More Options Modal -> Queue Album clicked")
+                        onLibraryAction(LibraryAction.QueueAlbum(selectAlbum))
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showAlbumMoreOptions = false
+                        }
+                    }
+                },
+                onClose = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Hide sheet state")
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE; set AlbumMoreOptions to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showAlbumMoreOptions = false
+                        }
+                    }
+                },
+                context = "Library",
+            )
+        }
+
+        // bottom sheet context - song more option btn
+        else if (showSongMoreOptions) {
+            Log.i(TAG, "Library Content -> Song More Options is TRUE")
+            SongMoreOptionsBottomModal(
+                onDismissRequest = {
+                    showBottomSheet = false
+                    showSongMoreOptions = false
+                },
+                sheetState = sheetState,
+                song = selectSong,
+                play = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> PlaySong clicked")
+                        onLibraryAction(LibraryAction.PlaySong(selectSong))
+                        navigateToPlayer()
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                playNext = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> PlaySongNext clicked")
+                        onLibraryAction(LibraryAction.PlaySongNext(selectSong))
+                        navigateToPlayer()
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                //addToPlaylist = {},
+                addToQueue = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> QueueSong clicked")
+                        onLibraryAction(LibraryAction.QueueSong(selectSong))
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                goToArtist = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> GoToArtist clicked")
+                        navigateToArtistDetails(selectSong.artistId)
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                goToAlbum = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Song More Options Modal -> GoToAlbum clicked")
+                        navigateToAlbumDetails(selectSong.albumId)
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                onClose = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Hide sheet state")
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showSongMoreOptions = false
+                        }
+                    }
+                },
+                context = "Library",
+            )
+        }
+
+        // bottom sheet context - artist more option btn
+        else if (showArtistMoreOptions) {
+            Log.i(TAG, "Library Content -> Artist More Options is TRUE")
+            ArtistMoreOptionsBottomModal(
+                onDismissRequest = {
+                    showBottomSheet = false
+                    showArtistMoreOptions = false
+                },
+                sheetState = sheetState,
+                artist = selectArtist,
+                play = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Artist More Options Modal -> PlayArtist clicked")
+                        onLibraryAction(LibraryAction.PlayArtist(selectArtist))
+                        navigateToPlayer()
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showArtistMoreOptions = false
+                        }
+                    }
+                },
+                playNext = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Artist More Options Modal -> PlayArtistNext clicked")
+                        onLibraryAction(LibraryAction.PlayArtistNext(selectArtist))
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showArtistMoreOptions = false
+                        }
+                    }
+                },
+                shuffle = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Artist More Options Modal -> ShuffleArtist clicked")
+                        onLibraryAction(LibraryAction.ShuffleArtist(selectArtist))
+                        navigateToPlayer()
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showArtistMoreOptions = false
+                        }
+                    }
+                },
+                //addToPlaylist = {},
+                addToQueue = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Artist More Options Modal -> QueueArtist clicked")
+                        onLibraryAction(LibraryAction.QueueArtist(selectArtist))
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showArtistMoreOptions = false
+                        }
+                    }
+                },
+                onClose = {
+                    coroutineScope.launch {
+                        Log.i(TAG, "Hide sheet state")
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        Log.i(TAG, "set showBottomSheet to FALSE")
+                        if(!sheetState.isVisible) {
+                            showBottomSheet = false
+                            showArtistMoreOptions = false
+                        }
+                    }
+                },
+                context = "ArtistDetails",
+            )
+        }
+    }
 }
 
 @Composable
@@ -570,7 +927,6 @@ private fun LibraryCategoryTabs(
     libraryCategories: List<LibraryCategory>,
     selectedLibraryCategory: LibraryCategory,
     onLibraryCategorySelected: (LibraryCategory) -> Unit,
-    //modifier: Modifier = Modifier,
 ) {
     if (libraryCategories.isEmpty()) {
         return
@@ -628,23 +984,6 @@ private fun LibraryCategoryTabIndicator(
     )
 }
 
-/*@Composable
-private fun lastUpdated(updated: OffsetDateTime): String {
-    val duration = Duration.between(updated.toLocalDateTime(), LocalDateTime.now())
-    val days = duration.toDays().toInt()
-
-    return when {
-        days > 28 -> stringResource(R.string.updated_longer)
-        days >= 7 -> {
-            val weeks = days / 7
-            quantityStringResource(R.plurals.updated_weeks_ago, weeks, weeks)
-        }
-
-        days > 0 -> quantityStringResource(R.plurals.updated_days_ago, days, days)
-        else -> stringResource(R.string.updated_today)
-    }
-}*/
-
 @Preview
 @Composable
 private fun LibraryTopAppBarPreview() {
@@ -666,6 +1005,7 @@ private fun PreviewLibrary() {
         LibraryScreen(
             windowSizeClass = CompactWindowSizeClass,
             isLoading = false,
+
             libraryCategories = LibraryCategory.entries,
             selectedLibraryCategory = LibraryCategory.Songs,
             libraryAlbums = PreviewAlbums,
@@ -679,17 +1019,22 @@ private fun PreviewLibrary() {
                 PreviewArtists.size,
                 PreviewAlbums.size,
                 PreviewPlaylists.size),
+
+            selectSong = PreviewSongs[0],
+            selectAlbum = PreviewAlbums[1],
+            selectArtist = PreviewArtists[0],
+
             onLibraryAction = {},
             navigateToHome = {},
             navigateToLibrary = {},
+            navigateToPlayer = {},
+            navigateToSearch = {},
             navigateToSettings = {},
             navigateToAlbumDetails = {},
             navigateToArtistDetails = {},
-            navigateToPlaylistDetails = {},
-            navigateToGenreDetails = {},
             navigateToComposerDetails = {},
-            navigateToPlayer = {},
-            navigateToSearch = {},
+            navigateToGenreDetails = {},
+            navigateToPlaylistDetails = {},
         )
     }
 }

--- a/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/music/ui/library/LibraryScreen.kt
@@ -131,7 +131,7 @@ fun LibraryScreen(
     navigateToAlbumDetails: (Long) -> Unit,
     navigateToArtistDetails: (Long) -> Unit,
     navigateToComposerDetails: (ComposerInfo) -> Unit,
-    navigateToGenreDetails: (GenreInfo) -> Unit,
+    navigateToGenreDetails: (Long) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: () -> Unit,
     viewModel: LibraryViewModel = hiltViewModel()
@@ -224,7 +224,7 @@ private fun LibraryScreen(
     navigateToAlbumDetails: (Long) -> Unit,
     navigateToArtistDetails: (Long) -> Unit,
     navigateToComposerDetails: (ComposerInfo) -> Unit,
-    navigateToGenreDetails: (GenreInfo) -> Unit,
+    navigateToGenreDetails: (Long) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -372,7 +372,7 @@ private fun LibraryContent(
     navigateToAlbumDetails: (Long) -> Unit,
     navigateToArtistDetails: (Long) -> Unit,
     navigateToComposerDetails: (ComposerInfo) -> Unit,
-    navigateToGenreDetails: (GenreInfo) -> Unit,
+    navigateToGenreDetails: (Long) -> Unit,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: () -> Unit,
 ) {
@@ -501,7 +501,7 @@ private fun LibraryContent(
                         genres = libraryGenres,
                         navigateToGenreDetails = { genre: GenreInfo ->
                             Log.i(TAG, "Genre clicked: ${genre.name}")
-                            navigateToGenreDetails(genre)
+                            navigateToGenreDetails(genre.id)
                         },
                         onGenreMoreOptionsClick = { genre: GenreInfo ->
                             Log.i(TAG, "Genre More Option Clicked: ${genre.name}")
@@ -941,7 +941,7 @@ private fun LibraryContent(
                 goToGenre = {
                     coroutineScope.launch {
                         Log.i(TAG, "Genre More Options Modal -> Go To Genre clicked")
-                        navigateToGenreDetails(selectedGenre)
+                        navigateToGenreDetails(selectedGenre.id)
                         sheetState.hide()
                     }.invokeOnCompletion {
                         Log.i(TAG, "set showBottomSheet to FALSE; set GenreMoreOptions to FALSE")

--- a/app/src/main/java/com/example/music/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/library/LibraryViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.music.data.database.model.Song
 import com.example.music.domain.usecases.GetLibraryComposersUseCase
 import com.example.music.domain.usecases.GetLibraryPlaylistsUseCase
 import com.example.music.domain.usecases.GetAppPreferencesUseCase
@@ -14,8 +13,9 @@ import com.example.music.domain.model.ComposerInfo
 import com.example.music.domain.model.GenreInfo
 import com.example.music.domain.model.PlaylistInfo
 import com.example.music.domain.model.SongInfo
-//import com.example.music.domain.player.SongPlayer
 import com.example.music.data.util.combine
+import com.example.music.domain.usecases.GetAlbumDetailsV2
+import com.example.music.domain.usecases.GetArtistDetailsV2
 import com.example.music.domain.usecases.GetLibraryAlbumsV2
 import com.example.music.domain.usecases.GetLibraryArtistsV2
 import com.example.music.domain.usecases.GetLibraryGenresV2
@@ -27,10 +27,9 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-private const val TAG = "Library View Model"
 
 /** Changelog:
  *
@@ -43,6 +42,25 @@ private const val TAG = "Library View Model"
  * 7/22-23/2025 - Removed PlayerSong completely
  */
 
+private const val TAG = "Library View Model"
+
+data class LibraryScreenUiState(
+    val isLoading: Boolean = true,
+    val errorMessage: String? = null,
+    val libraryCategories: List<LibraryCategory> = emptyList(),
+    val selectedLibraryCategory: LibraryCategory = LibraryCategory.Playlists,
+    val libraryAlbums: List<AlbumInfo> = emptyList(),
+    val libraryArtists: List<ArtistInfo> = emptyList(),
+    val libraryComposers: List<ComposerInfo> = emptyList(),
+    val libraryGenres: List<GenreInfo> = emptyList(),
+    val libraryPlaylists: List<PlaylistInfo> = emptyList(),
+    val librarySongs: List<SongInfo> = emptyList(),
+    val totals: List<Int> = emptyList(),
+    val selectSong: SongInfo = SongInfo(),
+    val selectAlbum: AlbumInfo = AlbumInfo(),
+    val selectArtist: ArtistInfo = ArtistInfo()
+)
+
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
     getLibrarySongsV2: GetLibrarySongsV2,
@@ -53,6 +71,9 @@ class LibraryViewModel @Inject constructor(
     getLibraryAlbumsV2: GetLibraryAlbumsV2,
     getTotalCountsV2: GetTotalCountsV2,
     getAppPreferences: GetAppPreferencesUseCase,
+
+    private val getAlbumDetailsV2: GetAlbumDetailsV2,
+    private val getArtistDetailsV2: GetArtistDetailsV2,
     private val songController: SongController
 ) : ViewModel() {
     /* ------ Current running UI needs:  ------
@@ -93,7 +114,6 @@ class LibraryViewModel @Inject constructor(
     private val sortedGenres = getLibraryGenresUseCase("name", true)
         .shareIn(viewModelScope, SharingStarted.WhileSubscribed())*/
 
-
     /* ------ Objects used in previous iterations:  ------
     private val songs = songRepo.getAllSongs()
         .shareIn(viewModelScope, SharingStarted.WhileSubscribed())
@@ -110,7 +130,11 @@ class LibraryViewModel @Inject constructor(
 
     // Holds the sorting preferences saved in the data store
     //private val sortPrefs = getAppPreferences()
-    private val showBottomSheet = MutableStateFlow(false)
+
+    // Holds the selected items values to show in more options modals
+    private val selectedSong = MutableStateFlow<SongInfo?>(null)
+    private val selectedAlbum = MutableStateFlow<AlbumInfo?>(null)
+    private val selectedArtist = MutableStateFlow<ArtistInfo?>(null)
 
     // Holds our view state which the UI collects via [state]
     private val _state = MutableStateFlow(LibraryScreenUiState())
@@ -122,18 +146,15 @@ class LibraryViewModel @Inject constructor(
         get() = _state
 
     init {
+        Log.i(TAG, "init START")
         viewModelScope.launch {
-            Log.i(TAG, "viewModelScope launch start")
+            Log.i(TAG, "viewModelScope launch START")
             val counts = getTotalCountsV2()
 
-            // Combines the latest value from each of the flows, allowing us to generate a
-            // view state instance which only contains the latest values.
             combine(
+                refreshing,
                 libraryCategories,
                 selectedLibraryCategory,
-                refreshing,
-                showBottomSheet,
-//                appPreferences.appPreferencesFlow,
                 appPreferencesFlow,
                 //getLibraryAlbumsUseCase("title", true),//sortedAlbums,
                 //getLibraryAlbumsV2("title", true),
@@ -150,6 +171,9 @@ class LibraryViewModel @Inject constructor(
 
                 //getLibrarySongsUseCase("title", true),//sortedSongs,
                 //getLibrarySongsV2("title", true),
+                selectedSong,
+                selectedAlbum,
+                selectedArtist,
             ) {
 
             /*combine(
@@ -175,10 +199,9 @@ class LibraryViewModel @Inject constructor(
                     getLibrarySongsUseCase(values.songSortOrder.name, values.isSongAsc)//sortedSongs,
                 },
             ){*/
+                refreshing,
                 libraryCategories,
                 libraryCategory,
-                refreshing,
-                showBottomSheet,
                 appPreferences,
                 //libraryAlbums,
                 //libraryArtists,
@@ -186,12 +209,15 @@ class LibraryViewModel @Inject constructor(
                 //libraryGenres,
                 libraryPlaylists,
                 //librarySongs,
+                selectSong,
+                selectAlbum,
+                selectArtist
                 ->
 
-                Log.i(TAG, "LibraryScreenUiState:")
-                Log.i(TAG, "isLoading: $refreshing")
-                Log.i(TAG, "libraryCategories: $libraryCategories")
-                Log.i(TAG, "selectedLibraryCategory: $libraryCategory")
+                Log.i(TAG, "LibraryScreenUiState combine START:\n" +
+                    "isLoading: $refreshing\n" +
+                    "libraryCategories: $libraryCategories\n" +
+                    "selectedLibraryCategory: $libraryCategory\n")
                 var libraryAlbums: List<AlbumInfo> = emptyList()
                 var libraryArtists: List<ArtistInfo> = emptyList()
                 //var libraryComposers: List<ComposerInfo> = emptyList()
@@ -239,7 +265,9 @@ class LibraryViewModel @Inject constructor(
                     libraryPlaylists = libraryPlaylists,
                     librarySongs = librarySongs,
                     totals = counts,
-                    showBottomModal = showBottomSheet,
+                    selectSong = selectSong ?: SongInfo(),
+                    selectAlbum = selectAlbum ?: AlbumInfo(),
+                    selectArtist = selectArtist ?: ArtistInfo()
                 )
             }.catch { throwable ->
                 Log.i(TAG, "Error Caught: ${throwable.message}")
@@ -253,8 +281,8 @@ class LibraryViewModel @Inject constructor(
                 _state.value = it
             }
         }
-
         refresh(force = false)
+        Log.i(TAG, "init END")
     }
 
     fun refresh(force: Boolean = true) {
@@ -264,7 +292,6 @@ class LibraryViewModel @Inject constructor(
             runCatching {
                 Log.i(TAG, "Refresh runCatching")
                 refreshing.value = true
-                //podcastsRepository.updatePodcasts(force)
             }.onFailure {
                 Log.i(TAG, "$it ::: runCatching failed (not sure what this means)")
             }
@@ -275,15 +302,30 @@ class LibraryViewModel @Inject constructor(
     }
 
     fun onLibraryAction(action: LibraryAction) {
+        Log.i(TAG, "onLibraryAction - $action")
         when (action) {
             is LibraryAction.LibraryCategorySelected -> onLibraryCategorySelected(action.libraryCategory)
-            //maybe filtering / sorting selections added here?
-            is LibraryAction.PlaySongs -> onPlaySongs(action.songs)
+            is LibraryAction.AlbumMoreOptionsClicked -> onAlbumMoreOptionsClicked(action.album)
+            is LibraryAction.ArtistMoreOptionsClicked -> onArtistMoreOptionsClicked(action.artist)
+            is LibraryAction.SongMoreOptionsClicked -> onSongMoreOptionsClicked(action.song)
+
+            is LibraryAction.PlaySong -> onPlaySong(action.song)
+            is LibraryAction.PlaySongNext -> onPlaySongNext(action.song)
             is LibraryAction.QueueSong -> onQueueSong(action.song)
+
+            is LibraryAction.PlaySongs -> onPlaySongs(action.songs)
             is LibraryAction.QueueSongs -> onQueueSongs(action.songs)
-            is LibraryAction.ShowModal -> onShowModal(action.libraryCategory, action.isModalOpen)
             is LibraryAction.ShuffleSongs -> onShuffleSongs(action.songs)
-            is LibraryAction.SongClicked -> onSongClicked(action.song)
+
+            is LibraryAction.PlayAlbum -> onPlayAlbum(action.album)
+            is LibraryAction.PlayAlbumNext -> onPlayAlbumNext(action.album)
+            is LibraryAction.ShuffleAlbum -> onShuffleAlbum(action.album)
+            is LibraryAction.QueueAlbum -> onQueueAlbum(action.album)
+
+            is LibraryAction.PlayArtist -> onPlayArtist(action.artist)
+            is LibraryAction.PlayArtistNext -> onPlayArtistNext(action.artist)
+            is LibraryAction.ShuffleArtist -> onShuffleArtist(action.artist)
+            is LibraryAction.QueueArtist -> onQueueArtist(action.artist)
         }
     }
 
@@ -292,36 +334,101 @@ class LibraryViewModel @Inject constructor(
         refresh()
     }
 
-    private fun onPlaySongs(songs: List<SongInfo>) {
-        Log.i(TAG, "onPlaySongs -> ${songs.size}")
-        songController.play(songs)
+    private fun onAlbumMoreOptionsClicked(album: AlbumInfo) {
+        Log.i(TAG, "onAlbumMoreOptionClick -> ${album.title}")
+        selectedAlbum.value = album
+    }
+    private fun onArtistMoreOptionsClicked(artist: ArtistInfo) {
+        Log.i(TAG, "onArtistMoreOptionClick -> ${artist.name}")
+        selectedArtist.value = artist
+    }
+    private fun onSongMoreOptionsClicked(song: SongInfo) {
+        Log.i(TAG, "onSongMoreOptionClick -> ${song.title}")
+        selectedSong.value = song
     }
 
+    private fun onPlaySong(song: SongInfo) {
+        Log.i(TAG, "onPlaySong - ${song.title}")
+        songController.play(song)
+    }
+    private fun onPlaySongNext(song: SongInfo) {
+        Log.i(TAG, "onPlaySongNext - ${song.title}")
+        songController.addToQueueNext(song)
+    }
     private fun onQueueSong(song: SongInfo) {
         Log.i(TAG, "onQueueSong -> ${song.title}")
         songController.addToQueue(song)
     }
 
+    private fun onPlaySongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onPlaySongs -> ${songs.size}")
+        songController.play(songs)
+    }
+    private fun onShuffleSongs(songs: List<SongInfo>) {
+        Log.i(TAG, "onShuffleSongs -> ${songs.size}")
+        songController.shuffle(songs)
+    }
     private fun onQueueSongs(songs: List<SongInfo>) {
         Log.i(TAG, "onQueueSongs -> ${songs.size}")
         songController.addToQueue(songs)
     }
 
-    private fun onShowModal(libraryCategory: LibraryCategory, isModalOpen: Boolean) {
-        //what is the purpose of this function?
-        // want to know which screen on library is being shown
-        // want to have a way for contexted modal? how would this accomplish it tho
-        showBottomSheet.value = isModalOpen
+    private fun onPlayAlbum(album: AlbumInfo) {
+        Log.i(TAG, "onPlaySongs -> ${album.title}")
+        viewModelScope.launch {
+            val songs = getAlbumDetailsV2(album.id).first().songs
+            songController.play(songs)
+        }
+    }
+    private fun onPlayAlbumNext(album: AlbumInfo) {
+        Log.i(TAG, "onPlayAlbumNext -> ${album.title}")
+        viewModelScope.launch {
+            val songs = getAlbumDetailsV2(album.id).first().songs
+            songController.addToQueueNext(songs)
+        }
+    }
+    private fun onShuffleAlbum(album: AlbumInfo) {
+        Log.i(TAG, "onShuffleAlbum -> ${album.title}")
+        viewModelScope.launch {
+            val songs = getAlbumDetailsV2(album.id).first().songs
+            songController.shuffle(songs)
+        }
+    }
+    private fun onQueueAlbum(album: AlbumInfo) {
+        Log.i(TAG, "onQueueAlbum -> ${album.title}")
+        viewModelScope.launch {
+            val songs = getAlbumDetailsV2(album.id).first().songs
+            songController.addToQueue(songs)
+        }
     }
 
-    private fun onShuffleSongs(songs: List<SongInfo>) {
-        Log.i(TAG, "onShuffleSongs -> ${songs.size}")
-        songController.shuffle(songs)
+    private fun onPlayArtist(artist: ArtistInfo) {
+        Log.i(TAG, "onPlayArtist -> ${artist.name}")
+        viewModelScope.launch {
+            val songs = getArtistDetailsV2(artist.id).first().songs
+            songController.play(songs)
+        }
     }
-
-    private fun onSongClicked(song: SongInfo) {
-        Log.i(TAG, "onSongClicked -> ${song.title}")
-        songController.play(song)
+    private fun onPlayArtistNext(artist: ArtistInfo) {
+        Log.i(TAG, "onPlayArtistNext -> ${artist.name}")
+        viewModelScope.launch {
+            val songs = getArtistDetailsV2(artist.id).first().songs
+            songController.addToQueueNext(songs)
+        }
+    }
+    private fun onShuffleArtist(artist: ArtistInfo) {
+        Log.i(TAG, "onShuffleArtist -> ${artist.name}")
+        viewModelScope.launch {
+            val songs = getArtistDetailsV2(artist.id).first().songs
+            songController.shuffle(songs)
+        }
+    }
+    private fun onQueueArtist(artist: ArtistInfo) {
+        Log.i(TAG, "onQueueArtist -> ${artist.name}")
+        viewModelScope.launch {
+            val songs = getArtistDetailsV2(artist.id).first().songs
+            songController.addToQueue(songs)
+        }
     }
 }
 
@@ -332,28 +439,29 @@ enum class LibraryCategory {
 @Immutable
 sealed interface LibraryAction {
     data class LibraryCategorySelected(val libraryCategory: LibraryCategory) : LibraryAction
+    data class AlbumMoreOptionsClicked(val album: AlbumInfo) : LibraryAction
+    data class ArtistMoreOptionsClicked(val artist: ArtistInfo) : LibraryAction
+    data class SongMoreOptionsClicked(val song: SongInfo) : LibraryAction
+
+    data class PlaySong(val song: SongInfo) : LibraryAction // songMO-play
+    data class PlaySongNext(val song: SongInfo) : LibraryAction // songMO-playNext
+    data class QueueSong(val song: SongInfo) : LibraryAction // songMO-queue
+
     data class PlaySongs(val songs: List<SongInfo>) : LibraryAction
-    data class QueueSong(val song: SongInfo) : LibraryAction
     data class QueueSongs(val songs: List<SongInfo>) : LibraryAction
-    data class ShowModal(val libraryCategory: LibraryCategory, val isModalOpen: Boolean) : LibraryAction
     data class ShuffleSongs(val songs: List<SongInfo>) : LibraryAction
-    data class SongClicked(val song: SongInfo) : LibraryAction
+
+    data class PlayAlbum(val album: AlbumInfo) : LibraryAction
+    data class PlayAlbumNext(val album: AlbumInfo) : LibraryAction
+    data class ShuffleAlbum(val album: AlbumInfo) : LibraryAction
+    data class QueueAlbum(val album: AlbumInfo) : LibraryAction
+
+    data class PlayArtist(val artist: ArtistInfo) : LibraryAction
+    data class PlayArtistNext(val artist: ArtistInfo) : LibraryAction
+    data class ShuffleArtist(val artist: ArtistInfo) : LibraryAction
+    data class QueueArtist(val artist: ArtistInfo) : LibraryAction
 }
 
-data class LibraryScreenUiState(
-    val isLoading: Boolean = true,
-    val errorMessage: String? = null,
-    val libraryCategories: List<LibraryCategory> = emptyList(),
-    val selectedLibraryCategory: LibraryCategory = LibraryCategory.Playlists,
-    val libraryAlbums: List<AlbumInfo> = emptyList(),
-    val libraryArtists: List<ArtistInfo> = emptyList(),
-    val libraryComposers: List<ComposerInfo> = emptyList(),
-    val libraryGenres: List<GenreInfo> = emptyList(),
-    val libraryPlaylists: List<PlaylistInfo> = emptyList(),
-    val librarySongs: List<SongInfo> = emptyList(),
-    val totals: List<Int> = emptyList(),
-    val showBottomModal: Boolean = false,
-)
 /* sealed interface LibraryScreenUiState {
     data object Loading : LibraryScreenUiState
     data class Ready(

--- a/app/src/main/java/com/example/music/ui/library/album/Albums.kt
+++ b/app/src/main/java/com/example/music/ui/library/album/Albums.kt
@@ -143,7 +143,6 @@ fun LazyGridScope.albumItems(
         if(showBottomSheet) {
             LibrarySortSelectionBottomModal(
                 onDismissRequest = { showBottomSheet = false },
-                coroutineScope = coroutineScope,
                 libraryCategory = LibraryCategory.Albums,
             )
         }

--- a/app/src/main/java/com/example/music/ui/library/album/Albums.kt
+++ b/app/src/main/java/com/example/music/ui/library/album/Albums.kt
@@ -1,6 +1,7 @@
 package com.example.music.ui.library.album
 
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -29,11 +30,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -49,13 +45,13 @@ import com.example.music.designsys.component.AlbumImage
 import com.example.music.designsys.theme.MusicShapes
 import com.example.music.domain.testing.PreviewAlbums
 import com.example.music.domain.model.AlbumInfo
-import com.example.music.ui.library.LibraryCategory
-import com.example.music.ui.shared.LibrarySortSelectionBottomModal
 import com.example.music.ui.theme.MusicTheme
 import com.example.music.util.fullWidthItem
 import com.example.music.util.quantityStringResource
 import kotlinx.coroutines.CoroutineScope
 
+private const val TAG = "Library Albums"
+private val FEATURED_ALBUM_IMAGE_SIZE_DP = 160.dp
 /**
  * Album Items Lazy List Scope Generator.
  * Provides header item with a count of the albums given, and
@@ -63,49 +59,13 @@ import kotlinx.coroutines.CoroutineScope
  */
 fun LazyListScope.albumItems(
     albums: List<AlbumInfo>,
-    coroutineScope: CoroutineScope,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
+    onMoreOptionsClick: () -> Unit,
+    onSortClick: () -> Unit,
+    onSelectClick: () -> Unit
 ) {
+    Log.i(TAG, "Lazy List START")
     item {
-        Text(
-            text = """\s[a-z]""".toRegex().replace(
-                quantityStringResource(R.plurals.albums, albums.size, albums.size)
-            ) {
-                it.value.uppercase()
-            },
-            //text = quantityStringResource(R.plurals.albums, albums.size, albums.size),
-            textAlign = TextAlign.Left,
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(8.dp)
-        )
-    }
-
-    items(albums) { item ->
-        AlbumItemRow(
-            album = item,
-            coroutineScope = coroutineScope,
-            navigateToAlbumDetails = navigateToAlbumDetails,
-        )
-    }
-}
-
-/**
- * Album Items Lazy Grid Scope Generator.
- * Provides header item with a count of the albums given, and
- * generates a grid of albums, with each album item shown as a card.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-fun LazyGridScope.albumItems(
-    albums: List<AlbumInfo>,
-    coroutineScope: CoroutineScope,
-    navigateToAlbumDetails: (AlbumInfo) -> Unit,
-    //modifier: Modifier = Modifier,
-) {
-
-    // section1: header
-    fullWidthItem {
-        // ******** var  for modal remember here
-        var showBottomSheet by remember { mutableStateOf(false) }
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
@@ -120,10 +80,9 @@ fun LazyGridScope.albumItems(
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.padding(8.dp).weight(1f,true)
             )
-            //Spacer(Modifier.weight(1f,true))
 
             // sort icon
-            IconButton(onClick={showBottomSheet = true}) {
+            IconButton(onClick = onSortClick) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.Sort,//want this to be sort icon
                     contentDescription = stringResource(R.string.icon_sort),
@@ -132,7 +91,7 @@ fun LazyGridScope.albumItems(
             }
 
             // multi-select icon
-            IconButton(onClick={/* filter */}) {
+            IconButton(onClick = onSelectClick) {
                 Icon(
                     imageVector = Icons.Filled.Checklist,//want this to be multi select icon
                     contentDescription = stringResource(R.string.icon_multi_select),
@@ -140,27 +99,83 @@ fun LazyGridScope.albumItems(
                 )
             }
         }
-        if(showBottomSheet) {
-            LibrarySortSelectionBottomModal(
-                onDismissRequest = { showBottomSheet = false },
-                libraryCategory = LibraryCategory.Albums,
+    }
+
+    items(albums) { album ->
+        AlbumItemRow(
+            album = album,
+            navigateToAlbumDetails = navigateToAlbumDetails,
+            onMoreOptionsClick = onMoreOptionsClick,
+            modifier = Modifier.fillParentMaxWidth(),
+        )
+    }
+}
+
+/**
+ * Album Items Lazy Grid Scope Generator.
+ * Provides header item with a count of the albums given, and
+ * generates a grid of albums, with each album item shown as a card.
+ */
+fun LazyGridScope.albumItems(
+    albums: List<AlbumInfo>,
+    navigateToAlbumDetails: (AlbumInfo) -> Unit,
+    onAlbumMoreOptionsClick: (AlbumInfo) -> Unit,
+    onSortClick: () -> Unit = {},
+    onSelectClick: () -> Unit = {},
+) {
+    Log.i(TAG, "Lazy Grid START")
+    fullWidthItem {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = """\s[a-z]""".toRegex().replace(
+                    quantityStringResource(R.plurals.albums, albums.size, albums.size)
+                ) {
+                    it.value.uppercase()
+                },
+                textAlign = TextAlign.Left,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(8.dp).weight(1f,true)
             )
+
+            // sort icon
+            IconButton(onClick = onSortClick) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.Sort,//want this to be sort icon
+                    contentDescription = stringResource(R.string.icon_sort),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+
+            // multi-select icon
+            IconButton(onClick = onSelectClick) {
+                Icon(
+                    imageVector = Icons.Filled.Checklist,//want this to be multi select icon
+                    contentDescription = stringResource(R.string.icon_multi_select),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
         }
     }
 
     items(
         albums,
         span = { GridItemSpan(1) }
-    ){ item ->
+    ){ album ->
         Surface(
             shape = MaterialTheme.shapes.large,
             color = Color.Transparent,
             modifier = Modifier,
-            onClick = { navigateToAlbumDetails(item) }
+            onClick = { navigateToAlbumDetails(album) }
         ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally){
-                AlbumItemBoxHeader(item)
-                AlbumItemBoxFooter(item)
+                AlbumItemBoxHeader(album)
+                AlbumItemBoxFooter(
+                    album = album, 
+                    onMoreOptionsClick = { onAlbumMoreOptionsClick(album) }
+                )
             }
         }
     }
@@ -173,7 +188,7 @@ fun LazyGridScope.albumItems(
 private fun AlbumItemRow(
     album: AlbumInfo,
     navigateToAlbumDetails: (AlbumInfo) -> Unit,
-    coroutineScope: CoroutineScope,
+    onMoreOptionsClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(modifier = Modifier.padding(4.dp)){
@@ -218,20 +233,9 @@ private fun AlbumItemRow(
                     }
                 }
 
-                IconButton( // more options button
-                    //modifier = Modifier.padding(0.dp),
-                    onClick = { /*
-                        coroutineScope.launch {
-                            AlbumMoreOptionsBottomModal(
-                                onDismissRequest = {},
-                                coroutineScope = coroutineScope,
-                                album = album,
-                                navigateToAlbumDetails = navigateToAlbumDetails,
-                            )
-                        }*/
-                    }, // pretty sure I need this to be context dependent, might pass something within savedStateHandler? within viewModel??
-                ) {
-                    Icon( // more options icon
+                // More Options btn
+                IconButton(onClick = onMoreOptionsClick) {
+                    Icon(
                         imageVector = Icons.Default.MoreVert,
                         contentDescription = stringResource(R.string.icon_more),
                         tint = MaterialTheme.colorScheme.onPrimaryContainer,
@@ -242,11 +246,10 @@ private fun AlbumItemRow(
     }
 }
 
-private val FEATURED_ALBUM_IMAGE_SIZE_DP = 160.dp
-
 @Composable
 private fun AlbumItemBoxFooter(
     album: AlbumInfo,
+    onMoreOptionsClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -261,11 +264,7 @@ private fun AlbumItemBoxFooter(
             modifier = Modifier.padding(4.dp).weight(1f,true)
         )
 
-        //Spacer(Modifier.weight(1f))
-
-        IconButton(
-            onClick = {  },
-        ) {
+        IconButton(onClick = onMoreOptionsClick) {
             Icon(
                 imageVector = Icons.Default.MoreVert,
                 contentDescription = stringResource(R.string.icon_more),
@@ -309,52 +308,15 @@ private fun AlbumItemBoxHeader(
     }
 }
 
-@Composable
-private fun TopAlbumRowItem(
-    albumName: String,
-    albumImage: Uri,
-    //isFollowed: Boolean,
-    modifier: Modifier = Modifier,
-    //onToggleFollowClicked: () -> Unit,
-) {
-    Column(
-        modifier.semantics(mergeDescendants = true) {}
-    ) {
-        Box(
-            Modifier
-                .fillMaxWidth()
-                .aspectRatio(1f)
-                .align(Alignment.CenterHorizontally)
-        ) {
-            AlbumImage(
-                albumImage = albumImage,
-                contentDescription = albumName,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clip(MaterialTheme.shapes.medium),
-            )
-        }
-
-        Text(
-            text = albumName,
-            style = MaterialTheme.typography.bodyMedium,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier
-                .padding(top = 8.dp)
-                .fillMaxWidth()
-        )
-    }
-}
-
-//@Preview
+@Preview
 @Composable
 fun AlbumItemPreviewRow() {
     MusicTheme {
         AlbumItemRow(
             album = PreviewAlbums[0],
             navigateToAlbumDetails = {},
-            coroutineScope = rememberCoroutineScope(),
+            onMoreOptionsClick = {},
+            modifier = Modifier
         )
     }
 }
@@ -372,7 +334,7 @@ fun AlbumItemPreviewBox() {
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     AlbumItemBoxHeader(PreviewAlbums[0])
-                    AlbumItemBoxFooter(PreviewAlbums[0])
+                    AlbumItemBoxFooter(PreviewAlbums[0], {})
                 }
             }
 
@@ -384,7 +346,7 @@ fun AlbumItemPreviewBox() {
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     AlbumItemBoxHeader(PreviewAlbums[3])
-                    AlbumItemBoxFooter(PreviewAlbums[3])
+                    AlbumItemBoxFooter(PreviewAlbums[3], {})
                 }
             }
         }

--- a/app/src/main/java/com/example/music/ui/library/artist/Artists.kt
+++ b/app/src/main/java/com/example/music/ui/library/artist/Artists.kt
@@ -139,7 +139,6 @@ fun LazyGridScope.artistItems(
         if(showBottomSheet) {
             LibrarySortSelectionBottomModal(
                 onDismissRequest = { showBottomSheet = false },
-                coroutineScope = coroutineScope,
                 libraryCategory = LibraryCategory.Artists,
             )
         }
@@ -208,7 +207,6 @@ fun LazyGridScope.artistItems(
         if(showBottomSheet) {
             LibrarySortSelectionBottomModal(
                 onDismissRequest = { showBottomSheet = false },
-                coroutineScope = coroutineScope,
                 libraryCategory = LibraryCategory.Artists,
             )
         }

--- a/app/src/main/java/com/example/music/ui/library/artist/Artists.kt
+++ b/app/src/main/java/com/example/music/ui/library/artist/Artists.kt
@@ -65,7 +65,7 @@ private const val TAG = "Library Artists"
 fun LazyListScope.artistItems(
     artists: List<ArtistInfo>,
     navigateToArtistDetails: (ArtistInfo) -> Unit,
-    onArtistMoreOptionsClick: () -> Unit,
+    onArtistMoreOptionsClick: (ArtistInfo) -> Unit,
     onSortClick: () -> Unit,
     onSelectClick: () -> Unit
 ) {

--- a/app/src/main/java/com/example/music/ui/library/artist/Artists.kt
+++ b/app/src/main/java/com/example/music/ui/library/artist/Artists.kt
@@ -83,9 +83,7 @@ fun LazyListScope.artistItems(
                 },
                 textAlign = TextAlign.Left,
                 style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier
-                    .padding(8.dp)
-                    .weight(1f, true)
+                modifier = Modifier.padding(8.dp).weight(1f, true)
             )
 
             // Sort btn
@@ -145,9 +143,7 @@ fun LazyGridScope.artistItems(
                 },
                 textAlign = TextAlign.Left,
                 style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier
-                    .padding(8.dp)
-                    .weight(1f, true)
+                modifier = Modifier.padding(8.dp).weight(1f, true)
             )
 
             // Sort btn
@@ -195,7 +191,7 @@ fun LazyGridScope.artistItems(
     onSortClick: () -> Unit = {},
     onSelectClick: () -> Unit = {},
 ) {
-    Log.i(TAG, "Lazy Grid START")
+    Log.i(TAG, "Lazy Grid with Sticky Headers START")
     //section 1: header
     fullWidthItem{
         Row(
@@ -351,16 +347,14 @@ private fun ArtistListItemIcon(
     Box(
         modifier = modifier
             .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.3f))
-    ){
+    ) {
         Text(
             text = artist[0].toString(),
             minLines = 1,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.primary,
             style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(vertical = 15.dp),
+            modifier = Modifier.fillMaxSize().padding(vertical = 15.dp),
         )
     }
 }

--- a/app/src/main/java/com/example/music/ui/library/composer/Composers.kt
+++ b/app/src/main/java/com/example/music/ui/library/composer/Composers.kt
@@ -127,7 +127,6 @@ fun LazyGridScope.composerItems(
         if(showBottomSheet) {
             LibrarySortSelectionBottomModal(
                 onDismissRequest = { showBottomSheet = false },
-                coroutineScope = coroutineScope,
                 libraryCategory = LibraryCategory.Composers,
             )
         }

--- a/app/src/main/java/com/example/music/ui/library/genre/Genres.kt
+++ b/app/src/main/java/com/example/music/ui/library/genre/Genres.kt
@@ -127,7 +127,6 @@ fun LazyGridScope.genreItems(
         if(showBottomSheet) {
             LibrarySortSelectionBottomModal(
                 onDismissRequest = { showBottomSheet = false },
-                coroutineScope = coroutineScope,
                 libraryCategory = LibraryCategory.Genres,
             )
         }

--- a/app/src/main/java/com/example/music/ui/library/genre/Genres.kt
+++ b/app/src/main/java/com/example/music/ui/library/genre/Genres.kt
@@ -1,6 +1,8 @@
 package com.example.music.ui.library.genre
 
+import android.util.Log
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,9 +10,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.Checklist
@@ -44,52 +48,82 @@ import com.example.music.util.fullWidthItem
 import com.example.music.util.quantityStringResource
 import kotlinx.coroutines.CoroutineScope
 
+private const val TAG = "Library Genres"
+
 /**
  * Genre Items Lazy List Scope Generator.
  * Provides header item with a count of the genres given, and
  * generates a column of genres, with each genre item shown as a row.
  */
-/*fun LazyListScope.genreItems(
+fun LazyListScope.genreItems(
     genres: List<GenreInfo>,
     navigateToGenreDetails: (GenreInfo) -> Unit,
+    onGenreMoreOptionsClick: (GenreInfo) -> Unit,
+    onSortClick: () -> Unit,
+    onSelectClick: () -> Unit,
 ) {
+    Log.i(TAG, "Lazy List START")
     item {
-        Text(
-            text = """\s[a-z]""".toRegex().replace(
-                quantityStringResource(R.plurals.genres, genres.size, genres.size)
-            ) {
-                it.value[1].uppercase()
-            },
-            textAlign = TextAlign.Left,
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(8.dp)
-        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = """\s[a-z]""".toRegex().replace(
+                    quantityStringResource(R.plurals.genres, genres.size, genres.size)
+                ) {
+                    it.value.uppercase()
+                },
+                textAlign = TextAlign.Left,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(8.dp).weight(1f, true)
+            )
+        }
+
+        // Sort btn
+        IconButton(onClick = onSortClick) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.Sort,
+                contentDescription = stringResource(R.string.icon_sort),
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+
+        // Multi-Select btn
+        IconButton(onClick = onSelectClick) {
+            Icon(
+                imageVector = Icons.Filled.Checklist,
+                contentDescription = stringResource(R.string.icon_multi_select),
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
     }
 
-    items(genres) { item ->
+    items(genres) { genre ->
         GenreListItem(
-            genre = item,
+            genre = genre,
             navigateToGenreDetails = navigateToGenreDetails,
+            onMoreOptionsClick = { onGenreMoreOptionsClick(genre) },
             modifier = Modifier.fillParentMaxWidth()
         )
     }
-}*/
+}
 
 /**
  * Genre Items Lazy Grid Scope Generator.
  * Provides header item with a count of the genres given, and
  * generates a column of genres, with each genre item shown as a row.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 fun LazyGridScope.genreItems(
     genres: List<GenreInfo>,
-    coroutineScope: CoroutineScope,
     navigateToGenreDetails: (GenreInfo) -> Unit,
+    onGenreMoreOptionsClick: (GenreInfo) -> Unit,
+    onSortClick: () -> Unit,
+    onSelectClick: () -> Unit,
 ) {
+    Log.i(TAG, "Lazy Grid START")
     // section1: header
     fullWidthItem {
-        // ******** var  for modal remember here
-        var showBottomSheet by remember { mutableStateOf(false) }
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
@@ -104,41 +138,35 @@ fun LazyGridScope.genreItems(
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.padding(8.dp).weight(1f,true)
             )
-            //Spacer(Modifier.weight(1f,true))
 
-            // sort icon
-            IconButton(onClick= { showBottomSheet = true } ) {
+            // Sort btn
+            IconButton(onClick = onSortClick) {
                 Icon(
-                    imageVector = Icons.AutoMirrored.Filled.Sort,//want this to be sort icon
+                    imageVector = Icons.AutoMirrored.Filled.Sort,
                     contentDescription = stringResource(R.string.icon_sort),
                     tint = MaterialTheme.colorScheme.onPrimaryContainer,
                 )
             }
 
-            // multi-select icon
-            IconButton(onClick={/* filter */}) {
+            // Multi-Select btn
+            IconButton(onClick = onSelectClick) {
                 Icon(
-                    imageVector = Icons.Filled.Checklist,//want this to be multi select icon
+                    imageVector = Icons.Filled.Checklist,
                     contentDescription = stringResource(R.string.icon_multi_select),
                     tint = MaterialTheme.colorScheme.onPrimaryContainer,
                 )
             }
-        }
-        if(showBottomSheet) {
-            LibrarySortSelectionBottomModal(
-                onDismissRequest = { showBottomSheet = false },
-                libraryCategory = LibraryCategory.Genres,
-            )
         }
     }
 
     items(
         genres,
         span = { GridItemSpan(maxLineSpan) }
-    ) { item ->
+    ) { genre ->
         GenreListItem(
-            genre = item,
-            navigateToGenreDetails = navigateToGenreDetails,
+            genre = genre,
+            navigateToGenreDetails =  { navigateToGenreDetails(genre) },
+            onMoreOptionsClick = { onGenreMoreOptionsClick(genre) },
             modifier = Modifier.fillMaxWidth()
         )
     }
@@ -148,37 +176,37 @@ fun LazyGridScope.genreItems(
 private fun GenreListItem(
     genre: GenreInfo,
     navigateToGenreDetails: (GenreInfo) -> Unit,
+    onMoreOptionsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier.padding(4.dp)) { //outermost layer with padding of 4 for separation between other song list items
+    Box(modifier = modifier.padding(4.dp)) {
         Surface(
-            //second most layer, contains onclick action and background color
             shape = MaterialTheme.shapes.large,
-            //color = MaterialTheme.colorScheme.background,
-            color = MaterialTheme.colorScheme.surfaceContainer,
-            onClick = { navigateToGenreDetails(genre) }, //this is how navigateToPlayer should be used for each song ListItem, as the passed in onClick event
+            color = MaterialTheme.colorScheme.surfaceContainer, //MaterialTheme.colorScheme.background,
+            onClick = { navigateToGenreDetails(genre) },
         ) {
-            GenreListItemRow( //design content of song list item
+            GenreListItemRow(
                 genre = genre,
+                onMoreOptionsClick = onMoreOptionsClick,
                 modifier = modifier//.padding(4.dp),
             )
         }
     }
 }
 
-
 @Composable
 private fun GenreListItemRow(
     genre: GenreInfo,
+    onMoreOptionsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row( //third layer, contains layout logic and information for content
+    Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
     ) {
 
         GenreListItemIcon(
-            genre = genre.name, //placeholder
+            genre = genre.name,
             modifier = Modifier
                 .size(56.dp)
                 .clip(MaterialTheme.shapes.small)
@@ -194,32 +222,22 @@ private fun GenreListItemRow(
                 modifier = Modifier.padding(vertical = 2.dp, horizontal = 10.dp)
             )
             Row(
+                horizontalArrangement = Arrangement.Start,
                 modifier = modifier.padding(horizontal = 10.dp)
             ) {
-                /*if (genre.albumCount != null) { //if showArtistName is true
-                    Text(
-                        text = quantityStringResource(R.plurals.albums, genre.albumCount!!, genre.albumCount!!),
-                        maxLines = 1,
-                        minLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.padding(vertical = 2.dp),
-                    )
-                }*/
                 Text(
                     text = quantityStringResource(R.plurals.songs, genre.songCount, genre.songCount),
                     maxLines = 1,
+                    minLines = 1,
                     style = MaterialTheme.typography.bodySmall,
                     modifier = Modifier.padding(vertical = 2.dp),
                 )
             }
         }
 
-        IconButton( //more options button
-            //modifier = Modifier.padding(0.dp),
-            onClick = {  }, //pretty sure I need this to be context dependent, might pass something within savedStateHandler? within viewModel??
-        ) {
-            Icon( //more options icon
+        // More Options btn
+        IconButton(onClick = onMoreOptionsClick) {
+            Icon(
                 imageVector = Icons.Default.MoreVert,
                 contentDescription = stringResource(R.string.icon_more),
                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
@@ -236,7 +254,10 @@ private fun GenreListItemIcon(
     genre: String,
     modifier: Modifier = Modifier
 ) {
-    Box(modifier = modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.3f))){
+    Box(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.3f))
+    ) {
         Text(
             text = genre[0].toString(),
             minLines = 1,
@@ -254,7 +275,9 @@ fun PreviewGenreItem() {
     MusicTheme {
         GenreListItem(
             genre = PreviewGenres[0],
-            navigateToGenreDetails = {}
+            navigateToGenreDetails = {},
+            onMoreOptionsClick = {},
+            modifier = Modifier,
         )
     }
 }

--- a/app/src/main/java/com/example/music/ui/library/playlist/Playlists.kt
+++ b/app/src/main/java/com/example/music/ui/library/playlist/Playlists.kt
@@ -211,8 +211,7 @@ fun LazyGridScope.playlistItems(
                         showBottomSheet = false
                         //showSheet = showBottomSheet
                         showContext = false
-                   },
-                    coroutineScope = coroutineScope,
+                    },
                     libraryCategory = LibraryCategory.Playlists,
                 )
             }

--- a/app/src/main/java/com/example/music/ui/library/playlist/Playlists.kt
+++ b/app/src/main/java/com/example/music/ui/library/playlist/Playlists.kt
@@ -502,7 +502,7 @@ fun PlaylistMoreOptionsBottomModal(
 
             // action items, shown items are dependent on this being a song item
             songActions.forEach { item ->
-                ActionOptionRow(item)
+                ActionOptionRow(item.first, item.second)
                 /*Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth().padding(8.dp).clickable { item.action }
@@ -525,7 +525,7 @@ fun PlaylistMoreOptionsBottomModal(
             navActions.add( Pair(ActionItem( "Go to Playlist", Icons.AutoMirrored.Outlined.PlaylistAddCheck, R.string.icon_playlist), {} ) )
 
             navActions.forEach { item ->
-                ActionOptionRow(item)
+                ActionOptionRow(item.first, item.second)
                 /*Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth().padding(8.dp).clickable { item.action }

--- a/app/src/main/java/com/example/music/ui/library/song/Songs.kt
+++ b/app/src/main/java/com/example/music/ui/library/song/Songs.kt
@@ -1,17 +1,36 @@
 package com.example.music.ui.library.song
 
 import android.util.Log
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Sort
+import androidx.compose.material.icons.filled.Checklist
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.example.music.R
+import com.example.music.designsys.theme.MusicShapes
 import com.example.music.domain.model.SongInfo
 import com.example.music.ui.shared.SongListItem
 import com.example.music.util.fullWidthItem
+import com.example.music.util.quantityStringResource
 
 /** Changelog:
  *
@@ -44,10 +63,11 @@ fun LazyListScope.songItems(
             modifier = Modifier.fillMaxWidth()
         ) {
             Text(
-                text = """\s[a-z]""".toRegex()
-                    .replace(quantityStringResource(R.plurals.songs, songs.size, songs.size)) {
-                        it.value.uppercase()
-                    },
+                text = """\s[a-z]""".toRegex().replace(
+                    quantityStringResource(R.plurals.songs, songs.size, songs.size)
+                ) {
+                    it.value.uppercase()
+                },
                 textAlign = TextAlign.Left,
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.padding(8.dp).weight(1f, true)

--- a/app/src/main/java/com/example/music/ui/library/song/Songs.kt
+++ b/app/src/main/java/com/example/music/ui/library/song/Songs.kt
@@ -103,7 +103,6 @@ fun LazyListScope.songItems(
         if (showBottomSheet) {
             LibrarySortSelectionBottomModal(
                 onDismissRequest = { showBottomSheet = false },
-                coroutineScope = coroutineScope,
                 libraryCategory = LibraryCategory.Songs,
             )
         }
@@ -221,7 +220,6 @@ fun LazyGridScope.songItems(
         if(showBottomSheet) {
             LibrarySortSelectionBottomModal(
                 onDismissRequest = { showBottomSheet = false },
-                coroutineScope = coroutineScope,
                 libraryCategory = LibraryCategory.Songs,
             )
         }
@@ -244,7 +242,6 @@ fun LazyGridScope.songItems(
         items = songs,
         span = { GridItemSpan(maxLineSpan) }
     ) { song ->
-        //Box(Modifier.padding(horizontal = 12.dp, vertical = 0.dp)) {
         SongListItem(
             song = song,
             onClick = {
@@ -253,7 +250,6 @@ fun LazyGridScope.songItems(
                 navigateToPlayer()
             },
             onMoreOptionsClick = {},
-            //onQueueSong = {},
             isListEditable = false,
             showArtistName = true,
             showAlbumImage = true,
@@ -261,7 +257,6 @@ fun LazyGridScope.songItems(
             showTrackNumber = false,
             modifier = Modifier.fillMaxWidth()
         )
-        //}
     }
 }
 

--- a/app/src/main/java/com/example/music/ui/library/song/Songs.kt
+++ b/app/src/main/java/com/example/music/ui/library/song/Songs.kt
@@ -1,48 +1,17 @@
 package com.example.music.ui.library.song
 
 import android.util.Log
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Sort
-import androidx.compose.material.icons.filled.Checklist
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Shuffle
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults.buttonColors
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import com.example.music.R
-import com.example.music.designsys.theme.MusicShapes
 import com.example.music.domain.model.SongInfo
-import com.example.music.ui.library.LibraryAction
 import com.example.music.ui.shared.SongListItem
-import com.example.music.ui.library.LibraryCategory
-import com.example.music.ui.shared.LibrarySortSelectionBottomModal
 import com.example.music.util.fullWidthItem
-import com.example.music.util.quantityStringResource
-import kotlinx.coroutines.CoroutineScope
-
-private const val TAG = "Library Songs"
 
 /** Changelog:
  *
@@ -53,20 +22,23 @@ private const val TAG = "Library Songs"
  * 7/22-23/2025 - Removed PlayerSong completely
  */
 
+private const val TAG = "Library Songs"
+
 /**
  * Overloaded version of lazy list for songItems
  */
-@OptIn(ExperimentalMaterial3Api::class)
 fun LazyListScope.songItems(
     songs: List<SongInfo>,
-    coroutineScope: CoroutineScope,
-    onLibraryAction: (LibraryAction) -> Unit,
-    navigateToPlayer: () -> Unit,
+    navigateToPlayer: (SongInfo) -> Unit,
+    onSongMoreOptionsClick: (SongInfo) -> Unit,
+    onSortClick: () -> Unit = {},
+    onSelectClick: () -> Unit = {},
+    onPlayClick: () -> Unit = {},
+    onShuffleClick: () -> Unit = {},
 ) {
+    Log.i(TAG, "Lazy List START")
     //section 1: header
     item {
-        // ******** var  for modal remember here
-        var showBottomSheet by remember { mutableStateOf(false) }
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
@@ -83,7 +55,7 @@ fun LazyListScope.songItems(
             //Spacer(Modifier.weight(1f,true))
 
             // sort icon
-            IconButton(onClick = { showBottomSheet = true }) {
+            IconButton(onClick = onSortClick) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.Sort,//want this to be sort icon
                     contentDescription = stringResource(R.string.icon_sort),
@@ -92,7 +64,7 @@ fun LazyListScope.songItems(
             }
 
             // multi-select icon
-            IconButton(onClick = {/* filter */ }) {
+            IconButton(onClick = onSelectClick) {
                 Icon(
                     imageVector = Icons.Filled.Checklist,//want this to be multi select icon
                     contentDescription = stringResource(R.string.icon_multi_select),
@@ -100,24 +72,13 @@ fun LazyListScope.songItems(
                 )
             }
         }
-        if (showBottomSheet) {
-            LibrarySortSelectionBottomModal(
-                onDismissRequest = { showBottomSheet = false },
-                libraryCategory = LibraryCategory.Songs,
-            )
-        }
     }
 
+    // section 1.5: play and shuffle buttons
     item {
         PlayShuffleButtons(
-            onPlayClick = {
-                onLibraryAction(LibraryAction.PlaySongs(songs))
-                navigateToPlayer()
-            },
-            onShuffleClick = {
-                onLibraryAction(LibraryAction.ShuffleSongs(songs))
-                navigateToPlayer()
-            },
+            onPlayClick = onPlayClick,
+            onShuffleClick = onShuffleClick,
         )
     }
 
@@ -126,13 +87,8 @@ fun LazyListScope.songItems(
     ) { song ->
         SongListItem(
             song = song,
-            onClick = {
-                Log.i(TAG, "Song clicked: ${song.title}")
-                onLibraryAction(LibraryAction.SongClicked(song))
-                navigateToPlayer()
-            },
-            onMoreOptionsClick = {},
-            //onQueueSong = {},
+            onClick = { navigateToPlayer(song) },
+            onMoreOptionsClick = { onSongMoreOptionsClick(song) },
             isListEditable = false,
             showArtistName = true,
             showAlbumImage = true,
@@ -141,49 +97,23 @@ fun LazyListScope.songItems(
             modifier = Modifier.fillMaxWidth()
         )
     }
-
-    /* // original lazy list version
-    item {
-        Text(
-            text = """\s[a-z]""".toRegex().replace(quantityStringResource(R.plurals.songs, songs.size, songs.size)) {
-                it.value.uppercase()
-            },
-            textAlign = TextAlign.Left,
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(8.dp)
-        )
-    }
-
-    items(songs) { item ->
-        SongListItem(
-            song = item,
-            onClick = { navigateToPlayer(item) },
-            //onQueueSong = {},
-            isListEditable = false,
-            showArtistName = true,
-            showAlbumImage = true,
-            showAlbumTitle = true,
-            showTrackNumber = false,
-            modifier = Modifier.fillParentMaxWidth(),
-        )
-    }*/
 }
 
 /**
  * Overloaded version of lazy grid for songItems
  */
-@OptIn(ExperimentalMaterial3Api::class)
 fun LazyGridScope.songItems(
     songs: List<SongInfo>,
-    coroutineScope: CoroutineScope,
-    onLibraryAction: (LibraryAction) -> Unit,
-    navigateToPlayer: () -> Unit,
+    navigateToPlayer: (SongInfo) -> Unit,
+    onSongMoreOptionsClick: (SongInfo) -> Unit,
+    onSortClick: () -> Unit = {},
+    onSelectClick: () -> Unit = {},
+    onPlayClick: () -> Unit = {},
+    onShuffleClick: () -> Unit = {},
 ) {
-
+    Log.i(TAG, "Lazy Grid START")
     //section 1: header
     fullWidthItem {
-        // ******** var  for modal remember here
-        var showBottomSheet by remember { mutableStateOf(false) }
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
@@ -195,12 +125,12 @@ fun LazyGridScope.songItems(
                     },
                 textAlign = TextAlign.Left,
                 style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(8.dp).weight(1f,true)
+                modifier = Modifier.padding(8.dp).weight(1f, true)
             )
             //Spacer(Modifier.weight(1f,true))
 
             // sort icon
-            IconButton(onClick = { showBottomSheet = true }) {
+            IconButton(onClick = onSortClick) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.Sort,//want this to be sort icon
                     contentDescription = stringResource(R.string.icon_sort),
@@ -209,7 +139,7 @@ fun LazyGridScope.songItems(
             }
 
             // multi-select icon
-            IconButton(onClick = {/* filter */ }) {
+            IconButton(onClick = onSelectClick) {
                 Icon(
                     imageVector = Icons.Filled.Checklist,//want this to be multi select icon
                     contentDescription = stringResource(R.string.icon_multi_select),
@@ -217,24 +147,13 @@ fun LazyGridScope.songItems(
                 )
             }
         }
-        if(showBottomSheet) {
-            LibrarySortSelectionBottomModal(
-                onDismissRequest = { showBottomSheet = false },
-                libraryCategory = LibraryCategory.Songs,
-            )
-        }
     }
 
+    // section 1.5: play and shuffle buttons
     fullWidthItem {
         PlayShuffleButtons(
-            onPlayClick = {
-                onLibraryAction(LibraryAction.PlaySongs(songs))
-                navigateToPlayer()
-            },
-            onShuffleClick = {
-                onLibraryAction(LibraryAction.ShuffleSongs(songs))
-                navigateToPlayer()
-            },
+            onPlayClick = onPlayClick,
+            onShuffleClick = onShuffleClick,
         )
     }
 
@@ -244,12 +163,8 @@ fun LazyGridScope.songItems(
     ) { song ->
         SongListItem(
             song = song,
-            onClick = {
-                Log.i(TAG, "Song clicked: ${song.title}")
-                onLibraryAction(LibraryAction.SongClicked(song))
-                navigateToPlayer()
-            },
-            onMoreOptionsClick = {},
+            onClick = { navigateToPlayer(song) },
+            onMoreOptionsClick = { onSongMoreOptionsClick(song) },
             isListEditable = false,
             showArtistName = true,
             showAlbumImage = true,
@@ -270,20 +185,10 @@ private fun PlayShuffleButtons(
     modifier: Modifier = Modifier,
 ) {
     Row(modifier.padding(bottom = 8.dp)) {
-        //Row(Modifier.padding(bottom = 8.dp)) { // original version for screens that don't have carousel / don't need to remove horizontal padding on lazyVerticalGrid
         // play btn
         Button(
-            onClick = onPlayClick, //what is the thing that would jump start this step process. would it go thru the viewModel??
-            //step 1: regardless of shuffle being on or off, set shuffle to off
-            //step 2: prepare the mediaPlayer with the new queue of items in order from playlist
-            //step 3: set the player to play the first item in queue
-            //step 4: navigateToPlayer(first item)
-            //step 5: start playing
-            /*coroutineScope.launch {
-                sheetState.hide()
-                showThemeSheet = false
-            }*/
-            //did have colors set, colors = buttonColors( container -> primary, content -> background ) // coroutineScope.launch { sheetState.hide() showThemeSheet = false },
+            onClick = onPlayClick,
+            //did have colors set, colors = buttonColors( container -> primary, content -> background )
             shape = MusicShapes.small,
             modifier = Modifier
                 .padding(horizontal = 8.dp)
@@ -298,18 +203,7 @@ private fun PlayShuffleButtons(
 
         // shuffle btn
         Button(
-            onClick = onShuffleClick, //what is the thing that would jump start this step process
-            //step 1: regardless of shuffle being on or off, set shuffle to on
-            //step 2?: confirm the shuffle type
-            //step 3: prepare the mediaPlayer with the new queue of items shuffled from playlist
-            //step 4: set the player to play the first item in queue
-            //step 5: navigateToPlayer(first item)
-            //step 6: start playing
-            //needs to take the songs in the playlist, shuffle the
-            /*coroutineScope.launch {
-                sheetState.hide()
-                showThemeSheet = false
-            }*/
+            onClick = onShuffleClick,
             //did have colors set, colors = buttonColors( container -> primary, content -> background )
             shape = MusicShapes.small,
             modifier = Modifier

--- a/app/src/main/java/com/example/music/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/player/PlayerViewModel.kt
@@ -227,7 +227,12 @@ class PlayerViewModel @Inject constructor(
                     }
                     currentSong = getSongDataV2(id.toLong())
                     Log.d(TAG, "Current Song set to ${currentSong.title}")
+                    songController.logTrackNumber()
                 }
+            }
+
+            Player.EVENT_TRACKS_CHANGED -> {
+                songController.logTrackNumber()
             }
 
             // Event for checking if play when ready has changed

--- a/app/src/main/java/com/example/music/ui/shared/Actions.kt
+++ b/app/src/main/java/com/example/music/ui/shared/Actions.kt
@@ -42,15 +42,15 @@ data class ActionItem(
  * Object that contains all the possible actions for the MoreOptions bottom modals.
  */
 object Actions {
-    val PlayItem: ActionItem = ActionItem("Play", Icons.Filled.PlayArrow, R.string.icon_play) //{ /*navigateToPlayerSong(song)*/ }
+    val PlayItem: ActionItem = ActionItem("Play", Icons.Filled.PlayArrow, R.string.icon_play)
     val PlayItemNext: ActionItem = ActionItem("Play next", Icons.AutoMirrored.Filled.QueueMusic, R.string.icon_play_next)
-    val ShuffleItem: ActionItem = ActionItem("Shuffle", Icons.Filled.Shuffle, R.string.icon_shuffle) // is for playlist, album, artist, composer, genre
-    val AddToPlaylist: ActionItem = ActionItem("Add to Playlist", Icons.AutoMirrored.Filled.PlaylistAdd, R.string.icon_add_to_playlist) // is for individual song, for multiple songs if selection works, for album, for artist, for composer, for genre, for playlist
-    val AddToQueue: ActionItem = ActionItem("Add to Queue", Icons.Filled.Queue, R.string.icon_add_to_queue) // is for individual song, for multiple songs if selection works, for album, for artist, for composer, for genre, for playlist
+    val ShuffleItem: ActionItem = ActionItem("Shuffle", Icons.Filled.Shuffle, R.string.icon_shuffle)
+    val AddToPlaylist: ActionItem = ActionItem("Add to Playlist", Icons.AutoMirrored.Filled.PlaylistAdd, R.string.icon_add_to_playlist)
+    val AddToQueue: ActionItem = ActionItem("Add to Queue", Icons.Filled.Queue, R.string.icon_add_to_queue)
 
-    val GoToArtist: ActionItem = ActionItem("Go to Artist", Icons.Filled.Person, R.string.icon_artist) // navigateToArtistDetails(transform artistName to artist.Id)
-    val GoToAlbumArtist: ActionItem = ActionItem("Go to Album Artist", Icons.Filled.Person, R.string.icon_artist) // navigateToArtistDetails(transform artistName to artist.Id)
-    val GoToAlbum: ActionItem = ActionItem("Go to Album", Icons.Filled.Album, R.string.icon_album) // navigateToAlbumDetails(transform albumTitle to album.Id)
+    val GoToArtist: ActionItem = ActionItem("Go to Artist", Icons.Filled.Person, R.string.icon_artist)
+    val GoToAlbumArtist: ActionItem = ActionItem("Go to Album Artist", Icons.Filled.Person, R.string.icon_artist)
+    val GoToAlbum: ActionItem = ActionItem("Go to Album", Icons.Filled.Album, R.string.icon_album)
     val GoToComposer: ActionItem = ActionItem("Go to Composer", Icons.Filled.Person, R.string.icon_composer)
     val GoToGenre: ActionItem = ActionItem("Go to Genre", Icons.Filled.Category, R.string.icon_genre)
     val GoToPlaylist: ActionItem = ActionItem("Go to Playlist", Icons.Filled.LibraryMusic, R.string.icon_playlist)

--- a/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
+++ b/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -26,24 +25,14 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.filled.Album
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Queue
-import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.BottomSheetScaffoldState
 import androidx.compose.material3.Button
@@ -73,13 +62,11 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -112,27 +99,6 @@ import com.example.music.ui.tooling.CompLightPreview
 import com.example.music.util.fullWidthItem
 import com.example.music.util.quantityStringResource
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import java.time.Duration
-
-/** Changelog:
- *
- * 4/2/2025 - Revised PlayerSong as UI model supplement. SongInfo domain model
- * has been adjusted to support UI with the string values of the foreign key
- * ids and remaining extra info that was not in PlayerSong. This doesn't mean full
- * removal like the other, non-Player screens because Bottom Modals also contains
- * BottomPlayer, which does need PlayerSong as the supporting model.
- *
- * 4/9/2025 - Updated AlbumMoreOptions, ComposerMoreOptions, GenreMoreOptions, PlaylistMoreOptions
- * to use ActionOptionRow for displaying their individual object's actions. And cleaned up some
- * of the commented out code that's not needed anymore.
- *
- * 4/14/2024 - Created CustomDragHandle to create a drag handle that takes up less space.
- * Updated the bottom modals' padding for column structure and list items so the onPress, onClick
- * highlight covers the full width of the item.
- *
- * 7/22-23/2025 - Removed PlayerSong completely
- */
 
 private const val TAG = "Bottom Modal"
 
@@ -456,7 +422,7 @@ fun SongMoreOptionsBottomModal(
                 //ActionOptionRow( Pair(Actions.RemoveFromQueue) {} )
             //ActionOptionRow( Pair(Actions.DeleteFromLibrary) {} ) */
 
-            Button( // close btn
+            Button(
                 onClick = onClose,
                 colors = buttonColors(
                     containerColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -527,11 +493,11 @@ fun AlbumMoreOptionsBottomModal(
 
             // if album has album artist and not already on ArtistDetails screen
             if (album.albumArtistId != null && context != "ArtistDetails")
-                ActionOptionRow( Actions.GoToAlbumArtist, goToArtist )
+                ActionOptionRow(Actions.GoToAlbumArtist, goToArtist)
 
             // if in artistDetails, in library.Albums,
             if (context != "AlbumDetails")
-                ActionOptionRow( Actions.GoToAlbum, goToAlbum )
+                ActionOptionRow(Actions.GoToAlbum, goToAlbum)
 
             //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
             //ActionOptionRow( Actions.EditAlbumTags, {} )
@@ -602,10 +568,10 @@ fun ArtistMoreOptionsBottomModal(
             artistActions.forEach { item ->
                 ActionOptionRow(item.first, item.second)
             }
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             // if on library.artists
             if (context != "ArtistDetails") {
+                HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
                 ActionOptionRow( Actions.GoToArtist, goToArtist )
             }
 
@@ -679,10 +645,10 @@ fun ComposerMoreOptionsBottomModal(
             composerActions.forEach { item ->
                 ActionOptionRow(item.first, item.second)
             }
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             // if on library.composers
             if (context != "ComposerDetails") {
+                HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
                 ActionOptionRow( Actions.GoToComposer, { navigateToComposerDetails(composer)} )
             }
 
@@ -755,10 +721,10 @@ fun GenreMoreOptionsBottomModal(
             genreActions.forEach { item ->
                 ActionOptionRow(item.first, item.second)
             }
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             // if on library.genres
             if (context != "GenreDetails") {
+                HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
                 ActionOptionRow(Actions.GoToGenre, goToGenre)
             }
 
@@ -791,8 +757,6 @@ fun PlaylistMoreOptionsBottomModal(
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
 
     playlist: PlaylistInfo,
-    navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit = {},
     play: () -> Unit = {},
     playNext: () -> Unit = {},
     shuffle: () -> Unit = {},
@@ -803,10 +767,10 @@ fun PlaylistMoreOptionsBottomModal(
     context: String = "",
 ) {
     ModalBottomSheet(
-        onDismissRequest = onDismissRequest,//{showBottomSheet = false}
-        sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
         scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
         dragHandle = { CustomDragHandle() },
         properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
@@ -833,20 +797,19 @@ fun PlaylistMoreOptionsBottomModal(
             playlistActions.forEach { item ->
                 ActionOptionRow(item.first, item.second)
             }
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             // if on library.playlists
             if (context != "PlaylistDetails") {
-                ActionOptionRow( Actions.GoToPlaylist, goToPlaylist ) // { navigateToPlaylistDetails(playlist.id) }
                 HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
+                ActionOptionRow(Actions.GoToPlaylist, goToPlaylist)
             }
 
-            ActionOptionRow( Actions.EditPlaylistTags, {} )
-            ActionOptionRow( Actions.EditPlaylistOrder, {} )
+            //ActionOptionRow( Actions.EditPlaylistTags, {} )
+            //ActionOptionRow( Actions.EditPlaylistOrder, {} )
 
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
-            ActionOptionRow( Actions.ExportPlaylist, {} )
-            ActionOptionRow( Actions.DeletePlaylist, {} )
+            //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
+            //ActionOptionRow( Actions.ExportPlaylist, {} )
+            //ActionOptionRow( Actions.DeletePlaylist, {} )
 
             Button(
                 onClick = onClose,
@@ -895,10 +858,10 @@ fun QueueMoreOptionsBottomModal(
     context: String = "",
 ) {
     ModalBottomSheet(
-        onDismissRequest = onDismissRequest,//{showBottomSheet = false}
-        sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
         scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
         dragHandle = { CustomDragHandle() },
         properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
@@ -916,11 +879,11 @@ fun QueueMoreOptionsBottomModal(
             ) {
                 Text("Now Playing")
             }
-            HorizontalDivider( thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp) )
+            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
-            ActionOptionRow( Actions.AddToPlaylist, addToPlaylist )
-            ActionOptionRow( Actions.ClearQueue, clearQueue )
-            ActionOptionRow( Actions.SaveQueueToPlaylist, {} )
+            ActionOptionRow(Actions.AddToPlaylist, addToPlaylist)
+            ActionOptionRow(Actions.ClearQueue, clearQueue)
+            ActionOptionRow(Actions.SaveQueueToPlaylist, {})
 
             Button(
                 onClick = onClose,
@@ -1044,7 +1007,7 @@ fun LibrarySortSelectionBottomModal(
 
             item {
                 Row {
-                    //cancel/exit btn
+                    // Cancel/Exit btn
                     Button(
                         onClick = onClose,
                         colors = buttonColors(
@@ -1061,7 +1024,7 @@ fun LibrarySortSelectionBottomModal(
                         Text("CANCEL")
                     }
 
-                    //apply btn
+                    // Apply btn
                     Button(
                         onClick = onApply,
                         colors = buttonColors(
@@ -1099,8 +1062,8 @@ fun DetailsSortSelectionBottomModal(
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
         scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
         dragHandle = { CustomDragHandle() },
         properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
@@ -1164,7 +1127,7 @@ fun DetailsSortSelectionBottomModal(
 
             item {
                 Row {
-                    //cancel/exit btn
+                    // Cancel/Exit btn
                     Button(
                         onClick = onClose,
                         colors = buttonColors(
@@ -1181,7 +1144,7 @@ fun DetailsSortSelectionBottomModal(
                         Text("CANCEL")
                     }
 
-                    //apply btn
+                    // Apply btn
                     Button(
                         onClick = onApply,
                         colors = buttonColors(
@@ -1320,7 +1283,7 @@ fun CreatePlaylistBottomModal(
 
             fullWidthItem {
                 Row {
-                    //cancel btn
+                    // Cancel btn
                     Button(
                         onClick = onClose,
                         colors = buttonColors(
@@ -1337,7 +1300,7 @@ fun CreatePlaylistBottomModal(
                         Text("CANCEL")
                     }
 
-                    //create playlist btn
+                    // Create playlist btn
                     Button(
                         onClick = onCreate,
                         enabled = !createEnabled.value,
@@ -1374,12 +1337,12 @@ fun BottomSheet(
     navigateToPlayer: () -> Unit = {},
     //navigateToQueue: () -> Unit = {},
     sheetState: BottomSheetScaffoldState = rememberBottomSheetScaffoldState(),
-        /*SheetState(
-            skipPartiallyExpanded = false,
-            density = Density(1f,1f),
-            initialValue = if (isActive) SheetValue.PartiallyExpanded else SheetValue.Hidden,
-            skipHiddenState = isActive,
-        )*/
+    /*SheetState(
+        skipPartiallyExpanded = false,
+        density = Density(1f,1f),
+        initialValue = if (isActive) SheetValue.PartiallyExpanded else SheetValue.Hidden,
+        skipHiddenState = isActive,
+    )*/
     modifier: Modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars),
     content: @Composable () -> Unit = {},
 ) {

--- a/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
+++ b/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
@@ -1,6 +1,7 @@
 package com.example.music.ui.shared
 
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
@@ -132,29 +133,32 @@ import java.time.Duration
  * 7/22-23/2025 - Removed PlayerSong completely
  */
 
+private const val TAG = "Bottom Modal"
+
 //More Options Modal Content - Action Options Row Composable
 // contains the Action Item to display and the onClick action to be performed when the row is clicked
 // ActionItem contains the icon, name, and contentDescription of the action to perform
 @Composable
 fun ActionOptionRow(
-    item: Pair<ActionItem, ()->Unit>
+    item: ActionItem,
+    action: () -> Unit
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { item.second }
+            .clickable { action() }
             .height(56.dp)
             .padding(horizontal = 24.dp)
     ) {
         Icon(
-            imageVector = item.first.icon,
+            imageVector = item.icon,
             tint = MaterialTheme.colorScheme.onPrimaryContainer,
-            contentDescription = stringResource(item.first.contentDescription),
+            contentDescription = stringResource(item.contentDescription),
             modifier = Modifier.padding(4.dp)
         )
         Text(
-            text = item.first.name,
+            text = item.name,
             modifier = Modifier.padding(start = 16.dp)
         )
     }
@@ -370,32 +374,29 @@ fun CustomDragHandle() {
 @Composable
 fun SongMoreOptionsBottomModal(
     onDismissRequest: () -> Unit,
-
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
     contentColor: Color = MaterialTheme.colorScheme.onBackground,
     containerColor: Color = MaterialTheme.colorScheme.background,
-    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
+    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// scrim.copy(alpha=0.2f),
     properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
 
-    //coroutineScope: CoroutineScope,
     song: SongInfo,
-    navigateToPlayer: () -> Unit = {}, //FixMe
+    navigateToPlayer: () -> Unit = {},
+    //navigateToArtistDetails: () -> Unit = {},
+    navigateToAlbumDetails: () -> Unit = {},
+    addToQueue: () -> Unit = {},
+    addToQueueNext: () -> Unit = {},
     sheetOnClick: () -> Unit = {},
-    // would likely need the other navigateTo screens here too
-
-    //do i need a context variable? like if this was from PlaylistDetails, or ArtistDetails, or Home, or Library
-    // could this be done with the navController? or does it have to be a string? or an enum?
     context: String = "",
-    //showBottomSheet: Boolean,
 ) {
     ModalBottomSheet(
-        onDismissRequest = onDismissRequest, //{showBottomSheet = false}
-        sheetState = sheetState, //rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        containerColor = containerColor, //MaterialTheme.colorScheme.background,
-        contentColor = contentColor, //MaterialTheme.colorScheme.onBackground,
-        scrimColor = scrimColor, //MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),
-        dragHandle = { CustomDragHandle() }, //dragHandle: @Composable () -> Unit = { BottomSheetDefaults.DragHandle() },
-        properties = properties, //ModalBottomSheetProperties(shouldDismissOnBackPress = true),
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        scrimColor = scrimColor,
+        dragHandle = { CustomDragHandle() },
+        properties = properties,
     ) {
         Column (
             verticalArrangement = Arrangement.Top,
@@ -408,45 +409,45 @@ fun SongMoreOptionsBottomModal(
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             val songActions = arrayListOf(
-                Pair(Actions.PlayItem) { navigateToPlayer() }, //FixMe
-                Pair(Actions.PlayItemNext) {},
-                Pair(Actions.AddToPlaylist) {},
-                Pair(Actions.AddToQueue) {},
+                Pair(Actions.PlayItem, navigateToPlayer), //FixMe
+                Pair(Actions.PlayItemNext, addToQueueNext),
+                Pair(Actions.AddToPlaylist, addToQueue),
+                Pair(Actions.AddToQueue, addToQueue),
             )
 
             // action items, shown items are dependent on this being a song item
             songActions.forEach { item ->
-                ActionOptionRow(item)
+                ActionOptionRow(item.first, item.second)
             }
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             // if the song has an artist name and current screen is not ArtistDetails
-            if (song.artistName != "" && context != "ArtistDetails")
-                ActionOptionRow( Pair(Actions.GoToArtist) {  } ) //navigateToArtistDetails()
+            //if (song.artistName != "" && context != "ArtistDetails")
+                //ActionOptionRow( Pair(Actions.GoToArtist) { navigateToArtistDetails() } ) //navigateToArtistDetails()
 
             // if the song has an album title and current screen is not AlbumDetails
             if (song.albumTitle != "" && context != "AlbumDetails")
-                ActionOptionRow( Pair(Actions.GoToAlbum) {  } ) //navigateToAlbumDetails()
+                ActionOptionRow( Actions.GoToAlbum, navigateToAlbumDetails ) //navigateToAlbumDetails()
 
-//            if (song.genreName != "" && context != "GenreDetails")
-//                ActionOptionRow( Pair(Actions.GoToGenre) {} )
+            /* //if (song.genreName != "" && context != "GenreDetails")
+                //ActionOptionRow( Pair(Actions.GoToGenre) {} )
 
-//            if (song.composerName != "" && context != "ComposerDetails")
-//                ActionOptionRow( Pair(Actions.GoToComposer) {} )
+            //if (song.composerName != "" && context != "ComposerDetails")
+                //ActionOptionRow( Pair(Actions.GoToComposer) {} )
 
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
+            //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
-            ActionOptionRow( Pair(Actions.EditSongTags) {} ) //onClick action would go into lambda edit song tags
+            //ActionOptionRow( Pair(Actions.EditSongTags) {} ) //onClick action would go into lambda edit song tags
 
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
+            //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
-            if (context == "PlaylistDetails")
-                ActionOptionRow( Pair(Actions.RemoveFromPlaylist) {} )
+            //if (context == "PlaylistDetails")
+                //ActionOptionRow( Pair(Actions.RemoveFromPlaylist) {} )
 
-            if (context == "Queue")
-                ActionOptionRow( Pair(Actions.RemoveFromQueue) {} )
+            //if (context == "Queue")
+                //ActionOptionRow( Pair(Actions.RemoveFromQueue) {} )
 
-            ActionOptionRow( Pair(Actions.DeleteFromLibrary) {} )
+            //ActionOptionRow( Pair(Actions.DeleteFromLibrary) {} ) */
 
             Button( // close btn
                 onClick = sheetOnClick,
@@ -517,21 +518,21 @@ fun AlbumMoreOptionsBottomModal(
 
             // action items, shown items are dependent on this being a song item
             albumActions.forEach { item ->
-                ActionOptionRow(item)
+                ActionOptionRow(item.first, item.second)
             }
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             // if album has album artist and not already on ArtistDetails screen
             if (album.albumArtistId != null && context != "ArtistDetails")
-                ActionOptionRow( Pair(Actions.GoToAlbumArtist) {} ) // { navigateToArtistDetails(albumArtistId) }
+                ActionOptionRow( Actions.GoToAlbumArtist, {} ) // { navigateToArtistDetails(albumArtistId) }
 
             // if in artistDetails, in library.Albums,
             if (context != "AlbumDetails")
-                ActionOptionRow( Pair(Actions.GoToAlbum) {} ) // { navigateToAlbumDetails(albumId) or navigateToAlbumDetails(album) }
+                ActionOptionRow( Actions.GoToAlbum, {} ) // { navigateToAlbumDetails(albumId) or navigateToAlbumDetails(album) }
 
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
-            ActionOptionRow( Pair(Actions.EditAlbumTags) {} ) //onClick action would go into lambda edit album tags
+            ActionOptionRow( Actions.EditAlbumTags, {} ) //onClick action would go into lambda edit album tags
 
             Button(
                 onClick = {
@@ -571,7 +572,7 @@ fun ArtistMoreOptionsBottomModal(
 
     coroutineScope: CoroutineScope,
     artist: ArtistInfo,
-    navigateToArtistDetails: (ArtistInfo) -> Unit,
+    //navigateToArtistDetails: (ArtistInfo) -> Unit,
     navigateToPlayer: () -> Unit = {},
     context: String = "",
     //showBottomSheet: Boolean,
@@ -607,19 +608,17 @@ fun ArtistMoreOptionsBottomModal(
 
             // action items, shown items are dependent on this being an artist item
             artistActions.forEach { item ->
-                ActionOptionRow(item)
+                ActionOptionRow(item.first, item.second)
             }
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             // if on library.artists
             if (context != "ArtistDetails") {
-                ActionOptionRow(Pair(Actions.GoToArtist) {
-                    navigateToArtistDetails(artist)
-                }) // { navigateToArtistDetails(artist.id) }
+                ActionOptionRow( Actions.GoToArtist, {} )
                 HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
             }
 
-            ActionOptionRow(Pair(Actions.EditArtistTags) {}) //onClick action in the lambda
+            ActionOptionRow( Actions.EditArtistTags, {}) //onClick action in the lambda
 
             Button(
                 onClick = {
@@ -695,20 +694,18 @@ fun ComposerMoreOptionsBottomModal(
 
             // action items, shown items are dependent on this being a song item
             composerActions.forEach { item ->
-                ActionOptionRow(item)
+                ActionOptionRow(item.first, item.second)
             }
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             // if on library.composers
             if (context != "ComposerDetails") {
-                ActionOptionRow(Pair(Actions.GoToComposer) {
-                    navigateToComposerDetails(composer)
-                }) // { navigateToComposerDetails(composer.id) }
+                ActionOptionRow( Actions.GoToComposer, { navigateToComposerDetails(composer)} ) // { navigateToComposerDetails(composer.id) }
 
                 HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
             }
 
-            ActionOptionRow( Pair(Actions.EditComposerTags) {} )
+            ActionOptionRow( Actions.EditComposerTags, {} )
 
             Button(
                 onClick = {
@@ -784,19 +781,17 @@ fun GenreMoreOptionsBottomModal(
 
             // action items, shown items are dependent on this being a song item
             genreActions.forEach { item ->
-                ActionOptionRow(item)
+                ActionOptionRow(item.first, item.second)
             }
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             // if on library.genres
             if (context != "GenreDetails") {
-                ActionOptionRow(Pair(Actions.GoToGenre) {
-                    navigateToGenreDetails(genre)
-                }) // { navigateToGenreDetails(genre.id) }
+                ActionOptionRow(Actions.GoToGenre, { navigateToGenreDetails(genre) }) // { navigateToGenreDetails(genre.id) }
                 HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
             }
 
-            ActionOptionRow(Pair(Actions.EditGenreTags) {})
+            ActionOptionRow(Actions.EditGenreTags, {})
 
             Button(
                 onClick = {
@@ -870,24 +865,22 @@ fun PlaylistMoreOptionsBottomModal(
 
             // action items, shown items are dependent on this being a song item
             playlistActions.forEach { item ->
-                ActionOptionRow(item)
+                ActionOptionRow(item.first, item.second)
             }
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             // if on library.playlists
             if (context != "PlaylistDetails") {
-                ActionOptionRow( Pair(Actions.GoToPlaylist) {
-                    navigateToPlaylistDetails(playlist)
-                }) // { navigateToPlaylistDetails(playlist.id) }
+                ActionOptionRow( Actions.GoToPlaylist, { navigateToPlaylistDetails(playlist) }) // { navigateToPlaylistDetails(playlist.id) }
                 HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
             }
 
-            ActionOptionRow(Pair(Actions.EditPlaylistTags) {})
-            ActionOptionRow(Pair(Actions.EditPlaylistOrder) {})
+            ActionOptionRow(Actions.EditPlaylistTags, {})
+            ActionOptionRow(Actions.EditPlaylistOrder, {})
 
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
-            ActionOptionRow( Pair(Actions.ExportPlaylist) { /*  */ } )
-            ActionOptionRow( Pair(Actions.DeletePlaylist) { /* */ } )
+            ActionOptionRow( Actions.ExportPlaylist, {} )
+            ActionOptionRow( Actions.DeletePlaylist, {} )
 
             Button(
                 onClick = {
@@ -963,9 +956,9 @@ fun QueueMoreOptionsBottomModal(
             }
             HorizontalDivider( thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp) )
 
-            ActionOptionRow( Pair(Actions.AddToPlaylist) {} )
-            ActionOptionRow( Pair(Actions.ClearQueue) {} )
-            ActionOptionRow( Pair(Actions.SaveQueueToPlaylist) {} )
+            ActionOptionRow( Actions.AddToPlaylist, {} )
+            ActionOptionRow( Actions.ClearQueue, {} )
+            ActionOptionRow( Actions.SaveQueueToPlaylist, {} )
 
             Button(
                 onClick = {

--- a/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
+++ b/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
@@ -377,9 +377,10 @@ fun SongMoreOptionsBottomModal(
     scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
     properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
 
-    coroutineScope: CoroutineScope,
+    //coroutineScope: CoroutineScope,
     song: SongInfo,
     navigateToPlayer: () -> Unit = {}, //FixMe
+    sheetOnClick: () -> Unit = {},
     // would likely need the other navigateTo screens here too
 
     //do i need a context variable? like if this was from PlaylistDetails, or ArtistDetails, or Home, or Library
@@ -387,16 +388,14 @@ fun SongMoreOptionsBottomModal(
     context: String = "",
     //showBottomSheet: Boolean,
 ) {
-    var showBottomSheet by remember { mutableStateOf(false) }
-
     ModalBottomSheet(
         onDismissRequest = onDismissRequest, //{showBottomSheet = false}
         sheetState = sheetState, //rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        contentColor = contentColor, //MaterialTheme.colorScheme.onBackground,
         containerColor = containerColor, //MaterialTheme.colorScheme.background,
+        contentColor = contentColor, //MaterialTheme.colorScheme.onBackground,
         scrimColor = scrimColor, //MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),
+        dragHandle = { CustomDragHandle() }, //dragHandle: @Composable () -> Unit = { BottomSheetDefaults.DragHandle() },
         properties = properties, //ModalBottomSheetProperties(shouldDismissOnBackPress = true),
-        dragHandle = { CustomDragHandle() }
     ) {
         Column (
             verticalArrangement = Arrangement.Top,
@@ -450,13 +449,7 @@ fun SongMoreOptionsBottomModal(
             ActionOptionRow( Pair(Actions.DeleteFromLibrary) {} )
 
             Button( // close btn
-                onClick = {
-                    showBottomSheet = false
-                    coroutineScope.launch {
-                        sheetState.hide()
-                        showBottomSheet = false
-                    }
-                },
+                onClick = sheetOnClick,
                 colors = buttonColors(
                     containerColor = MaterialTheme.colorScheme.surfaceVariant,
                     contentColor = MaterialTheme.colorScheme.onBackground,
@@ -1939,7 +1932,7 @@ fun PreviewMoreOptionsModal() {
                 skipPartiallyExpanded = true,
                 density = Density(1f,1f)
             ),
-            coroutineScope = rememberCoroutineScope(),
+            //coroutineScope = rememberCoroutineScope(),
             song = PreviewSongs[0],
         )
     }

--- a/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
+++ b/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
@@ -64,6 +64,7 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -135,9 +136,11 @@ import java.time.Duration
 
 private const val TAG = "Bottom Modal"
 
-//More Options Modal Content - Action Options Row Composable
-// contains the Action Item to display and the onClick action to be performed when the row is clicked
-// ActionItem contains the icon, name, and contentDescription of the action to perform
+/**
+ * More Options Modal Content - Action Options Row Composable
+ * contains the Action Item to display and the onClick action to be performed when the row is clicked
+ * ActionItem contains the icon, name, and contentDescription of the action to perform
+ */
 @Composable
 fun ActionOptionRow(
     item: ActionItem,
@@ -164,7 +167,9 @@ fun ActionOptionRow(
     }
 }
 
-//More Options Modal Header
+/**
+ * More Options Modal Header
+ */
 @Composable
 fun MoreOptionModalHeader(
     title: String = "", // item's name or title
@@ -265,8 +270,10 @@ fun MoreOptionModalHeader(
     }
 }
 
-//More Options Modal Header - Header Item Image
-// used for SongInfo, PlayerSong, AlbumInfo (maybe should also be fore PlaylistInfo)
+/**
+ * More Options Modal Header - Header Item Image
+ * used for SongInfo, PlayerSong, AlbumInfo (maybe should also be fore PlaylistInfo)
+ */
 @Composable
 fun HeaderImage(
     artworkUri: Uri,
@@ -282,8 +289,10 @@ fun HeaderImage(
     )
 }
 
-//More Options Modal Header - Header Item First Initial
-// used for ArtistInfo, ComposerInfo, GenreInfo
+/**
+ * More Options Modal Header - Header Item First Initial
+ * used for ArtistInfo, ComposerInfo, GenreInfo
+ */
 @Composable
 fun HeaderInitial(
     name: String = ""
@@ -306,7 +315,9 @@ fun HeaderInitial(
     }
 }
 
-//More Options Modal Header - Song Item Subtitle text
+/**
+ * More Options Modal Header - Song Item Subtitle text
+ */
 fun SongInfo.setSubtitle(): String =
     if ((this.artistName != "") && (this.albumTitle != "")) {
         this.artistName + " • " + this.albumTitle
@@ -314,37 +325,47 @@ fun SongInfo.setSubtitle(): String =
         (this.artistName) + (this.albumTitle)
     }
 
-//More Options Modal Header - Artist Item Subtitle text
-@Composable
-fun ArtistInfo.setSubtitle(): String =
-    quantityStringResource(R.plurals.albums, this.albumCount, this.albumCount) +
-            " • " +
-            quantityStringResource(R.plurals.songs, this.songCount, this.songCount)
-
-//More Options Modal Header - Playlist Item Subtitle text
-@Composable
-fun PlaylistInfo.setSubtitle(): String =
-    quantityStringResource(R.plurals.songs, this.songCount, this.songCount)
-
-//More Options Modal Header - Composer Item Subtitle text
-@Composable
-fun ComposerInfo.setSubtitle(): String =
-    quantityStringResource(R.plurals.songs, this.songCount, this.songCount)
-
-//More Options Modal Header - Genre Item Subtitle text
-@Composable
-fun GenreInfo.setSubtitle(): String =
-    quantityStringResource(R.plurals.songs, this.songCount, this.songCount)
-
-//More Options Modal Header - Album Item Subtitle text
+/**
+ * More Options Modal Header - Album Item Subtitle text
+ */
 @Composable
 fun AlbumInfo.setSubtitle(): String =
     if (this.albumArtistId == null)
         quantityStringResource(R.plurals.songs, this.songCount, this.songCount)
     else {
         this.albumArtistName + " • " +
-            quantityStringResource(R.plurals.songs, this.songCount, this.songCount)
+                quantityStringResource(R.plurals.songs, this.songCount, this.songCount)
     }
+
+/**
+ * More Options Modal Header - Artist Item Subtitle text
+ */
+@Composable
+fun ArtistInfo.setSubtitle(): String =
+    quantityStringResource(R.plurals.albums, this.albumCount, this.albumCount) +
+            " • " +
+            quantityStringResource(R.plurals.songs, this.songCount, this.songCount)
+
+/**
+ * More Options Modal Header - Composer Item Subtitle text
+ */
+@Composable
+fun ComposerInfo.setSubtitle(): String =
+    quantityStringResource(R.plurals.songs, this.songCount, this.songCount)
+
+/**
+ * More Options Modal Header - Genre Item Subtitle text
+ */
+@Composable
+fun GenreInfo.setSubtitle(): String =
+    quantityStringResource(R.plurals.songs, this.songCount, this.songCount)
+
+/**
+ * More Options Modal Header - Playlist Item Subtitle text
+ */
+@Composable
+fun PlaylistInfo.setSubtitle(): String =
+    quantityStringResource(R.plurals.songs, this.songCount, this.songCount)
 
 @Composable
 fun CustomDragHandle() {
@@ -365,38 +386,36 @@ fun CustomDragHandle() {
  * -view song info (media metadata)
  */
 
-/** Idea for modal: to show action items like a dropdown menu when an item's more options btn is clicked/pressed.
- *  First, need to be able to call it from any screen that has a more options btn.
- *  Second, need it to show context dependent on the item context
- *  aka what type of object the more options btn press was from.
+/**
+ * Idea for modal: to show action items like a dropdown menu when an item's more options btn is clicked/pressed.
+ * First, need to be able to call it from any screen that has a more options btn.
+ * Second, need it to show context dependent on the item context
+ * aka what type of object the more options btn press was from.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SongMoreOptionsBottomModal(
     onDismissRequest: () -> Unit,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
-    contentColor: Color = MaterialTheme.colorScheme.onBackground,
-    containerColor: Color = MaterialTheme.colorScheme.background,
-    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// scrim.copy(alpha=0.2f),
-    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
 
     song: SongInfo,
-    navigateToPlayer: () -> Unit = {},
-    //navigateToArtistDetails: () -> Unit = {},
-    navigateToAlbumDetails: () -> Unit = {},
+    play: () -> Unit = {},
+    playNext: () -> Unit = {},
+    //addToPlaylist() -> Unit = {},
     addToQueue: () -> Unit = {},
-    addToQueueNext: () -> Unit = {},
-    sheetOnClick: () -> Unit = {},
+    goToArtist: () -> Unit = {},
+    goToAlbum: () -> Unit = {},
+    onClose: () -> Unit = {},
     context: String = "",
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        containerColor = containerColor,
-        contentColor = contentColor,
-        scrimColor = scrimColor,
+        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
         dragHandle = { CustomDragHandle() },
-        properties = properties,
+        properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
     ) {
         Column (
             verticalArrangement = Arrangement.Top,
@@ -409,9 +428,9 @@ fun SongMoreOptionsBottomModal(
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             val songActions = arrayListOf(
-                Pair(Actions.PlayItem, navigateToPlayer), //FixMe
-                Pair(Actions.PlayItemNext, addToQueueNext),
-                Pair(Actions.AddToPlaylist, addToQueue),
+                Pair(Actions.PlayItem, play),
+                Pair(Actions.PlayItemNext, playNext),
+                //Pair(Actions.AddToPlaylist, addToPlaylist),
                 Pair(Actions.AddToQueue, addToQueue),
             )
 
@@ -422,12 +441,12 @@ fun SongMoreOptionsBottomModal(
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             // if the song has an artist name and current screen is not ArtistDetails
-            //if (song.artistName != "" && context != "ArtistDetails")
-                //ActionOptionRow( Pair(Actions.GoToArtist) { navigateToArtistDetails() } ) //navigateToArtistDetails()
+            if (song.artistName != "" && context != "ArtistDetails")
+                ActionOptionRow( Actions.GoToArtist, goToArtist )
 
             // if the song has an album title and current screen is not AlbumDetails
             if (song.albumTitle != "" && context != "AlbumDetails")
-                ActionOptionRow( Actions.GoToAlbum, navigateToAlbumDetails ) //navigateToAlbumDetails()
+                ActionOptionRow( Actions.GoToAlbum, goToAlbum )
 
             /* //if (song.genreName != "" && context != "GenreDetails")
                 //ActionOptionRow( Pair(Actions.GoToGenre) {} )
@@ -450,7 +469,7 @@ fun SongMoreOptionsBottomModal(
             //ActionOptionRow( Pair(Actions.DeleteFromLibrary) {} ) */
 
             Button( // close btn
-                onClick = sheetOnClick,
+                onClick = onClose,
                 colors = buttonColors(
                     containerColor = MaterialTheme.colorScheme.surfaceVariant,
                     contentColor = MaterialTheme.colorScheme.onBackground,
@@ -472,32 +491,27 @@ fun SongMoreOptionsBottomModal(
 @Composable
 fun AlbumMoreOptionsBottomModal(
     onDismissRequest: () -> Unit,
-
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
-    contentColor: Color = MaterialTheme.colorScheme.onBackground,
-    containerColor: Color = MaterialTheme.colorScheme.background,
-    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
-    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
 
-    coroutineScope: CoroutineScope,
     album: AlbumInfo,
+    play: () -> Unit = {},
+    playNext: () -> Unit = {},
+    shuffle: () -> Unit = {},
+    //addToPlaylist: () -> Unit = {},
+    addToQueue: () -> Unit = {},
+    goToArtist: () -> Unit = {},
+    goToAlbum: () -> Unit = {}, // if on Library.Albums tab
+    onClose: () -> Unit = {},
     context: String,
-    //AlbumDetails context? ArtistDetails context?
-    //navigateToAlbumDetails: (AlbumInfo) -> Unit, //usage depends on content: if on library.albums, albumDetails, artistDetails. aka not necessary for moreOptions on albumDetails
-    //navigateToArtistDetails: (ArtistInfo) -> Unit,
-    //navigateToPlayer: () -> Unit = {},
-    //showBottomSheet: Boolean,
 ) {
-    var showBottomSheet by remember { mutableStateOf(false) }
-
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,//{showBottomSheet = false}
         sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        contentColor = contentColor,//MaterialTheme.colorScheme.onBackground,
-        containerColor = containerColor,//MaterialTheme.colorScheme.background,
-        scrimColor = scrimColor,//MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),
-        properties = properties, //ModalBottomSheetProperties(shouldDismissOnBackPress = true),
-        dragHandle = { CustomDragHandle() }
+        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
+        dragHandle = { CustomDragHandle() },
+        properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
     ) {
         Column (
             verticalArrangement = Arrangement.Top,
@@ -510,10 +524,11 @@ fun AlbumMoreOptionsBottomModal(
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             val albumActions = arrayListOf(
-                Pair(Actions.PlayItem) {  }, //play(album)
-                Pair(Actions.ShuffleItem) {  }, //shuffle(album)
-                Pair(Actions.AddToPlaylist) {  }, //addToPlaylist(album)
-                Pair(Actions.AddToQueue) {  }, //addToQueue(album)
+                Pair(Actions.PlayItem, play),
+                Pair(Actions.PlayItemNext, playNext),
+                Pair(Actions.ShuffleItem, shuffle),
+                //Pair(Actions.AddToPlaylist, addToPlaylist),
+                Pair(Actions.AddToQueue, addToQueue),
             )
 
             // action items, shown items are dependent on this being a song item
@@ -524,24 +539,18 @@ fun AlbumMoreOptionsBottomModal(
 
             // if album has album artist and not already on ArtistDetails screen
             if (album.albumArtistId != null && context != "ArtistDetails")
-                ActionOptionRow( Actions.GoToAlbumArtist, {} ) // { navigateToArtistDetails(albumArtistId) }
+                ActionOptionRow( Actions.GoToAlbumArtist, goToArtist ) // { navigateToArtistDetails(albumArtistId) }
 
             // if in artistDetails, in library.Albums,
             if (context != "AlbumDetails")
-                ActionOptionRow( Actions.GoToAlbum, {} ) // { navigateToAlbumDetails(albumId) or navigateToAlbumDetails(album) }
+                ActionOptionRow( Actions.GoToAlbum, goToAlbum ) // { navigateToAlbumDetails(albumId) or navigateToAlbumDetails(album) }
 
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             ActionOptionRow( Actions.EditAlbumTags, {} ) //onClick action would go into lambda edit album tags
 
             Button(
-                onClick = {
-                    showBottomSheet = false
-                    coroutineScope.launch {
-                        sheetState.hide()
-                        showBottomSheet = false
-                    }
-                },
+                onClick = onClose,
                 colors = buttonColors(
                     containerColor = MaterialTheme.colorScheme.surfaceVariant,//.copy(alpha = 0.5f),
                     contentColor = MaterialTheme.colorScheme.onBackground,
@@ -563,32 +572,27 @@ fun AlbumMoreOptionsBottomModal(
 @Composable
 fun ArtistMoreOptionsBottomModal(
     onDismissRequest: () -> Unit,
-
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
-    contentColor: Color = MaterialTheme.colorScheme.onBackground,
-    containerColor: Color = MaterialTheme.colorScheme.background,
-    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
-    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
 
-    coroutineScope: CoroutineScope,
     artist: ArtistInfo,
-    //navigateToArtistDetails: (ArtistInfo) -> Unit,
-    navigateToPlayer: () -> Unit = {},
+    play: () -> Unit = {},
+    playNext: () -> Unit = {},
+    shuffle: () -> Unit = {},
+    //addToPlaylist: () -> Unit = {},
+    addToQueue: () -> Unit = {},
+    goToArtist: () -> Unit = {}, // if on Library.Artists tab
+    onClose: () -> Unit = {},
     context: String = "",
-    //showBottomSheet: Boolean,
 ) {
-    var showBottomSheet by remember { mutableStateOf(false) }
-
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,//{showBottomSheet = false}
         sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        contentColor = contentColor,//MaterialTheme.colorScheme.onBackground,
-        containerColor = containerColor,//MaterialTheme.colorScheme.background,
-        scrimColor = scrimColor,//MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),
-        properties = properties, //ModalBottomSheetProperties(shouldDismissOnBackPress = true),
-        dragHandle = { CustomDragHandle() }
+        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
+        dragHandle = { CustomDragHandle() },
+        properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
     ) {
-
         Column (
             verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.Start,
@@ -600,10 +604,11 @@ fun ArtistMoreOptionsBottomModal(
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             val artistActions = arrayListOf(
-                Pair(Actions.PlayItem) { /* probably call controller here, pass in artist songs */ }, // play(artist)
-                Pair(Actions.ShuffleItem) { /* probably call controller here, pass in artist songs */ }, // shuffle(artist)
-                Pair(Actions.AddToPlaylist) { /* probably call controller here, pass in artist songs */ }, //addToPlaylist(artist)
-                Pair(Actions.AddToQueue) { /* probably call controller here, pass in artist songs */ }, //addToQueue(artist)
+                Pair(Actions.PlayItem, play),
+                Pair(Actions.PlayItemNext, playNext),
+                Pair(Actions.ShuffleItem, shuffle),
+                //Pair(Actions.AddToPlaylist, addToPlaylist),
+                Pair(Actions.AddToQueue, addToQueue),
             )
 
             // action items, shown items are dependent on this being an artist item
@@ -614,20 +619,14 @@ fun ArtistMoreOptionsBottomModal(
 
             // if on library.artists
             if (context != "ArtistDetails") {
-                ActionOptionRow( Actions.GoToArtist, {} )
+                ActionOptionRow( Actions.GoToArtist, goToArtist )
                 HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
             }
 
-            ActionOptionRow( Actions.EditArtistTags, {}) //onClick action in the lambda
+            ActionOptionRow( Actions.EditArtistTags, {} ) //onClick action in the lambda
 
             Button(
-                onClick = {
-                    showBottomSheet = false
-                    coroutineScope.launch {
-                        sheetState.hide()
-                        showBottomSheet = false
-                    }
-                },
+                onClick = onClose,
                 colors = buttonColors(
                     containerColor = MaterialTheme.colorScheme.surfaceVariant,//.copy(alpha = 0.5f),
                     contentColor = MaterialTheme.colorScheme.onBackground,
@@ -649,36 +648,32 @@ fun ArtistMoreOptionsBottomModal(
 @Composable
 fun ComposerMoreOptionsBottomModal(
     onDismissRequest: () -> Unit,
-
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
-    contentColor: Color = MaterialTheme.colorScheme.onBackground,
-    containerColor: Color = MaterialTheme.colorScheme.background,
-    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
-    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
 
-    coroutineScope: CoroutineScope,
     composer: ComposerInfo,
-    navigateToComposerDetails: (ComposerInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit = {},
+    play: () -> Unit = {},
+    playNext: () -> Unit = {},
+    shuffle: () -> Unit = {},
+    //addToPlaylist: () -> Unit = {},
+    addToQueue: () -> Unit = {},
+    navigateToComposerDetails: (ComposerInfo) -> Unit, // if on Library.Composers tab
+    onClose: () -> Unit = {},
     context: String = "",
-    //showBottomSheet: Boolean,
 ) {
-    var showBottomSheet by remember { mutableStateOf(false) }
-
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,//{showBottomSheet = false}
         sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        contentColor = contentColor,//MaterialTheme.colorScheme.onBackground,
-        containerColor = containerColor,//MaterialTheme.colorScheme.background,
-        scrimColor = scrimColor,//MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),
-        properties = properties, //ModalBottomSheetProperties(shouldDismissOnBackPress = true),
-        dragHandle = { CustomDragHandle() }
+        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
+        dragHandle = { CustomDragHandle() },
+        properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
     ) {
 
         Column (
-            modifier = Modifier.padding(horizontal = 24.dp),
             verticalArrangement = Arrangement.Top,
-            horizontalAlignment = Alignment.Start
+            horizontalAlignment = Alignment.Start,
+            modifier = Modifier,
         ) {
             // header section
             MoreOptionModalHeader(composer.name, composer)
@@ -686,10 +681,11 @@ fun ComposerMoreOptionsBottomModal(
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             val composerActions = listOf(
-                Pair(Actions.PlayItem) { /* probably call controller here, pass in composer songs */ }, // play(composer)
-                Pair(Actions.ShuffleItem) { /* probably call controller here, pass in composer songs */ }, // shuffle(composer)
-                Pair(Actions.AddToPlaylist) { /* probably call controller here, pass in composer songs */ }, //addToPlaylist(composer)
-                Pair(Actions.AddToQueue) { /* probably call controller here, pass in composer songs */ }, //addToQueue(composer)
+                Pair(Actions.PlayItem, play),
+                Pair(Actions.PlayItemNext, playNext),
+                Pair(Actions.ShuffleItem, shuffle),
+                //Pair(Actions.AddToPlaylist, addToPlaylist),
+                Pair(Actions.AddToQueue, addToQueue),
             )
 
             // action items, shown items are dependent on this being a song item
@@ -708,13 +704,7 @@ fun ComposerMoreOptionsBottomModal(
             ActionOptionRow( Actions.EditComposerTags, {} )
 
             Button(
-                onClick = {
-                    showBottomSheet = false
-                    coroutineScope.launch {
-                        sheetState.hide()
-                        showBottomSheet = false
-                    }
-                },
+                onClick = onClose,
                 colors = buttonColors(
                     containerColor = MaterialTheme.colorScheme.surfaceVariant,//.copy(alpha = 0.5f),
                     contentColor = MaterialTheme.colorScheme.onBackground,
@@ -736,47 +726,45 @@ fun ComposerMoreOptionsBottomModal(
 @Composable
 fun GenreMoreOptionsBottomModal(
     onDismissRequest: () -> Unit,
-
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
-    contentColor: Color = MaterialTheme.colorScheme.onBackground,
-    containerColor: Color = MaterialTheme.colorScheme.background,
-    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
-    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
 
-    coroutineScope: CoroutineScope,
     genre: GenreInfo,
     navigateToGenreDetails: (GenreInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit = {},
+    play: () -> Unit = {},
+    playNext: () -> Unit = {},
+    shuffle: () -> Unit = {},
+    //addToPlaylist: () -> Unit = {},
+    addToQueue: () -> Unit = {},
+    goToGenre: () -> Unit = {}, // if on Library.Genres tab
+    onClose: () -> Unit = {},
     context: String = "",
-    //showBottomSheet: Boolean,
 ) {
-    var showBottomSheet by remember { mutableStateOf(false) }
-
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,//{showBottomSheet = false}
         sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        contentColor = contentColor,//MaterialTheme.colorScheme.onBackground,
-        containerColor = containerColor,//MaterialTheme.colorScheme.background,
-        scrimColor = scrimColor,//MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),
-        properties = properties, //ModalBottomSheetProperties(shouldDismissOnBackPress = true),
-        dragHandle = { CustomDragHandle() }
+        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
+        dragHandle = { CustomDragHandle() },
+        properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
     ) {
-
         Column (
-            modifier = Modifier.padding(horizontal = 24.dp),
             verticalArrangement = Arrangement.Top,
-            horizontalAlignment = Alignment.Start
+            horizontalAlignment = Alignment.Start,
+            modifier = Modifier,
         ) {
             // header section
             MoreOptionModalHeader(genre.name, genre)
 
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray)
+            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             val genreActions = listOf(
-                Pair(Actions.PlayItem) { /* probably call controller here, pass in genre songs */ }, // play(genre)
-                Pair(Actions.ShuffleItem) { /* probably call controller here, pass in genre songs */ }, // shuffle(genre)
-                Pair(Actions.AddToPlaylist) { /* probably call controller here, pass in genre songs */ }, //addToPlaylist(genre)
-                Pair(Actions.AddToQueue) { /* probably call controller here, pass in genre songs */ }, //addToQueue(genre)
+                Pair(Actions.PlayItem, play),
+                Pair(Actions.PlayItemNext, playNext),
+                Pair(Actions.ShuffleItem, shuffle),
+                //Pair(Actions.AddToPlaylist, addToPlaylist),
+                Pair(Actions.AddToQueue, addToQueue),
             )
 
             // action items, shown items are dependent on this being a song item
@@ -788,19 +776,14 @@ fun GenreMoreOptionsBottomModal(
             // if on library.genres
             if (context != "GenreDetails") {
                 ActionOptionRow(Actions.GoToGenre, { navigateToGenreDetails(genre) }) // { navigateToGenreDetails(genre.id) }
-                HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
             }
+
+            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             ActionOptionRow(Actions.EditGenreTags, {})
 
             Button(
-                onClick = {
-                    showBottomSheet = false
-                    coroutineScope.launch {
-                        sheetState.hide()
-                        showBottomSheet = false
-                    }
-                },
+                onClick = onClose,
                 colors = buttonColors(
                     containerColor = MaterialTheme.colorScheme.surfaceVariant,//.copy(alpha = 0.5f),
                     contentColor = MaterialTheme.colorScheme.onBackground,
@@ -823,33 +806,32 @@ fun GenreMoreOptionsBottomModal(
 fun PlaylistMoreOptionsBottomModal(
     onDismissRequest: () -> Unit,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
-    contentColor: Color = MaterialTheme.colorScheme.onBackground,
-    containerColor: Color = MaterialTheme.colorScheme.background,
-    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
-    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
-    coroutineScope: CoroutineScope,
+
     playlist: PlaylistInfo,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
     navigateToPlayer: (SongInfo) -> Unit = {},
+    play: () -> Unit = {},
+    playNext: () -> Unit = {},
+    shuffle: () -> Unit = {},
+    //addToPlaylist: () -> Unit = {},
+    addToQueue: () -> Unit = {},
+    goToPlaylist: () -> Unit = {}, // if on Library.Playlists tab
+    onClose: () -> Unit = {},
     context: String = "",
-    //showBottomSheet: Boolean,
 ) {
-    var showBottomSheet by remember { mutableStateOf(false) }
-
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,//{showBottomSheet = false}
         sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        contentColor = contentColor,//MaterialTheme.colorScheme.onBackground,
-        containerColor = containerColor,//MaterialTheme.colorScheme.background,
-        scrimColor = scrimColor,//MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),
-        properties = properties, //ModalBottomSheetProperties(shouldDismissOnBackPress = true),
-        dragHandle = { CustomDragHandle() }
+        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
+        dragHandle = { CustomDragHandle() },
+        properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
     ) {
-
         Column (
             verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.Start,
-            modifier = Modifier//.padding(horizontal = 24.dp),
+            modifier = Modifier,
         ) {
             // header section
             MoreOptionModalHeader(playlist.name, playlist)
@@ -857,10 +839,11 @@ fun PlaylistMoreOptionsBottomModal(
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
             val playlistActions = listOf(
-                Pair(Actions.PlayItem) { /* probably call controller here, pass in playlist songs */ }, // play(playlist)
-                Pair(Actions.ShuffleItem) { /* probably call controller here, pass in playlist songs */ }, // shuffle(playlist)
-                Pair(Actions.AddToPlaylist) { /* probably call controller here, pass in playlist songs */ }, //addToPlaylist(playlist)
-                Pair(Actions.AddToQueue) { /* probably call controller here, pass in playlist songs */ }, //addToQueue(playlist)
+                Pair(Actions.PlayItem, play),
+                Pair(Actions.PlayItemNext, playNext),
+                Pair(Actions.ShuffleItem, shuffle),
+                //Pair(Actions.AddToPlaylist, addToPlaylist),
+                Pair(Actions.AddToQueue, addToQueue),
             )
 
             // action items, shown items are dependent on this being a song item
@@ -871,25 +854,19 @@ fun PlaylistMoreOptionsBottomModal(
 
             // if on library.playlists
             if (context != "PlaylistDetails") {
-                ActionOptionRow( Actions.GoToPlaylist, { navigateToPlaylistDetails(playlist) }) // { navigateToPlaylistDetails(playlist.id) }
+                ActionOptionRow( Actions.GoToPlaylist, goToPlaylist ) // { navigateToPlaylistDetails(playlist.id) }
                 HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
             }
 
-            ActionOptionRow(Actions.EditPlaylistTags, {})
-            ActionOptionRow(Actions.EditPlaylistOrder, {})
+            ActionOptionRow( Actions.EditPlaylistTags, {} )
+            ActionOptionRow( Actions.EditPlaylistOrder, {} )
 
             HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
             ActionOptionRow( Actions.ExportPlaylist, {} )
             ActionOptionRow( Actions.DeletePlaylist, {} )
 
             Button(
-                onClick = {
-                    showBottomSheet = false
-                    coroutineScope.launch {
-                        sheetState.hide()
-                        showBottomSheet = false
-                    }
-                },
+                onClick = onClose,
                 colors = buttonColors(
                     containerColor = MaterialTheme.colorScheme.surfaceVariant,
                     contentColor = MaterialTheme.colorScheme.onBackground,
@@ -923,23 +900,25 @@ fun PlaylistMoreOptionsBottomModal(
 fun QueueMoreOptionsBottomModal(
     onDismissRequest: () -> Unit,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
-    contentColor: Color = MaterialTheme.colorScheme.onBackground,
-    containerColor: Color = MaterialTheme.colorScheme.background,
-    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
-    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
-    coroutineScope: CoroutineScope,
-    queue: String = "", // placeholder
-) {
-    var showBottomSheet by remember { mutableStateOf(false) }
 
+    navigateToPlayer: () -> Unit = {},
+    play: () -> Unit = {},
+    playNext: () -> Unit = {},
+    shuffle: () -> Unit = {},
+    addToPlaylist: () -> Unit = {},
+    addToQueue: () -> Unit = {},
+    clearQueue: () -> Unit = {},
+    onClose: () -> Unit = {},
+    context: String = "",
+) {
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,//{showBottomSheet = false}
         sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        contentColor = contentColor,//MaterialTheme.colorScheme.onBackground,
-        containerColor = containerColor,//MaterialTheme.colorScheme.background,
-        scrimColor = scrimColor,//MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),
-        properties = properties, //ModalBottomSheetProperties(shouldDismissOnBackPress = true),
-        dragHandle = { CustomDragHandle() }
+        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
+        dragHandle = { CustomDragHandle() },
+        properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
     ) {
         Column (
             verticalArrangement = Arrangement.Top,
@@ -956,18 +935,12 @@ fun QueueMoreOptionsBottomModal(
             }
             HorizontalDivider( thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp) )
 
-            ActionOptionRow( Actions.AddToPlaylist, {} )
-            ActionOptionRow( Actions.ClearQueue, {} )
+            ActionOptionRow( Actions.AddToPlaylist, addToPlaylist )
+            ActionOptionRow( Actions.ClearQueue, clearQueue )
             ActionOptionRow( Actions.SaveQueueToPlaylist, {} )
 
             Button(
-                onClick = {
-                    showBottomSheet = false
-                    coroutineScope.launch {
-                        sheetState.hide()
-                        showBottomSheet = false
-                    }
-                },
+                onClick = onClose,
                 colors = buttonColors(
                     containerColor = MaterialTheme.colorScheme.surfaceVariant,
                     contentColor = MaterialTheme.colorScheme.onBackground,
@@ -991,26 +964,21 @@ fun QueueMoreOptionsBottomModal(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LibrarySortSelectionBottomModal(
-    onDismissRequest: () -> Unit,// = { var showBottomSheet = false },
-
+    onDismissRequest: () -> Unit,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-    contentColor: Color = MaterialTheme.colorScheme.onBackground,
-    containerColor: Color = MaterialTheme.colorScheme.background,
-    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
-    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
 
-    coroutineScope: CoroutineScope,
     libraryCategory: LibraryCategory,
+    onClose: () -> Unit = {},
+    onSave: () -> Unit = {},
 ){
-    //var showBottomSheet by remember { mutableStateOf(false) }
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        contentColor = contentColor,
-        containerColor = containerColor,
-        scrimColor = scrimColor,
-        properties = properties,
-        dragHandle = { CustomDragHandle() }
+        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
+        dragHandle = { CustomDragHandle() },
+        properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
     ) {
         LazyColumn (
             verticalArrangement = Arrangement.Top,
@@ -1095,13 +1063,7 @@ fun LibrarySortSelectionBottomModal(
                 Row {
                     //cancel/exit btn
                     Button(
-                        onClick = {
-                            //showBottomSheet = false
-                            coroutineScope.launch {
-                                sheetState.hide()
-                                //showBottomSheet = false
-                            }
-                        },
+                        onClick = onClose,
                         colors = buttonColors(
                             containerColor = MaterialTheme.colorScheme.surfaceVariant,
                             contentColor = MaterialTheme.colorScheme.onBackground,
@@ -1118,12 +1080,7 @@ fun LibrarySortSelectionBottomModal(
 
                     //apply btn
                     Button(
-                        onClick = {
-                            //showBottomSheet = false
-                            coroutineScope.launch {
-                                sheetState.hide()
-                            }
-                        },
+                        onClick = onSave,
                         colors = buttonColors(
                             contentColor = MaterialTheme.colorScheme.background,
                             disabledContainerColor = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1148,27 +1105,22 @@ fun LibrarySortSelectionBottomModal(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DetailsSortSelectionBottomModal(
-    onDismissRequest: () -> Unit,// = { var showBottomSheet = false },
-
+    onDismissRequest: () -> Unit,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-    contentColor: Color = MaterialTheme.colorScheme.onBackground,
-    containerColor: Color = MaterialTheme.colorScheme.background,
-    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),
-    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
 
-    coroutineScope: CoroutineScope,
+    onClose: () -> Unit = {},
+    onSave: () -> Unit = {},
     content: String = "", // item(s) to be sorted
     context: String = "", // screen containing item(s) to sort
 ){
-    // var showBottomSheet by remember { mutableStateOf(false) }
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        contentColor = contentColor,
-        containerColor = containerColor,
-        scrimColor = scrimColor,
-        properties = properties,
-        dragHandle = { CustomDragHandle() }
+        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
+        dragHandle = { CustomDragHandle() },
+        properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
     ) {
         LazyColumn(
             verticalArrangement = Arrangement.Top,
@@ -1231,13 +1183,7 @@ fun DetailsSortSelectionBottomModal(
                 Row {
                     //cancel/exit btn
                     Button(
-                        onClick = {
-                            //showBottomSheet = false
-                            coroutineScope.launch {
-                                sheetState.hide()
-                                //showBottomSheet = false
-                            }
-                        },
+                        onClick = onClose,
                         colors = buttonColors(
                             containerColor = MaterialTheme.colorScheme.surfaceVariant,
                             contentColor = MaterialTheme.colorScheme.onBackground,
@@ -1254,12 +1200,7 @@ fun DetailsSortSelectionBottomModal(
 
                     //apply btn
                     Button(
-                        onClick = {
-                            //showBottomSheet = false
-                            coroutineScope.launch {
-                                sheetState.hide()
-                            }
-                        },
+                        onClick = onSave,
                         colors = buttonColors(
                             contentColor = MaterialTheme.colorScheme.background,
                             disabledContainerColor = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1285,14 +1226,11 @@ fun DetailsSortSelectionBottomModal(
 @Composable
 fun CreatePlaylistBottomModal(
     onDismissRequest: () -> Unit,
-
     sheetState: SheetState = rememberModalBottomSheetState(),
-    contentColor: Color = MaterialTheme.colorScheme.onBackground,
-    containerColor: Color = MaterialTheme.colorScheme.background,
-    scrimColor: Color = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),
-    properties: ModalBottomSheetProperties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
 
     coroutineScope: CoroutineScope,
+    onClose: () -> Unit = {},
+    onSave: () -> Unit = {},
 ) {
     var nameText by remember { mutableStateOf("") }
     var descriptionText by remember { mutableStateOf("") }
@@ -1311,15 +1249,14 @@ fun CreatePlaylistBottomModal(
         snapshotFlow { state.text }.collect{ validate(it) }
     }
 
-    //var showBottomSheet by remember { mutableStateOf(false) }
     ModalBottomSheet(
         onDismissRequest = onDismissRequest, //onDismissRequest = { showBottomSheet = false },
         sheetState = sheetState,
-        contentColor = contentColor,
-        containerColor = containerColor,
-        scrimColor = scrimColor,
-        properties = properties,
-        dragHandle = { CustomDragHandle() }
+        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
+        dragHandle = { CustomDragHandle() },
+        properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
     ) {
         LazyVerticalGrid(
             columns = GridCells.Fixed(1),
@@ -1402,13 +1339,7 @@ fun CreatePlaylistBottomModal(
                 Row {
                     //cancel btn
                     Button(
-                        onClick = { //still doesn't do the showBottomSheet thing correctly since it's in different file
-                            //showBottomSheet = false
-                            coroutineScope.launch {
-                                sheetState.hide()
-                                //showBottomSheet = false
-                            }
-                        },
+                        onClick = onClose,
                         colors = buttonColors(
                             containerColor = MaterialTheme.colorScheme.surfaceVariant,
                             contentColor = MaterialTheme.colorScheme.onBackground,
@@ -1457,20 +1388,21 @@ fun CreatePlaylistBottomModal(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BottomSheet(
-    song: SongInfo, //actually ... should this be SongInfo or PlayerSong, since the context is related to the Player
-    isPlaying: Boolean = true,
-    navigateToPlayer: (SongInfo) -> Unit = {}, //consequently, should this be using PlayerSong since it is indeed related to the Player
-    navigateToQueue: () -> Unit = {},
-    sheetState: BottomSheetScaffoldState =
-        rememberBottomSheetScaffoldState(
-            SheetState(
-                skipPartiallyExpanded = false,
-                density = Density(1f,1f),
-                initialValue = if (isPlaying) SheetValue.PartiallyExpanded else SheetValue.Hidden,
-                skipHiddenState = isPlaying,
-            )
-        ),
-    coroutineScope: CoroutineScope = rememberCoroutineScope(),
+    song: SongInfo,
+    isPlaying: Boolean,
+    onPlayPress: () -> Unit,
+    onPausePress: () -> Unit,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
+    navigateToPlayer: () -> Unit = {},
+    //navigateToQueue: () -> Unit = {},
+    sheetState: BottomSheetScaffoldState = rememberBottomSheetScaffoldState(),
+        /*SheetState(
+            skipPartiallyExpanded = false,
+            density = Density(1f,1f),
+            initialValue = if (isActive) SheetValue.PartiallyExpanded else SheetValue.Hidden,
+            skipHiddenState = isActive,
+        )*/
     modifier: Modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars),
     content: @Composable () -> Unit = {},
 ) {
@@ -1487,44 +1419,70 @@ fun BottomSheet(
         ),
     )*/
     BottomSheetScaffold(
-        scaffoldState = BottomSheetScaffoldState(
-            bottomSheetState = sheetState.bottomSheetState,//SheetState(initialValue = SheetValue.Expanded, skipPartiallyExpanded = true, density = Density(1f,1f)),
-            snackbarHostState = sheetState.snackbarHostState,//SnackbarHostState(),
-        ),
-        sheetContainerColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        sheetDragHandle = {
-            if (sheetState.bottomSheetState.hasExpandedState) {
-                CustomDragHandle()
-            } else
-                null
-        },
-        sheetShape = MusicShapes.extraSmall,
         sheetContent = {
-            if (sheetState.bottomSheetState.hasPartiallyExpandedState)
+            /*if (sheetState.bottomSheetState.hasPartiallyExpandedState)
                 BottomSheetPlayer(
                     song = song,
                     isPlaying = isPlaying,
                     navigateToPlayer = navigateToPlayer,
-                    navigateToQueue = navigateToQueue,
-                    onPlayPress = {  },
-                    onPausePress = {  },
+                    //navigateToQueue = navigateToQueue,
+                    onPlayPress = onPlayPress,
+                    onPausePress = onPausePress,
                     modifier = modifier,
                 )
             else if (sheetState.bottomSheetState.hasExpandedState)
-                BottomSheetFullPlayer(
+                */BottomSheetFullPlayer(
                     song = song,
                     isPlaying = isPlaying,
                     navigateToPlayer = navigateToPlayer,
-                    navigateToQueue = navigateToQueue,
-                    onPlayPress = {  },
-                    onPausePress = {  },
-                    onNext = {  },
-                    onPrevious = {  },
+                    //navigateToQueue = navigateToQueue,
+                    onPlayPress = onPlayPress,
+                    onPausePress = onPausePress,
+                    onNext = onNext,
+                    onPrevious = onPrevious,
                     modifier = modifier,
                 )
         },
-        modifier = modifier,//Modifier.windowInsetsPadding(WindowInsets.navigationBars),
-    ) {
+        //modifier = modifier,//Modifier.windowInsetsPadding(WindowInsets.navigationBars),
+        scaffoldState = BottomSheetScaffoldState(
+            bottomSheetState = sheetState.bottomSheetState,//SheetState(initialValue = SheetValue.Expanded, skipPartiallyExpanded = true, density = Density(1f,1f)),
+            snackbarHostState = sheetState.snackbarHostState,//SnackbarHostState(),
+        ),
+        sheetPeekHeight = 0.dp,
+        sheetMaxWidth = Dp.Unspecified,
+        sheetShape = MusicShapes.extraSmall,
+        sheetContainerColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        //sheetContentColor
+        //sheetTonalElevation
+        //sheetShadowElevation
+        sheetDragHandle = {
+            if (sheetState.bottomSheetState.hasExpandedState) {
+                CustomDragHandle()
+            }
+        },
+        sheetSwipeEnabled = false,
+        topBar = { /* // screen's top app bar
+            HomeTopAppBar(
+                navigateToSearch = navigateToSearch,
+                onNavigationIconClick = {
+                    coroutineScope.launch {
+                        drawerState.apply {
+                            if (isClosed) open() else close()
+                        }
+                    }
+                },
+            )
+            if (isLoading) {
+                LinearProgressIndicator(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                )
+        }*/ },
+        //snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+        containerColor = Color.Transparent,
+        contentColor = contentColorFor(MaterialTheme.colorScheme.background), //MaterialTheme.colorScheme.inverseSurface //or onPrimaryContainer
+    ) { //content with paddingValues
         content()
     }
 }
@@ -1534,14 +1492,18 @@ fun BottomSheet(
 fun BottomSheetPlayer(
     song: SongInfo,
     isPlaying: Boolean = true,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToQueue: () -> Unit = {},
+    navigateToPlayer: () -> Unit,
+    //navigateToQueue: () -> Unit = {},
     onPlayPress: () -> Unit = {},
     onPausePress: () -> Unit = {},
     modifier: Modifier = Modifier,
     playerButtonSize: Dp = 72.dp,
     sideButtonSize: Dp = 48.dp,
 ) {
+    Log.i(TAG, "Song: ${song.title}\n" +
+            "has Artist?: ${song.artistName}\n" +
+            "has artwork?: ${song.artworkUri}\n")
+
     val sideButtonsModifier = Modifier
         .size(sideButtonSize)
         .background(
@@ -1565,7 +1527,7 @@ fun BottomSheetPlayer(
         Surface(
             modifier = modifier.fillMaxWidth(),
             color = MaterialTheme.colorScheme.surfaceContainer,
-            onClick = { navigateToPlayer(song) },
+            onClick = { navigateToPlayer() },
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -1617,7 +1579,7 @@ fun BottomSheetPlayer(
                             }
                     )
                 }
-                IconButton(
+                /*IconButton(
                     onClick = {}
                 ) {
                     Icon(
@@ -1630,7 +1592,7 @@ fun BottomSheetPlayer(
                                 navigateToQueue()
                             }
                     )
-                }
+                }*/
             }
         }
     }
@@ -1641,8 +1603,8 @@ fun BottomSheetPlayer(
 fun BottomSheetFullPlayer(
     song: SongInfo,
     isPlaying: Boolean = true,
-    navigateToPlayer: (SongInfo) -> Unit,
-    navigateToQueue: () -> Unit = {},
+    navigateToPlayer: () -> Unit,
+    //navigateToQueue: () -> Unit = {},
     onPlayPress: () -> Unit = {},
     onPausePress: () -> Unit = {},
     onNext: () -> Unit = {},
@@ -1651,6 +1613,9 @@ fun BottomSheetFullPlayer(
     playerButtonSize: Dp = 72.dp,
     sideButtonSize: Dp = 48.dp,
 ) {
+    Log.i(TAG, "Song: ${song.title}\n" +
+        "has Artist?: ${song.artistName}\n" +
+        "has artwork?: ${song.artworkUri}\n")
     val sideButtonsModifier = Modifier
         .size(sideButtonSize)
         .background(
@@ -1675,7 +1640,7 @@ fun BottomSheetFullPlayer(
             modifier = Modifier
                 .fillMaxWidth(),
             color = MaterialTheme.colorScheme.surfaceContainer,
-            onClick = { navigateToPlayer(song) },
+            onClick = navigateToPlayer,
         ) {
             Column {
                 //track info row
@@ -1702,7 +1667,7 @@ fun BottomSheetFullPlayer(
                         )
                     }
 
-                    IconButton(
+                    /*IconButton(
                         onClick = {}
                     ) {
                         Icon(
@@ -1715,31 +1680,31 @@ fun BottomSheetFullPlayer(
                                     navigateToQueue()
                                 }
                         )
-                    }
+                    }*/
+
+                    //player buttons row
+                    BottomSheetPlayerButtons(
+                        //removed private modifier to borrow this fun for BottomModals
+                        //hasNext = true,
+                        isPlaying = isPlaying,
+                        onPlayPress = onPlayPress,
+                        onPausePress = onPausePress,
+                        onNext = onNext,
+                        onPrevious = onPrevious,
+                        modifier = Modifier,
+                        primaryButtonModifier = primaryButtonModifier,
+                        sideButtonsModifier = sideButtonsModifier,
+                        //need a state saver to handle button interactions
+                    )
+
+                    //slider row
+                    /*PlayerSlider(
+                        progress = 0f,
+                        timeElapsed = 0L,
+                        songDuration = song.duration,
+                        onSeek = {},
+                    )*/
                 }
-
-                //player buttons row
-                BottomSheetPlayerButtons(
-                    //removed private modifier to borrow this fun for BottomModals
-                    hasNext = true,
-                    isPlaying = isPlaying,
-                    onPlayPress = onPlayPress,
-                    onPausePress = onPausePress,
-                    onNext = onNext,
-                    onPrevious = onPrevious,
-                    modifier = Modifier,
-                    primaryButtonModifier = primaryButtonModifier,
-                    sideButtonsModifier = sideButtonsModifier,
-                    //need a state saver to handle button interactions
-                )
-
-                //slider row
-                PlayerSlider(
-                    progress = 0f,
-                    timeElapsed = 0L,
-                    songDuration = song.duration,
-                    onSeek = {},
-                )
             }
         }
     }
@@ -1747,7 +1712,7 @@ fun BottomSheetFullPlayer(
 
 @Composable
 fun BottomSheetPlayerButtons(
-    hasNext: Boolean = false,
+    //hasNext: Boolean = false,
     isPlaying: Boolean = true,
     onPlayPress: () -> Unit = {},
     onPausePress: () -> Unit = {},
@@ -1782,9 +1747,7 @@ fun BottomSheetPlayerButtons(
                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onPrimaryContainer),
                 modifier = primaryButtonModifier
                     .padding(8.dp)
-                    .clickable {
-                        onPausePress()
-                    }
+                    .clickable { onPausePress() }
             )
         } else {
             //determined that the current state is paused (isPlaying is false)
@@ -1795,9 +1758,7 @@ fun BottomSheetPlayerButtons(
                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onPrimaryContainer),
                 modifier = primaryButtonModifier
                     .padding(8.dp)
-                    .clickable {
-                        onPlayPress()
-                    }
+                    .clickable { onPlayPress() }
             )
         }
 
@@ -1808,8 +1769,8 @@ fun BottomSheetPlayerButtons(
             contentScale = ContentScale.Inside,
             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onPrimaryContainer),
             modifier = sideButtonsModifier
-                .clickable(enabled = hasNext, onClick = onNext)
-                .alpha(if (hasNext) 1f else 0.25f)
+                .clickable(enabled = true, onClick = onNext)
+                //.alpha(if (hasNext) 1f else 0.25f)
         )
     }
 }
@@ -1907,7 +1868,6 @@ fun PreviewLibrarySortModal() {
                 density = Density(1f,1f)
             ),
             libraryCategory = LibraryCategory.Genres,
-            coroutineScope = rememberCoroutineScope(),
         )
     }
 }
@@ -1937,7 +1897,16 @@ fun PreviewMoreOptionsModal() {
 fun PreviewBottomSheet() {
     MusicTheme {
         BottomSheet(
-            PreviewSongs[0]
+            song = PreviewSongs[0],
+            isPlaying = false,
+            onPlayPress = {},
+            onPausePress = {},
+            onNext = {},
+            onPrevious = {},
+            navigateToPlayer = {},
+            sheetState = rememberBottomSheetScaffoldState(),
+            modifier = Modifier,
+            content = {},
         )
     }
 }
@@ -1951,7 +1920,7 @@ fun PreviewBottomBarPlayer() {
             song = getSongData(6535),
             isPlaying = true,
             navigateToPlayer = {},
-            navigateToQueue = {},
+            //navigateToQueue = {},
             onPlayPress = {},
             onPausePress = {},
         )

--- a/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
+++ b/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
@@ -495,7 +495,7 @@ fun AlbumMoreOptionsBottomModal(
     goToArtist: () -> Unit = {},
     goToAlbum: () -> Unit = {}, // if on Library.Albums tab
     onClose: () -> Unit = {},
-    context: String,
+    context: String = "",
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,//{showBottomSheet = false}
@@ -722,13 +722,11 @@ fun GenreMoreOptionsBottomModal(
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
 
     genre: GenreInfo,
-    navigateToGenreDetails: (GenreInfo) -> Unit,
-    navigateToPlayer: (SongInfo) -> Unit = {},
     play: () -> Unit = {},
-    playNext: () -> Unit = {},
+    //playNext: () -> Unit = {},
     shuffle: () -> Unit = {},
     //addToPlaylist: () -> Unit = {},
-    addToQueue: () -> Unit = {},
+    //addToQueue: () -> Unit = {},
     goToGenre: () -> Unit = {}, // if on Library.Genres tab
     onClose: () -> Unit = {},
     context: String = "",
@@ -754,26 +752,26 @@ fun GenreMoreOptionsBottomModal(
 
             val genreActions = listOf(
                 Pair(Actions.PlayItem, play),
-                Pair(Actions.PlayItemNext, playNext),
+                //Pair(Actions.PlayItemNext, playNext),
                 Pair(Actions.ShuffleItem, shuffle),
                 //Pair(Actions.AddToPlaylist, addToPlaylist),
-                Pair(Actions.AddToQueue, addToQueue),
+                //Pair(Actions.AddToQueue, addToQueue),
             )
 
             // action items, shown items are dependent on this being a song item
             genreActions.forEach { item ->
                 ActionOptionRow(item.first, item.second)
             }
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
-
+            
             // if on library.genres
             if (context != "GenreDetails") {
-                ActionOptionRow(Actions.GoToGenre, { navigateToGenreDetails(genre) }) // { navigateToGenreDetails(genre.id) }
+                HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
+                ActionOptionRow(Actions.GoToGenre, goToGenre)
             }
 
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
+            //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
-            ActionOptionRow(Actions.EditGenreTags, {})
+            //ActionOptionRow(Actions.EditGenreTags, {})
 
             Button(
                 onClick = onClose,

--- a/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
+++ b/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
@@ -404,8 +404,8 @@ fun SongMoreOptionsBottomModal(
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
         scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
         dragHandle = { CustomDragHandle() },
         properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
@@ -443,22 +443,17 @@ fun SongMoreOptionsBottomModal(
 
             /* //if (song.genreName != "" && context != "GenreDetails")
                 //ActionOptionRow( Pair(Actions.GoToGenre) {} )
-
             //if (song.composerName != "" && context != "ComposerDetails")
                 //ActionOptionRow( Pair(Actions.GoToComposer) {} )
 
             //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
-
             //ActionOptionRow( Pair(Actions.EditSongTags) {} ) //onClick action would go into lambda edit song tags
 
             //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
-
             //if (context == "PlaylistDetails")
                 //ActionOptionRow( Pair(Actions.RemoveFromPlaylist) {} )
-
             //if (context == "Queue")
                 //ActionOptionRow( Pair(Actions.RemoveFromQueue) {} )
-
             //ActionOptionRow( Pair(Actions.DeleteFromLibrary) {} ) */
 
             Button( // close btn
@@ -498,10 +493,10 @@ fun AlbumMoreOptionsBottomModal(
     context: String = "",
 ) {
     ModalBottomSheet(
-        onDismissRequest = onDismissRequest,//{showBottomSheet = false}
-        sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
         scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
         dragHandle = { CustomDragHandle() },
         properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
@@ -532,20 +527,19 @@ fun AlbumMoreOptionsBottomModal(
 
             // if album has album artist and not already on ArtistDetails screen
             if (album.albumArtistId != null && context != "ArtistDetails")
-                ActionOptionRow( Actions.GoToAlbumArtist, goToArtist ) // { navigateToArtistDetails(albumArtistId) }
+                ActionOptionRow( Actions.GoToAlbumArtist, goToArtist )
 
             // if in artistDetails, in library.Albums,
             if (context != "AlbumDetails")
-                ActionOptionRow( Actions.GoToAlbum, goToAlbum ) // { navigateToAlbumDetails(albumId) or navigateToAlbumDetails(album) }
+                ActionOptionRow( Actions.GoToAlbum, goToAlbum )
 
             //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
-
-            //ActionOptionRow( Actions.EditAlbumTags, {} ) //onClick action would go into lambda edit album tags
+            //ActionOptionRow( Actions.EditAlbumTags, {} )
 
             Button(
                 onClick = onClose,
                 colors = buttonColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,//.copy(alpha = 0.5f),
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
                     contentColor = MaterialTheme.colorScheme.onBackground,
                     disabledContainerColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     disabledContentColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -578,10 +572,10 @@ fun ArtistMoreOptionsBottomModal(
     context: String = "",
 ) {
     ModalBottomSheet(
-        onDismissRequest = onDismissRequest,//{showBottomSheet = false}
-        sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
         scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
         dragHandle = { CustomDragHandle() },
         properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
@@ -614,14 +608,14 @@ fun ArtistMoreOptionsBottomModal(
             if (context != "ArtistDetails") {
                 ActionOptionRow( Actions.GoToArtist, goToArtist )
             }
-            //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
+            //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
             //ActionOptionRow( Actions.EditArtistTags, {} ) //onClick action in the lambda
 
             Button(
                 onClick = onClose,
                 colors = buttonColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,//.copy(alpha = 0.5f),
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
                     contentColor = MaterialTheme.colorScheme.onBackground,
                     disabledContainerColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     disabledContentColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -654,10 +648,10 @@ fun ComposerMoreOptionsBottomModal(
     context: String = "",
 ) {
     ModalBottomSheet(
-        onDismissRequest = onDismissRequest,//{showBottomSheet = false}
-        sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
         scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
         dragHandle = { CustomDragHandle() },
         properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
@@ -689,17 +683,16 @@ fun ComposerMoreOptionsBottomModal(
 
             // if on library.composers
             if (context != "ComposerDetails") {
-                ActionOptionRow( Actions.GoToComposer, { navigateToComposerDetails(composer)} ) // { navigateToComposerDetails(composer.id) }
-
-                HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
+                ActionOptionRow( Actions.GoToComposer, { navigateToComposerDetails(composer)} )
             }
 
-            ActionOptionRow( Actions.EditComposerTags, {} )
+            //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
+            //ActionOptionRow( Actions.EditComposerTags, {} )
 
             Button(
                 onClick = onClose,
                 colors = buttonColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,//.copy(alpha = 0.5f),
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
                     contentColor = MaterialTheme.colorScheme.onBackground,
                     disabledContainerColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     disabledContentColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -723,19 +716,19 @@ fun GenreMoreOptionsBottomModal(
 
     genre: GenreInfo,
     play: () -> Unit = {},
-    //playNext: () -> Unit = {},
+    playNext: () -> Unit = {},
     shuffle: () -> Unit = {},
     //addToPlaylist: () -> Unit = {},
-    //addToQueue: () -> Unit = {},
+    addToQueue: () -> Unit = {},
     goToGenre: () -> Unit = {}, // if on Library.Genres tab
     onClose: () -> Unit = {},
     context: String = "",
 ) {
     ModalBottomSheet(
-        onDismissRequest = onDismissRequest,//{showBottomSheet = false}
-        sheetState = sheetState,//rememberModalBottomSheetState(skipPartiallyExpanded = false,),
-        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
         scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
         dragHandle = { CustomDragHandle() },
         properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
@@ -752,31 +745,30 @@ fun GenreMoreOptionsBottomModal(
 
             val genreActions = listOf(
                 Pair(Actions.PlayItem, play),
-                //Pair(Actions.PlayItemNext, playNext),
+                Pair(Actions.PlayItemNext, playNext),
                 Pair(Actions.ShuffleItem, shuffle),
                 //Pair(Actions.AddToPlaylist, addToPlaylist),
-                //Pair(Actions.AddToQueue, addToQueue),
+                Pair(Actions.AddToQueue, addToQueue),
             )
 
             // action items, shown items are dependent on this being a song item
             genreActions.forEach { item ->
                 ActionOptionRow(item.first, item.second)
             }
-            
+            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
+
             // if on library.genres
             if (context != "GenreDetails") {
-                HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
                 ActionOptionRow(Actions.GoToGenre, goToGenre)
             }
 
             //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
-
             //ActionOptionRow(Actions.EditGenreTags, {})
 
             Button(
                 onClick = onClose,
                 colors = buttonColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,//.copy(alpha = 0.5f),
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
                     contentColor = MaterialTheme.colorScheme.onBackground,
                     disabledContainerColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     disabledContentColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -960,13 +952,13 @@ fun LibrarySortSelectionBottomModal(
 
     libraryCategory: LibraryCategory,
     onClose: () -> Unit = {},
-    onSave: () -> Unit = {},
+    onApply: () -> Unit = {},
 ){
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
         scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
         dragHandle = { CustomDragHandle() },
         properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
@@ -1071,7 +1063,7 @@ fun LibrarySortSelectionBottomModal(
 
                     //apply btn
                     Button(
-                        onClick = onSave,
+                        onClick = onApply,
                         colors = buttonColors(
                             contentColor = MaterialTheme.colorScheme.background,
                             disabledContainerColor = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1100,7 +1092,7 @@ fun DetailsSortSelectionBottomModal(
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
 
     onClose: () -> Unit = {},
-    onSave: () -> Unit = {},
+    onApply: () -> Unit = {},
     content: String = "", // item(s) to be sorted
     context: String = "", // screen containing item(s) to sort
 ){
@@ -1191,7 +1183,7 @@ fun DetailsSortSelectionBottomModal(
 
                     //apply btn
                     Button(
-                        onClick = onSave,
+                        onClick = onApply,
                         colors = buttonColors(
                             contentColor = MaterialTheme.colorScheme.background,
                             disabledContainerColor = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1221,7 +1213,7 @@ fun CreatePlaylistBottomModal(
 
     coroutineScope: CoroutineScope,
     onClose: () -> Unit = {},
-    onSave: () -> Unit = {},
+    onCreate: () -> Unit = {},
 ) {
     var nameText by remember { mutableStateOf("") }
     var descriptionText by remember { mutableStateOf("") }
@@ -1241,10 +1233,10 @@ fun CreatePlaylistBottomModal(
     }
 
     ModalBottomSheet(
-        onDismissRequest = onDismissRequest, //onDismissRequest = { showBottomSheet = false },
+        onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.background,//MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground,//MaterialTheme.colorScheme.onBackground,
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
         scrimColor = MaterialTheme.colorScheme.surfaceBright.copy(alpha=0.7f),// = MaterialTheme.colorScheme.scrim.copy(alpha=0.2f),
         dragHandle = { CustomDragHandle() },
         properties = ModalBottomSheetProperties(shouldDismissOnBackPress = true),
@@ -1347,13 +1339,7 @@ fun CreatePlaylistBottomModal(
 
                     //create playlist btn
                     Button(
-                        onClick = { //still doesn't do the showBottomSheet thing correctly since it's in different file
-                            //showBottomSheet = false
-                            coroutineScope.launch {
-                                sheetState.hide()
-                                //showBottomSheet = false
-                            }
-                        },
+                        onClick = onCreate,
                         enabled = !createEnabled.value,
                         colors = buttonColors(
                             contentColor = MaterialTheme.colorScheme.background,

--- a/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
+++ b/app/src/main/java/com/example/music/ui/shared/BottomModals.kt
@@ -174,7 +174,6 @@ fun ActionOptionRow(
 fun MoreOptionModalHeader(
     title: String = "", // item's name or title
     item: Any, // one of the info items ... should these Info types actually come from a base class?
-    //contentDescription: String = "", // also likely item's name or title, currently an item's artwork
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -217,32 +216,26 @@ fun MoreOptionModalHeader(
                 text = when(item) {
                     is SongInfo -> {
                         item.setSubtitle()
-                        //songSubtext(item)
                     }
 
                     is PlaylistInfo -> {
                         item.setSubtitle()
-                        //songCountSubtext(item)
                     }
 
                     is ArtistInfo -> {
                         item.setSubtitle()
-                        //artistSubtext(item)
                     }
 
                     is AlbumInfo -> {
                         item.setSubtitle()
-                        //songCountSubtext(item)
                     }
 
                     is ComposerInfo -> {
                         item.setSubtitle()
-                        //songCountSubtext(item)
                     }
 
                     is GenreInfo -> {
                         item.setSubtitle()
-                        //songCountSubtext(item)
                     }
 
                     else -> {
@@ -545,9 +538,9 @@ fun AlbumMoreOptionsBottomModal(
             if (context != "AlbumDetails")
                 ActionOptionRow( Actions.GoToAlbum, goToAlbum ) // { navigateToAlbumDetails(albumId) or navigateToAlbumDetails(album) }
 
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
+            //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
-            ActionOptionRow( Actions.EditAlbumTags, {} ) //onClick action would go into lambda edit album tags
+            //ActionOptionRow( Actions.EditAlbumTags, {} ) //onClick action would go into lambda edit album tags
 
             Button(
                 onClick = onClose,
@@ -620,10 +613,10 @@ fun ArtistMoreOptionsBottomModal(
             // if on library.artists
             if (context != "ArtistDetails") {
                 ActionOptionRow( Actions.GoToArtist, goToArtist )
-                HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
             }
+            //HorizontalDivider(thickness = 1.dp, color = Color.Gray, modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
 
-            ActionOptionRow( Actions.EditArtistTags, {} ) //onClick action in the lambda
+            //ActionOptionRow( Actions.EditArtistTags, {} ) //onClick action in the lambda
 
             Button(
                 onClick = onClose,

--- a/app/src/main/java/com/example/music/ui/shared/FeaturedItemsCarousel.kt
+++ b/app/src/main/java/com/example/music/ui/shared/FeaturedItemsCarousel.kt
@@ -55,7 +55,7 @@ private val FEATURED_ITEM_IMAGE_SIZE_DP = 160.dp
 fun FeaturedAlbumsCarousel(
     pagerState: PagerState,
     items: PersistentList<AlbumInfo>,
-    navigateToAlbumDetails: (AlbumInfo) -> Unit,
+    navigateToAlbumDetails: (Long) -> Unit,
     onMoreOptionsClick: (Any) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -78,7 +78,7 @@ fun FeaturedAlbumsCarousel(
                 val album = items[page]
                 FeaturedCarouselItem(
                     itemTitle = album.title,
-                    itemImage = album.artworkUri,//album.artwork!!,
+                    itemImage = album.artworkUri,
                     itemSize = album.songCount,
                     onMoreOptionsClick = { onMoreOptionsClick(album) },
                     //onClick = AlbumMoreOptionsBottomModal(album),
@@ -86,7 +86,7 @@ fun FeaturedAlbumsCarousel(
                     modifier = Modifier
                         .fillMaxSize()
                         .clickable {
-                            navigateToAlbumDetails(album)
+                            navigateToAlbumDetails(album.id)
                         }
                 )
             }

--- a/app/src/main/java/com/example/music/ui/shared/FeaturedItemsCarousel.kt
+++ b/app/src/main/java/com/example/music/ui/shared/FeaturedItemsCarousel.kt
@@ -84,16 +84,10 @@ fun FeaturedAlbumsCarousel(
                     itemTitle = album.title,
                     itemImage = album.artworkUri,
                     itemSize = album.songCount,
-                    onMoreOptionsClick = {
-                        onMoreOptionsClick(album)
-                    },
-                    //onClick = AlbumMoreOptionsBottomModal(album),
-                    //dateLastPlayed = album.dateLastPlayed?.let { lastUpdated(it) },
+                    onMoreOptionsClick = { onMoreOptionsClick(album) },
                     modifier = Modifier
                         .fillMaxSize()
-                        .clickable {
-                            navigateToAlbumDetails(album.id)
-                        }
+                        .clickable { navigateToAlbumDetails(album.id) }
                 )
             }
         }
@@ -112,9 +106,10 @@ fun FeaturedPlaylistsCarousel(
     pagerState: PagerState,
     items: PersistentList<PlaylistInfo>,
     navigateToPlaylistDetails: (PlaylistInfo) -> Unit,
+    onMoreOptionsClick: (PlaylistInfo) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    //Log.i(TAG, "Featured Playlist Item function start")
+    //Log.i(TAG, "Featured Playlist Carousel START")
     Column(modifier = modifier) {
         BoxWithConstraints(
             modifier = Modifier
@@ -137,15 +132,10 @@ fun FeaturedPlaylistsCarousel(
                     itemTitle = playlist.name,
                     itemImage = Uri.parse(""), // FixMe: needs Playlist Image generation
                     itemSize = playlist.songCount,
-                    onMoreOptionsClick = {},
-                    //onMoreOptionsClick = { onMoreOptionsClick(playlist) },
-                    //onClick = PlaylistMoreOptionsBottomModal(playlist),
-                    //dateLastPlayed = album.dateLastPlayed?.let { lastUpdated(it) },
+                    onMoreOptionsClick = { onMoreOptionsClick(playlist) },
                     modifier = Modifier
                         .fillMaxSize()
-                        .clickable {
-                            navigateToPlaylistDetails(playlist)
-                        }
+                        .clickable { navigateToPlaylistDetails(playlist) }
                 )
             }
         }
@@ -161,7 +151,7 @@ fun FeaturedCarouselItem(
     modifier: Modifier = Modifier,
 ) {
     Log.i(TAG, "Featured Carousel Item START: $itemTitle")
-    Column(modifier) {
+    Column(modifier = modifier) {
         Box(
             contentAlignment = Alignment.BottomStart,
             modifier = Modifier
@@ -197,10 +187,9 @@ fun FeaturedCarouselItem(
         ) {
             Text(
                 text = itemTitle,
-                //style = MaterialTheme.typography.bodySmall,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.titleMedium,
+                style = MaterialTheme.typography.titleMedium, //MaterialTheme.typography.bodySmall,
                 modifier = Modifier.padding(4.dp).weight(1f,true)
                 //modifier = Modifier
                     //.padding(top = 8.dp)
@@ -228,7 +217,6 @@ private fun PreviewCard() {
             itemTitle = PreviewAlbums[0].title,
             itemImage = Uri.parse(""),//album.artwork!!,
             onMoreOptionsClick = {},
-            //dateLastPlayed = album.dateLastPlayed?.let { lastUpdated(it) },
             modifier = Modifier
                 .size(FEATURED_ITEM_IMAGE_SIZE_DP, FEATURED_ITEM_IMAGE_SIZE_DP + 48.dp)
                 .fillMaxSize()

--- a/app/src/main/java/com/example/music/ui/shared/FeaturedItemsCarousel.kt
+++ b/app/src/main/java/com/example/music/ui/shared/FeaturedItemsCarousel.kt
@@ -1,6 +1,7 @@
 package com.example.music.ui.shared
 
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -41,7 +42,7 @@ import com.example.music.ui.theme.MusicTheme
 import com.example.music.util.quantityStringResource
 import kotlinx.collections.immutable.PersistentList
 
-private const val TAG = "Featured Albums Carousel"
+private const val TAG = "Featured Items Carousel"
 private val FEATURED_ITEM_IMAGE_SIZE_DP = 160.dp
 
 /**
@@ -59,12 +60,14 @@ fun FeaturedAlbumsCarousel(
     onMoreOptionsClick: (AlbumInfo) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    Log.i(TAG, "Featured Albums Carousel START")
     Column(modifier = modifier) {
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(Color.Transparent)
         ) {
+            Log.i(TAG, "Generating Horizontal pager")
             val horizontalPadding = (this.maxWidth - FEATURED_ITEM_IMAGE_SIZE_DP) / 2
             HorizontalPager(
                 state = pagerState,
@@ -75,12 +78,15 @@ fun FeaturedAlbumsCarousel(
                 pageSpacing = 24.dp,
                 pageSize = PageSize.Fixed(FEATURED_ITEM_IMAGE_SIZE_DP)
             ) { page ->
+                Log.i(TAG, "Generating Carousel Item: $page")
                 val album = items[page]
                 FeaturedCarouselItem(
                     itemTitle = album.title,
                     itemImage = album.artworkUri,
                     itemSize = album.songCount,
-                    onMoreOptionsClick = { onMoreOptionsClick(album) },
+                    onMoreOptionsClick = {
+                        onMoreOptionsClick(album)
+                    },
                     //onClick = AlbumMoreOptionsBottomModal(album),
                     //dateLastPlayed = album.dateLastPlayed?.let { lastUpdated(it) },
                     modifier = Modifier
@@ -151,11 +157,10 @@ fun FeaturedCarouselItem(
     itemTitle: String = "",
     itemImage: Uri,
     itemSize: Int = 0,
-    onMoreOptionsClick: (Any) -> Unit,
-    //onClick: () -> Unit, //pass in either Album or Playlist MoreOptionsModal action here
+    onMoreOptionsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    //Log.i(TAG, "Featured Carousel Item function start")
+    Log.i(TAG, "Featured Carousel Item START: $itemTitle")
     Column(modifier) {
         Box(
             contentAlignment = Alignment.BottomStart,
@@ -203,7 +208,7 @@ fun FeaturedCarouselItem(
 
             // more options btn
             IconButton(
-                onClick = { onMoreOptionsClick },
+                onClick = onMoreOptionsClick,
             ) {
                 Icon(
                     imageVector = Icons.Default.MoreVert,

--- a/app/src/main/java/com/example/music/ui/shared/FeaturedItemsCarousel.kt
+++ b/app/src/main/java/com/example/music/ui/shared/FeaturedItemsCarousel.kt
@@ -56,7 +56,7 @@ fun FeaturedAlbumsCarousel(
     pagerState: PagerState,
     items: PersistentList<AlbumInfo>,
     navigateToAlbumDetails: (Long) -> Unit,
-    onMoreOptionsClick: (Any) -> Unit,
+    onMoreOptionsClick: (AlbumInfo) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {

--- a/core/data/src/main/java/com/example/music/data/mediaresolver/Resolver.kt
+++ b/core/data/src/main/java/com/example/music/data/mediaresolver/Resolver.kt
@@ -938,7 +938,11 @@ suspend fun ContentResolver.findGenre(id: Long): Genre = queryExt(
     limit = 1,
 ) {
     it.moveToFirst()
-    val result = it.toGenre()
+    val result = it.toGenre(
+        getGenreAudioCount(
+            it.getLong(0)
+        )
+    )
     it.close()
     result
 }

--- a/core/data/src/main/java/com/example/music/data/mediaresolver/model/Genre.kt
+++ b/core/data/src/main/java/com/example/music/data/mediaresolver/model/Genre.kt
@@ -15,7 +15,7 @@ data class Genre(
     @JvmField val id: Long,
     @JvmField val name: String,
     @JvmField val sort: String,
-    @JvmField val numTracks: Int = -1
+    @JvmField val numTracks: Int = 0
 )
 
 /**

--- a/core/domain/src/main/java/com/example/music/domain/model/GenreInfo.kt
+++ b/core/domain/src/main/java/com/example/music/domain/model/GenreInfo.kt
@@ -15,7 +15,7 @@ private const val TAG = "GenreInfo"
 data class GenreInfo(
     var id: Long = 0,
     var name: String = "",
-    val songCount: Int = 0,
+    var songCount: Int = 0,
 )
 
 /**

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetGenreDetailsV2.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetGenreDetailsV2.kt
@@ -30,8 +30,6 @@ class GetGenreDetailsV2 @Inject constructor(
         Log.i(TAG, "Start: GenreId: $genreId")
         val genreItem: Flow<Genre> = mediaRepo.getGenreFlow(genreId)
 
-        //val songsFlow = mediaRepo.getSongsForGenre(genre.name)
-
         return combine(
             genreItem,
             genreItem.map {


### PR DESCRIPTION
### Description:
The code for using bottom sheets as a means of displaying a more options context menu did exist already, but it was woefully inadequate and under-utilized. This branch intended to both fix the bottom sheet modal components as well as make the UI more compatible with their display and function. The original issue describing needing to fix bottom modals eventually became too much to encapsulate in one issue, so it's been broken up into several issues with more focused needs. This one specifically covers making sure the object MoreOptions modals were consistent in their visual appearance, and each action provided functioned as expected.

### Changes Made:
- the navigation routes to Details screens were simplified
- SongController properties and functions were revised for better access through ViewModels
- All ViewModels with sealed interface and screen actions were reorganized and function actions were added for each MoreOptions menu action needed per screen
- ViewModels contain "selectObject" properties that is the object to display for a MoreOptions modal
- LibraryScreen is the only screen where the "selectObject" is NOT in the ViewModel and instead set as a remember variable for each tab of the library
- More logging
- Removed needless comments and import statements
- Extra, slight comment or line spacing clean-up for readability

Screens Affected:
- Home
- Library
- Library.Albums
- Library.Artists
- Library.Genres
- Library.Songs
- AlbumDetails
- ArtistDetails
- GenreDetails

### Related Issues:
Addresses Issue #15 