### PR TITLE
Fixing player screen UI: color scheme and component layout

### DIFF
--- a/app/src/main/java/com/example/music/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/music/ui/MainActivity.kt
@@ -78,8 +78,9 @@ class MainActivity : ComponentActivity() {
         startService(Intent(this@MainActivity, MediaService::class.java))
 
         enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.auto(Color.Transparent.toArgb(),Color.Transparent.toArgb()),//.auto(scrimLight, scrimDark),
-            navigationBarStyle = SystemBarStyle.auto(scrimLight.toArgb(), scrimDark.toArgb())
+            statusBarStyle = SystemBarStyle.auto(Color.Transparent.toArgb(),Color.Transparent.toArgb()),
+            navigationBarStyle = SystemBarStyle//.auto(scrimLight.toArgb(), scrimDark.toArgb()) //default, applies translucent scrim when in dark mode
+                .light(Color.Transparent.toArgb(), Color.Transparent.toArgb()) //sets navigation bar to be transparent, overrides defaulted scrim
         )
         Log.i(TAG, "edge to edge enabled")
 

--- a/app/src/main/java/com/example/music/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/com/example/music/ui/player/PlayerScreen.kt
@@ -86,7 +86,10 @@ import com.example.music.R
 import com.example.music.data.repository.RepeatType
 import com.example.music.designsys.component.AlbumImage
 import com.example.music.designsys.component.AlbumImageBm
+import com.example.music.designsys.component.ImageBackgroundColorScrim
+import com.example.music.designsys.component.ImageBackgroundColorScrim_Bm
 import com.example.music.designsys.component.ImageBackgroundRadialGradientScrim
+import com.example.music.designsys.component.ImageBackgroundRadialGradientScrim_Bm
 import com.example.music.domain.model.SongInfo
 import com.example.music.domain.testing.PreviewSongs
 import com.example.music.ui.shared.Error
@@ -97,6 +100,9 @@ import com.example.music.ui.tooling.SystemLightPreview
 import com.example.music.util.isCompact
 import com.example.music.util.isExpanded
 import com.example.music.util.isMedium
+import com.example.music.util.radialGradientScrimCentered
+import com.example.music.util.radialMultiGradientScrimAnyParams
+import com.example.music.util.radialMultiGradientScrimBottomRight
 import com.example.music.util.verticalGradientScrim
 import kotlinx.coroutines.launch
 import java.time.Duration
@@ -105,7 +111,7 @@ import kotlin.math.roundToLong
 private const val TAG = "Player Screen"
 
 /**
- * Stateless version of Player Screen
+ * Stateful version of Player Screen
  */
 @Composable
 fun PlayerScreen(
@@ -141,7 +147,7 @@ fun PlayerScreen(
     }*/
 }
 
-//wrapper for default class of possible control actions
+//wrappers for default class of possible control actions
 data class PlayerControlActions(
     val onPlayPress: () -> Unit,
     val onPausePress: () -> Unit,
@@ -151,7 +157,6 @@ data class PlayerControlActions(
     val onShuffle: () -> Unit,
     val onRepeat: () -> Unit
 )
-
 data class MiniPlayerControlActions(
     val onPlayPress: () -> Unit,
     val onPausePress: () -> Unit,
@@ -246,16 +251,27 @@ private fun FullScreenLoading(
 }
 //full screen circular progress - loading screen
 
+/**
+ * Draw a background image using the currently playing song's artwork cover
+ */
 @Composable
 private fun PlayerBackground(
     song: SongInfo,
     modifier: Modifier,
 ) {
-    ImageBackgroundRadialGradientScrim(
-        //url = song?.podcastImageUrl,
-        imageId = song.title, //FixMe: needs to be artwork bitmap or uri
-        colors = listOf(MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.surface.copy(alpha = 0.3f),),
-        //colors = listOf(MaterialTheme.colorScheme.onPrimary,MaterialTheme.colorScheme.onSecondary, MaterialTheme.colorScheme.onTertiary),//blueDarkColorSet.primary,
+    // YEEESSSSSSS IT FUCKING WORKSSSSSSSSS
+//    ImageBackgroundColorScrim_Bm(
+//        imageId = song.artworkBitmap,
+//        imageDescription = song.title,
+//        //color = MaterialTheme.colorScheme.surface.copy(alpha = 0.2f),
+//        modifier = modifier,
+//    )
+
+    ImageBackgroundRadialGradientScrim_Bm(
+        imageId = song.artworkBitmap,
+        imageDescription = song.title,
+        colors = listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.secondaryContainer, MaterialTheme.colorScheme.tertiaryContainer),
+        //colors = listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.tertiary, MaterialTheme.colorScheme.onSecondary),
         modifier = modifier,
     )
 }
@@ -278,7 +294,10 @@ fun PlayerContentWithBackground(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp)
 ) {
-    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
         PlayerBackground(
             song = currentSong,
             modifier = Modifier.fillMaxSize()
@@ -374,12 +393,16 @@ private fun PlayerContentRegular(
 ) {
     Column(
         modifier = modifier
+//            .background(MaterialTheme.colorScheme.background)
             .fillMaxSize()
-            //.radialGradientScrimBottomRight( colors = listOf(MaterialTheme.colorScheme.onPrimary, MaterialTheme.colorScheme.background) )
-            //.radialGradientScrimCentered( color = MaterialTheme.colorScheme.onPrimary )
-            //.verticalGradientScrim( color = MaterialTheme.colorScheme.onPrimary, startYPercentage = 1f, endYPercentage = 0f )
-            //.radialGradientScrimAnyOffset( color = MaterialTheme.colorScheme.onPrimary, xOffset = 2, yOffset = 3 )
-            //.radialGradientScrimAnyColorsOffset( colors = listOf(MaterialTheme.colorScheme.secondaryContainer, MaterialTheme.colorScheme.onPrimary), xOffset = 2, yOffset = 2  )
+//            .radialGradientScrimBottomRight( colors = listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.onSecondary) )
+//            .radialGradientScrimBottomRight( colors = listOf(MaterialTheme.colorScheme.onPrimary, MaterialTheme.colorScheme.onSecondary) )
+//            .radialGradientScrimBottomRight( colors = listOf(MaterialTheme.colorScheme.onPrimary, MaterialTheme.colorScheme.background) )
+//            .radialGradientScrimCentered( color = MaterialTheme.colorScheme.onPrimary )
+//            .verticalGradientScrim( color = MaterialTheme.colorScheme.onPrimary, startYPercentage = 1f, endYPercentage = 0f )
+//            .radialGradientScrimAnyOffset( color = MaterialTheme.colorScheme.onPrimaryContainer, xOffset = 2, yOffset = 3 )
+//            .radialGradientScrimAnyOffset( color = MaterialTheme.colorScheme.onPrimary, xOffset = 2, yOffset = 3 )
+//            .radialGradientScrimAnyColorsOffset( colors = listOf(MaterialTheme.colorScheme.secondaryContainer, MaterialTheme.colorScheme.onPrimary), xOffset = 2, yOffset = 2  )
             .systemBarsPadding()//why is this getting called again when it was passed into the column around PlayerContentRegular?
             .padding(horizontal = 8.dp)
     ) {
@@ -672,7 +695,13 @@ fun PlayerSlider(
 
         Row(Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
             Text(
-                text = "${Duration.ofMillis(timeElapsed).formatString()} • ${songDuration?.formatString()}",
+                text = Duration.ofMillis(timeElapsed).formatString(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.weight(1f))
+            Text(
+                text = "${songDuration?.formatString()}",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )

--- a/app/src/main/java/com/example/music/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/com/example/music/ui/player/PlayerScreen.kt
@@ -259,21 +259,21 @@ private fun PlayerBackground(
     song: SongInfo,
     modifier: Modifier,
 ) {
-    // YEEESSSSSSS IT FUCKING WORKSSSSSSSSS
-//    ImageBackgroundColorScrim_Bm(
-//        imageId = song.artworkBitmap,
-//        imageDescription = song.title,
-//        //color = MaterialTheme.colorScheme.surface.copy(alpha = 0.2f),
-//        modifier = modifier,
-//    )
-
-    ImageBackgroundRadialGradientScrim_Bm(
+    ImageBackgroundColorScrim_Bm(
         imageId = song.artworkBitmap,
         imageDescription = song.title,
-        colors = listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.secondaryContainer, MaterialTheme.colorScheme.tertiaryContainer),
-        //colors = listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.tertiary, MaterialTheme.colorScheme.onSecondary),
+        color = MaterialTheme.colorScheme.inversePrimary.copy(alpha = 0.65f),
+        //color = MaterialTheme.colorScheme.surface.copy(alpha = 0.2f),
         modifier = modifier,
     )
+
+//    ImageBackgroundRadialGradientScrim_Bm(
+//        imageId = song.artworkBitmap,
+//        imageDescription = song.title,
+//        colors = listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.secondaryContainer, MaterialTheme.colorScheme.tertiaryContainer),
+//        //colors = listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.tertiary, MaterialTheme.colorScheme.onSecondary),
+//        modifier = modifier,
+//    )
 }
 
 //combines player content with background

--- a/app/src/main/java/com/example/music/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/com/example/music/ui/player/PlayerScreen.kt
@@ -86,9 +86,7 @@ import com.example.music.R
 import com.example.music.data.repository.RepeatType
 import com.example.music.designsys.component.AlbumImage
 import com.example.music.designsys.component.AlbumImageBm
-import com.example.music.designsys.component.ImageBackgroundColorScrim
 import com.example.music.designsys.component.ImageBackgroundColorScrim_Bm
-import com.example.music.designsys.component.ImageBackgroundRadialGradientScrim
 import com.example.music.designsys.component.ImageBackgroundRadialGradientScrim_Bm
 import com.example.music.domain.model.SongInfo
 import com.example.music.domain.testing.PreviewSongs
@@ -395,14 +393,6 @@ private fun PlayerContentRegular(
         modifier = modifier
 //            .background(MaterialTheme.colorScheme.background)
             .fillMaxSize()
-//            .radialGradientScrimBottomRight( colors = listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.onSecondary) )
-//            .radialGradientScrimBottomRight( colors = listOf(MaterialTheme.colorScheme.onPrimary, MaterialTheme.colorScheme.onSecondary) )
-//            .radialGradientScrimBottomRight( colors = listOf(MaterialTheme.colorScheme.onPrimary, MaterialTheme.colorScheme.background) )
-//            .radialGradientScrimCentered( color = MaterialTheme.colorScheme.onPrimary )
-//            .verticalGradientScrim( color = MaterialTheme.colorScheme.onPrimary, startYPercentage = 1f, endYPercentage = 0f )
-//            .radialGradientScrimAnyOffset( color = MaterialTheme.colorScheme.onPrimaryContainer, xOffset = 2, yOffset = 3 )
-//            .radialGradientScrimAnyOffset( color = MaterialTheme.colorScheme.onPrimary, xOffset = 2, yOffset = 3 )
-//            .radialGradientScrimAnyColorsOffset( colors = listOf(MaterialTheme.colorScheme.secondaryContainer, MaterialTheme.colorScheme.onPrimary), xOffset = 2, yOffset = 2  )
             .systemBarsPadding()//why is this getting called again when it was passed into the column around PlayerContentRegular?
             .padding(horizontal = 8.dp)
     ) {

--- a/app/src/main/java/com/example/music/ui/shared/MiniPlayer.kt
+++ b/app/src/main/java/com/example/music/ui/shared/MiniPlayer.kt
@@ -70,7 +70,7 @@ fun MiniPlayer(
         modifier = modifier.fillMaxWidth(),
     ) {
         Surface(
-            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.45f), // Color.Transparent,
+            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.45f),
             contentColor = MaterialTheme.colorScheme.onSurface,
             onClick = { navigateToPlayer() },
             modifier = modifier.fillMaxWidth()

--- a/app/src/main/java/com/example/music/ui/shared/MiniPlayer.kt
+++ b/app/src/main/java/com/example/music/ui/shared/MiniPlayer.kt
@@ -36,6 +36,7 @@ import com.example.music.domain.model.SongInfo
 import com.example.music.domain.testing.getSongData
 import com.example.music.ui.theme.MusicTheme
 import com.example.music.ui.tooling.CompDarkPreview
+import com.example.music.ui.tooling.CompLightPreview
 import com.example.music.util.horizontalGradientScrim
 import com.example.music.util.radialMultiGradientScrimAnyOffset
 import com.example.music.util.radialMultiGradientScrimBottomRight
@@ -73,12 +74,12 @@ fun MiniPlayer(
             contentColor = MaterialTheme.colorScheme.onSurface,
             onClick = { navigateToPlayer() },
             modifier = modifier.fillMaxWidth()
-                .horizontalGradientScrim(MaterialTheme.colorScheme.primaryContainer)
-//                .radialMultiGradientScrimAnyOffset(
-//                    colors = listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.secondaryContainer),
-//                    xOffset = 1f,
-//                    yOffset = 0.5f,
-//                ),
+//                .horizontalGradientScrim(MaterialTheme.colorScheme.primaryContainer)
+                .radialMultiGradientScrimAnyOffset(
+                    colors = listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.secondaryContainer),
+                    xOffset = 1f,
+                    yOffset = 0.5f,
+                ),
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -109,7 +110,7 @@ fun MiniPlayer(
                         imageVector = Icons.Filled.Pause,
                         contentDescription = stringResource(R.string.pb_pause),
                         contentScale = ContentScale.Fit,
-                        colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onPrimary),
+                        colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.inversePrimary),
                         modifier = playButtonModifier
                             .padding(4.dp)
                             .clickable { onPausePress() }
@@ -121,7 +122,7 @@ fun MiniPlayer(
                         imageVector = Icons.Filled.PlayArrow,
                         contentDescription = stringResource(R.string.pb_play),
                         contentScale = ContentScale.Fit,
-                        colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onPrimary),
+                        colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.inversePrimary),
                         modifier = playButtonModifier
                             .padding(4.dp)
                             .clickable { onPlayPress() }
@@ -229,7 +230,7 @@ fun MiniPlayerExpanded(
     }
 }*/
 
-//@CompLightPreview
+@CompLightPreview
 @CompDarkPreview
 @Composable
 fun PreviewMiniPlayer() {

--- a/app/src/main/java/com/example/music/ui/shared/MiniPlayer.kt
+++ b/app/src/main/java/com/example/music/ui/shared/MiniPlayer.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -35,6 +36,9 @@ import com.example.music.domain.model.SongInfo
 import com.example.music.domain.testing.getSongData
 import com.example.music.ui.theme.MusicTheme
 import com.example.music.ui.tooling.CompDarkPreview
+import com.example.music.util.horizontalGradientScrim
+import com.example.music.util.radialMultiGradientScrimAnyOffset
+import com.example.music.util.radialMultiGradientScrimBottomRight
 
 private const val TAG = "Mini Player"
 
@@ -65,10 +69,16 @@ fun MiniPlayer(
         modifier = modifier.fillMaxWidth(),
     ) {
         Surface(
-            color = MaterialTheme.colorScheme.inversePrimary,
+            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.45f), // Color.Transparent,
             contentColor = MaterialTheme.colorScheme.onSurface,
             onClick = { navigateToPlayer() },
-            modifier = modifier.fillMaxWidth(),
+            modifier = modifier.fillMaxWidth()
+                .horizontalGradientScrim(MaterialTheme.colorScheme.primaryContainer)
+//                .radialMultiGradientScrimAnyOffset(
+//                    colors = listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.secondaryContainer),
+//                    xOffset = 1f,
+//                    yOffset = 0.5f,
+//                ),
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/example/music/ui/shared/ScreenBackground.kt
+++ b/app/src/main/java/com/example/music/ui/shared/ScreenBackground.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.example.music.util.radialGradientScrimBottomRight
+import com.example.music.util.radialMultiGradientScrimBottomRight
 
 /**
  * Composable for a screen's Background.
@@ -18,18 +18,22 @@ fun ScreenBackground(
     content: @Composable BoxScope.() -> Unit
 ) {
     Box(
-        modifier = modifier
-            .background(MaterialTheme.colorScheme.background)
+        modifier = modifier.background(MaterialTheme.colorScheme.background)
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .radialGradientScrimBottomRight(
-                    listOf(
-                        MaterialTheme.colorScheme.primaryContainer,
-                        MaterialTheme.colorScheme.onPrimary
-                    )
-                )//.copy(alpha = 0.9f))
+        Box(modifier = Modifier.fillMaxSize()
+            .radialMultiGradientScrimBottomRight(
+                listOf(
+                    MaterialTheme.colorScheme.onPrimary,
+                    MaterialTheme.colorScheme.onSecondary
+                )
+            )
+            // version of ScreenBackground's radialGradiantScrim that needs first Box's modifier above to have background set to colorScheme.background
+//            .radialGradientScrimBottomRight(
+//                listOf(
+//                    MaterialTheme.colorScheme.primaryContainer,
+//                    MaterialTheme.colorScheme.secondaryContainer
+//                )
+//            )
         )
         content()
     }

--- a/app/src/main/java/com/example/music/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/music/ui/theme/Color.kt
@@ -126,8 +126,8 @@ val scrimLight = Color(0xFF000000)
 
 val inverseSurfaceLight = Color(0xFF1D1A20)
 val inverseOnSurfaceLight = Color(0xFFF6EEF6)
-val inversePrimaryLight = Color(0xFFD9BAFA)
-val inversePrimaryLight2 = Color(0xFFFFF7FF) // unique color
+val inversePrimaryLight = Color(0xFFFFF7FF) // unique color
+val inversePrimaryLight2 = Color(0xFFD9BAFA)
 
 
 // Cool Tones Dark Color Section
@@ -168,5 +168,6 @@ val scrimDark = Color(0xFF000000)
 
 val inverseSurfaceDark = Color(0xFFE8E0E8)
 val inverseOnSurfaceDark = Color(0xFF332F35)
-val inversePrimaryDark = Color(0xFF6D538B)
-val inversePrimaryDark2 = Color(0xFF160B2A) // unique color
+val inversePrimaryDark = Color(0xFF160B2A) // unique color
+val inversePrimaryDark2 = Color(0xFF6D538B)
+

--- a/app/src/main/java/com/example/music/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/music/ui/theme/Color.kt
@@ -89,32 +89,33 @@ val surfaceBrightBlueDark = Color(0xFF38383E)
 
 
 // Cool Tones Light Color Section
-val primaryLight = Color(0xFF6D538B)
-val onPrimaryLight = Color(0xFFEADDF6) // 0xFFEFE2FA
-val primaryContainerLight = Color(0xFFEFDBFF)
-val onPrimaryContainerLight = Color(0xFF270D43)
+val primaryLight = Color(0xFF6D538B) // or 109,83,139 // 0xFF543B72 or 84,59,114
+val onPrimaryLight = Color(0xFFEADDF6) // white -> // or 234,221,246 // 0xFFEFE2FA or 239,226,250
+val primaryContainerLight = Color(0xFFEFDBFF) // or 239,219,255 // 0xFF6D538B or 109,83,139
+val onPrimaryContainerLight = Color(0xFF270D43) // or 39,13,67 // 0xFFE8CFFF or 232,207,255
 
-val secondaryLight = Color(0xFF256489)
-val onSecondaryLight = Color(0xFFCADCF5) // 0xFFD8E7FA
-val secondaryContainerLight = Color(0xFFA5CBEE) // 0xFFC9E6FF
-val onSecondaryContainerLight = Color(0xFF001E2F)
+val secondaryLight = Color(0xFF256489) // or 37,100,137 // 0xFF004C6E or 0,76,110
+val onSecondaryLight = Color(0xFFCADCF5) // white -> // or 202,220,245 // 0xFFD8E7FA or 216,231,250
+val secondaryContainerLight = Color(0xFFA5CBEE)  // 0xFFC9E6FF or 201,230,255 -> // or 165,203,228 // 0xFF256489 or 37,100,137
+val onSecondaryContainerLight = Color(0xFF001E2F) // or 0,30,47 // 0xFFB4DEFF or 180,222,255
 
-val tertiaryLight = Color(0xFF2A6A47)
-val onTertiaryLight = Color(0xFFC7F8D6) // 0xFFCBF8D9
-val tertiaryContainerLight = Color(0xFFA4E7B9) // 0xFFAFF2C4
-val onTertiaryContainerLight = Color(0xFF002110)
+val tertiaryLight = Color(0xFF2A6A47) // or 42,106,71 // 0xFF0A5131 or 10,81,49
+val onTertiaryLight = Color(0xFFC7F8D6) // white -> // or 199,248,214 // 0xFFCBF8D9 or 203,248,217
+val tertiaryContainerLight = Color(0xFFA4E7B9) // 0xFFAFF2C4 or 175,242,196 -> // or 164,231,185 // 0xFF2A6A47 or 47,106,71
+val onTertiaryContainerLight = Color(0xFF002110) // or 0,33,16 // 0xFFA5E7BB or 165,231,187
 
-val errorLight = Color(0xFFBA1A1A)
-val onErrorLight = Color(0xFFF1CDCD) // 0xFFFFFFFF
-val errorContainerLight = Color(0xFFEEB4B0) // 0xFFFFDAD6
-val onErrorContainerLight = Color(0xFF410002)
+val errorLight = Color(0xFFBA1A1A) // or 186,26,26 // 0xFF93000A or 147,0,10
+val onErrorLight = Color(0xFFF1CDCD)
+val errorContainerLight = Color(0xFFEEB4B0) // 0xFFFFDAD6 or 255,218,214 -> // or 238,180,176 // 0xFFBA1A1A or 186,26,26
+val onErrorContainerLight = Color(0xFF410002) // or 65,0,2 // 0xFFFFCDC7 or 255,205,199
 
 val backgroundLight = Color(0xFFFFF7FF)
 val onBackgroundLight = Color(0xFF1D1A20)
 
 val surfaceLight = Color(0xFFFFF7FF)
 val onSurfaceLight = Color(0xFF1D1A20)
-
+val surfaceDimLight = Color(0xFFDFD8E0)
+val surfaceBrightLight = Color(0xFFFFF7FF)
 val surfaceVariantLight = Color(0xFFE9E0EB)
 val onSurfaceVariantLight = Color(0xFF4A454E)
 
@@ -125,39 +126,38 @@ val scrimLight = Color(0xFF000000)
 
 val inverseSurfaceLight = Color(0xFF1D1A20)
 val inverseOnSurfaceLight = Color(0xFFF6EEF6)
-val inversePrimaryLight = Color(0xFFFFF7FF)
-
-val surfaceDimLight = Color(0xFFDFD8E0)
-val surfaceBrightLight = Color(0xFFFFF7FF)
+val inversePrimaryLight = Color(0xFFD9BAFA)
+val inversePrimaryLight2 = Color(0xFFFFF7FF) // unique color
 
 
 // Cool Tones Dark Color Section
 val primaryDark = Color(0xFFD9BAFA)
 val onPrimaryDark = Color(0xFF3D2459)
-val primaryContainerDark = Color(0xFF553B71)
-val onPrimaryContainerDark = Color(0xFFEFDBFF)
+val primaryContainerDark = Color(0xFF553B71) // 0xFF6D538B or 239,219,255
+val onPrimaryContainerDark = Color(0xFFEFDBFF) // 0xFFE8CFFF or 232,207,255
 
 val secondaryDark = Color(0xFF94CDF7)
 val onSecondaryDark = Color(0xFF00344D)
-val secondaryContainerDark = Color(0xFF004C6E)
-val onSecondaryContainerDark = Color(0xFFC9E6FF)
+val secondaryContainerDark = Color(0xFF004C6E) // 0xFF256489 or 37,100,137
+val onSecondaryContainerDark = Color(0xFFC9E6FF) // 0xFFB4DEFF or 201,230,255
 
 val tertiaryDark = Color(0xFF93D5AA)
 val onTertiaryDark = Color(0xFF00391F)
-val tertiaryContainerDark = Color(0xFF0B5130)
-val onTertiaryContainerDark = Color(0xFFAFF2C4)
+val tertiaryContainerDark = Color(0xFF0B5130) // 0xFF2A6A47 or 42,106,71
+val onTertiaryContainerDark = Color(0xFFAFF2C4) // 0xFFA5E7BB or 165,231,187
 
 val errorDark = Color(0xFFFFB4AB)
 val onErrorDark = Color(0xFF690005)
-val errorContainerDark = Color(0xFF93000A)
-val onErrorContainerDark = Color(0xFFFFDAD6)
+val errorContainerDark = Color(0xFF93000A) // 0xFFBA1A1A or 186,26,26
+val onErrorContainerDark = Color(0xFFFFDAD6) // 0xFFFFCDC7 or 255,205,199
 
 val backgroundDark = Color(0xFF151218)
 val onBackgroundDark = Color(0xFFE8E0E8)
 
 val surfaceDark = Color(0xFF151218)
 val onSurfaceDark = Color(0xFFE8E0E8)
-
+val surfaceDimDark = Color(0xFF151218)
+val surfaceBrightDark = Color(0xFF3C383E)
 val surfaceVariantDark = Color(0xFF4A454E)
 val onSurfaceVariantDark = Color(0xFFCCC4CF)
 
@@ -168,7 +168,5 @@ val scrimDark = Color(0xFF000000)
 
 val inverseSurfaceDark = Color(0xFFE8E0E8)
 val inverseOnSurfaceDark = Color(0xFF332F35)
-val inversePrimaryDark = Color(0xFF160B2A)
-
-val surfaceDimDark = Color(0xFF151218)
-val surfaceBrightDark = Color(0xFF3C383E)
+val inversePrimaryDark = Color(0xFF6D538B)
+val inversePrimaryDark2 = Color(0xFF160B2A) // unique color

--- a/app/src/main/java/com/example/music/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/music/ui/theme/Color.kt
@@ -90,23 +90,23 @@ val surfaceBrightBlueDark = Color(0xFF38383E)
 
 // Cool Tones Light Color Section
 val primaryLight = Color(0xFF6D538B)
-val onPrimaryLight = Color(0xFFFFFFFF)
+val onPrimaryLight = Color(0xFFEADDF6) // 0xFFEFE2FA
 val primaryContainerLight = Color(0xFFEFDBFF)
 val onPrimaryContainerLight = Color(0xFF270D43)
 
 val secondaryLight = Color(0xFF256489)
-val onSecondaryLight = Color(0xFFFFFFFF)
-val secondaryContainerLight = Color(0xFFC9E6FF)
+val onSecondaryLight = Color(0xFFCADCF5) // 0xFFD8E7FA
+val secondaryContainerLight = Color(0xFFA5CBEE) // 0xFFC9E6FF
 val onSecondaryContainerLight = Color(0xFF001E2F)
 
 val tertiaryLight = Color(0xFF2A6A47)
-val onTertiaryLight = Color(0xFFFFFFFF)
-val tertiaryContainerLight = Color(0xFFAFF2C4)
+val onTertiaryLight = Color(0xFFC7F8D6) // 0xFFCBF8D9
+val tertiaryContainerLight = Color(0xFFA4E7B9) // 0xFFAFF2C4
 val onTertiaryContainerLight = Color(0xFF002110)
 
 val errorLight = Color(0xFFBA1A1A)
-val onErrorLight = Color(0xFFFFFFFF)
-val errorContainerLight = Color(0xFFFFDAD6)
+val onErrorLight = Color(0xFFF1CDCD) // 0xFFFFFFFF
+val errorContainerLight = Color(0xFFEEB4B0) // 0xFFFFDAD6
 val onErrorContainerLight = Color(0xFF410002)
 
 val backgroundLight = Color(0xFFFFF7FF)

--- a/app/src/main/java/com/example/music/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/music/ui/theme/Theme.kt
@@ -6,13 +6,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
-import androidx.compose.ui.graphics.Color
 import com.example.music.designsys.theme.lightDefaultSet
 import com.example.music.designsys.theme.darkDefaultSet
 
-//public final val inversePrimary: Color
-//
 //Color to be used as a "primary" color in places where the inverse color scheme is needed, such as the button on a SnackBar
 @SuppressLint("ResourceAsColor")
 val blueLightColorSet = lightColorScheme(

--- a/app/src/main/java/com/example/music/util/GradientScrim.kt
+++ b/app/src/main/java/com/example/music/util/GradientScrim.kt
@@ -21,19 +21,40 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
 
+/***********************************************************************************************
+ *
+ * ********** MONOCHROMATIC AND MULTICOLOR RADIAL GRADIENTS **********
+ *
+ **********************************************************************************************/
+
 /**
- * Applies a monochromatic radial gradient scrim in the foreground emanating from any offset.
+ * Applies a monochromatic radial gradient scrim in the foreground with full parameter freedom.
+ * @param color [Color] : Base color to apply to the gradient
+ * @param colorStops [List] of [Float] : The list of color stops to draw per color
+ * @param maxDimension [Boolean] : Determines if radius will be based on the max dimension side (true)
+ * or the min dimension side (false)
+ * @param radius [Float] : Multiplier against the dimension determined by maxDimension
+ * @param xOffset [Float] : Multiplier against the width to determine the x-axis of the radial center
+ * @param yOffset [Float] : Multiplier against the height to determine the y-axis of the radial center
  */
-fun Modifier.radialGradientScrimAnyOffset(color: Color, xOffset: Int, yOffset: Int): Modifier {
+fun Modifier.radialMonoGradientScrimAnyParams(
+    color: Color = Color.Gray,
+    colorStops: List<Float>? = null,
+    maxDimension: Boolean = true,
+    radius: Float = 1.5f,
+    xOffset: Float = 1f,
+    yOffset: Float = 1f,
+): Modifier {
     val radialGradient = object : ShaderBrush() {
         override fun createShader(size: Size): Shader {
-            val largerDimension = max(size.height, size.width)
-            val smallerDimension = min(size.height, size.width)
+            val dimension =
+                if (maxDimension) max(size.height, size.width)
+                else min(size.height, size.width)
             return RadialGradientShader(
-                center = size.center.copy(x = size.width / xOffset, y = size.height / yOffset),
+                center = size.center.copy(x = size.width * xOffset, y = size.height * yOffset),
                 colors = listOf(color, Color.Transparent),
-                radius = smallerDimension * 1.5f,
-                colorStops = getColorStops(0) // forcing else branch
+                radius = dimension * radius,
+                colorStops = colorStops
             )
         }
     }
@@ -41,17 +62,35 @@ fun Modifier.radialGradientScrimAnyOffset(color: Color, xOffset: Int, yOffset: I
 }
 
 /**
- * Applies a multicolor radial gradient scrim in the foreground emanating from any offset.
+ * Applies a multicolor radial gradient scrim in the foreground with full parameter freedom.
+ * @param colors [List] of [Color] : List of colors to apply to the gradient
+ * @param colorStops Nullable [List] of [Float] : The list of color stops to draw per color
+ * @param maxDimension [Boolean] : Determines if radius will be based on the max dimension side (true)
+ * or the min dimension side (false)
+ * @param alpha [Float] : Alpha value to apply to the gradient
+ * @param radius [Float] : Multiplier against the dimension determined by maxDimension
+ * @param xOffset [Float] : Multiplier against the width to determine the x-axis of the radial center
+ * @param yOffset [Float] : Multiplier against the height to determine the y-axis of the radial center
  */
-fun Modifier.radialGradientScrimAnyColorsOffset(colors: List<Color>, xOffset: Int, yOffset: Int): Modifier {
+fun Modifier.radialMultiGradientScrimAnyParams(
+    colors: List<Color> = listOf(Color.Gray, Color.Transparent),
+    colorStops: List<Float>? = null,
+    maxDimension: Boolean = true,
+    @FloatRange(from = 0.0, to = 1.0) alpha: Float = 1f,
+    radius: Float = 1.5f,
+    xOffset: Float = 1f,
+    yOffset: Float = 1f,
+): Modifier {
     val radialGradient = object : ShaderBrush() {
         override fun createShader(size: Size): Shader {
-            val largerDimension = max(size.height, size.width)
+            val dimension =
+                if (maxDimension) max(size.height, size.width)
+                else min(size.height, size.width)
             return RadialGradientShader(
-                center = size.center.copy(x = size.width / xOffset, y = size.height / yOffset),
-                colors = colors + Color.Transparent,
-                radius = (largerDimension / (colors.size + 1)) * colors.size, //largerDimension / 2
-                colorStops = getColorStops(colors.size + 1) // adding Transparent color means +1 to og size
+                center = size.center.copy(x = size.width * xOffset, y = size.height * yOffset),
+                colors = colors.map { it.copy(alpha = alpha) },
+                radius = dimension * radius,
+                colorStops = colorStops
             )
         }
     }
@@ -61,15 +100,18 @@ fun Modifier.radialGradientScrimAnyColorsOffset(colors: List<Color>, xOffset: In
 /**
  * Applies a monochromatic radial gradient scrim in the foreground emanating from the top
  * center quarter of the element.
+ * @param color [Color] : Base color to apply to the gradient
  */
-fun Modifier.radialGradientScrimCentered(color: Color): Modifier {
+fun Modifier.radialGradientScrimCentered(
+    color: Color = Color.Gray
+): Modifier {
     val radialGradient = object : ShaderBrush() {
         override fun createShader(size: Size): Shader {
             val largerDimension = max(size.height, size.width)
             return RadialGradientShader(
                 center = size.center.copy(y = size.height / 4),
                 colors = listOf(color, Color.Transparent),
-                radius = largerDimension / 3,
+                radius = largerDimension / 0.5f,
                 colorStops = getColorStops(0) // forcing else branch
             )
         }
@@ -80,20 +122,149 @@ fun Modifier.radialGradientScrimCentered(color: Color): Modifier {
 /**
  * Applies a multicolor radial gradient scrim in the foreground emanating from the bottom
  * right of the element.
+ * @param colors [List] of [Color] : List of colors to apply to the gradient.
+ * Appends Transparent to blend the top left corner with the background
+ * @param alpha [Float] : Alpha value to apply to the gradient
  */
-fun Modifier.radialGradientScrimBottomRight(colors: List<Color>,): Modifier {
+fun Modifier.radialMultiGradientScrimBottomRight(
+    colors: List<Color>,
+    @FloatRange(from = 0.0, to = 1.0) alpha: Float = 1f,
+): Modifier {
     val radialGradient = object : ShaderBrush() {
         override fun createShader(size: Size): Shader {
             val largerDimension = max(size.height, size.width)
             return RadialGradientShader(
                 center = size.center.copy(x = size.width, y = size.height),
-                colors = colors + Color.Transparent,
+                colors = colors.map { it.copy(alpha = alpha) } + Color.Transparent,
                 radius = largerDimension * 1.75f,
                 colorStops = getColorStops(colors.size + 1)
             )
         }
     }
     return this.background(radialGradient)
+}
+
+/**
+ * Applies a multicolor radial gradient scrim in the foreground emanating from any location using
+ * offset multipliers.
+ * @param colors [List] of [Color] : List of colors to apply to the gradient
+ * @param alpha [Float] : Alpha value to apply to the gradient
+ * @param maxDimension [Boolean] : Determines if radius will be based on the max dimension side (true)
+ * or the min dimension side (false)
+ * @param xOffset [Float] : Multiplier against the width to determine the x-axis of the radial center
+ * @param yOffset [Float] : Multiplier against the height to determine the y-axis of the radial center
+ */
+fun Modifier.radialMultiGradientScrimAnyOffset(
+    colors: List<Color>,
+    @FloatRange(from = 0.0, to = 1.0) alpha: Float = 1f,
+    maxDimension: Boolean = true,
+    xOffset: Float = 1f,
+    yOffset: Float = 1f
+): Modifier {
+    val radialGradient = object : ShaderBrush() {
+        override fun createShader(size: Size): Shader {
+            val dimension =
+                if (maxDimension) max(size.height, size.width)
+                else min(size.height, size.width)
+            return RadialGradientShader(
+                center = size.center.copy(x = size.width * xOffset, y = size.height * yOffset),
+                colors = colors.map { it.copy(alpha = alpha) },
+                radius = dimension * 1.5f,
+                colorStops = getColorStops(colors.size)
+            )
+        }
+    }
+    return this.background(radialGradient)
+}
+
+/**
+ * Defines some possible color stops for radial gradient scrims.
+ */
+private fun getColorStops(size: Int): List<Float> =
+    when (size) {
+        1 -> listOf(0.5f)
+        2 -> listOf(0.3f, 0.7f)
+        3 -> listOf(0.25f, 0.5f, 0.75f)
+        4 -> listOf(0.2f, 0.4f, 0.6f, 0.8f)
+        5 -> listOf(0.20f, 0.35f, 0.50f, 0.65f, 0.80f)
+        else -> listOf(0f, 0.9f)
+    }
+
+
+/***********************************************************************************************
+ *
+ * ********** MONOCHROMATIC DIRECTIONAL GRADIENTS **********
+ *
+ **********************************************************************************************/
+
+/**
+ * Draws a horizontal gradient scrim in the foreground.
+ *
+ * @param color The color of the gradient scrim.
+ * @param startXPercentage The start x value, in percentage of the layout's width (0f to 1f)
+ * @param endXPercentage The end x value, in percentage of the layout's width (0f to 1f). This
+ * value can be smaller than [startXPercentage]. If that is the case, then the gradient direction
+ * will reverse (decaying downwards, instead of decaying upwards).
+ * @param decay The exponential decay to apply to the gradient. Defaults to `1.0f` which is
+ * a linear gradient.
+ * @param numStops The number of color stops to draw in the gradient. Higher numbers result in
+ * the higher visual quality at the cost of draw performance. Defaults to `16`.
+ */
+fun Modifier.horizontalGradientScrim(
+    color: Color,
+    @FloatRange(from = 0.0, to = 1.0) startXPercentage: Float = 0f,
+    @FloatRange(from = 0.0, to = 1.0) endXPercentage: Float = 1f,
+    decay: Float = 1.0f,
+    numStops: Int = 16
+) = this then HorizontalGradientElement(color, startXPercentage, endXPercentage, decay, numStops)
+
+private data class HorizontalGradientElement(
+    var color: Color,
+    var startXPercentage: Float = 0f,
+    var endXPercentage: Float = 1f,
+    var decay: Float = 1.0f,
+    var numStops: Int = 16
+) : ModifierNodeElement<GradientModifier>() {
+    fun createOnDraw(): DrawScope.() -> Unit {
+        val colors = if (decay != 1f) {
+            // If we have a non-linear decay, we need to create the color gradient steps
+            // manually
+            val baseAlpha = color.alpha
+            List(numStops) { i ->
+                val x = i * 1f / (numStops - 1)
+                val opacity = x.pow(decay)
+                color.copy(alpha = baseAlpha * opacity)
+            }
+        } else {
+            // If we have a linear decay, we just create a simple list of start + end colors
+            listOf(color.copy(alpha = 0f), color)
+        }
+
+        val brush = Brush.horizontalGradient(
+            colors = if (startXPercentage < endXPercentage) colors else colors.reversed()
+        )
+
+        return {
+            val topL = Offset(x = size.width * min(startXPercentage, endXPercentage), y = 0f)
+            val bottomR = Offset(x = size.width * max(startXPercentage, endXPercentage), y = size.height)
+
+            drawRect(
+                topLeft = topL,
+                size = Rect(topL, bottomR).size,
+                brush = brush
+            )
+        }
+    }
+    override fun create() = GradientModifier(createOnDraw())
+    override fun update(node: GradientModifier) { node.onDraw = createOnDraw() }
+    override fun InspectorInfo.inspectableProperties() {
+        name = "horizontalGradientScrim"
+        properties["color"] = color
+        properties["startXPercentage"] = startXPercentage
+        properties["endXPercentage"] = endXPercentage
+        properties["decay"] = decay
+        properties["numStops"] = numStops
+    }
 }
 
 /**
@@ -123,11 +294,10 @@ private data class VerticalGradientElement(
     var endYPercentage: Float = 1f,
     var decay: Float = 1.0f,
     var numStops: Int = 16
-) : ModifierNodeElement<VerticalGradientModifier>() {
+) : ModifierNodeElement<GradientModifier>() {
     fun createOnDraw(): DrawScope.() -> Unit {
         val colors = if (decay != 1f) {
-            // If we have a non-linear decay, we need to create the color gradient steps
-            // manually
+            // If we have a non-linear decay, we need to create the color gradient steps manually
             val baseAlpha = color.alpha
             List(numStops) { i ->
                 val x = i * 1f / (numStops - 1)
@@ -139,16 +309,13 @@ private data class VerticalGradientElement(
             listOf(color.copy(alpha = 0f), color)
         }
 
-        val brush =
-            // Reverse the gradient if decaying downwards
-            Brush.verticalGradient(
-                colors = if (startYPercentage < endYPercentage) colors else colors.reversed(),
-            )
+        val brush = Brush.verticalGradient(
+            colors = if (startYPercentage < endYPercentage) colors else colors.reversed(),
+        )
 
         return {
             val topLeft = Offset(0f, size.height * min(startYPercentage, endYPercentage))
-            val bottomRight =
-                Offset(size.width, size.height * max(startYPercentage, endYPercentage))
+            val bottomRight = Offset(size.width, size.height * max(startYPercentage, endYPercentage))
 
             drawRect(
                 topLeft = topLeft,
@@ -157,12 +324,8 @@ private data class VerticalGradientElement(
             )
         }
     }
-
-    override fun create() = VerticalGradientModifier(createOnDraw())
-
-    override fun update(node: VerticalGradientModifier) {
-        node.onDraw = createOnDraw()
-    }
+    override fun create() = GradientModifier(createOnDraw())
+    override fun update(node: GradientModifier) { node.onDraw = createOnDraw() }
 
     /**
      * Allow this custom modifier to be inspected in the layout inspector
@@ -177,25 +340,13 @@ private data class VerticalGradientElement(
     }
 }
 
-private class VerticalGradientModifier(
+private class GradientModifier(
     var onDraw: DrawScope.() -> Unit
-) : Modifier.Node(), DrawModifierNode {
+) : Modifier.Node(),
+    DrawModifierNode {
 
     override fun ContentDrawScope.draw() {
         onDraw()
         drawContent()
     }
 }
-
-/**
- * Defines the possible color stops for radial gradient scrims.
- */
-private fun getColorStops(size: Int): List<Float> =
-    when (size) {
-        1 -> listOf(0.5f)
-        2 -> listOf(0.3f, 0.7f)
-        3 -> listOf(0.25f, 0.5f, 0.75f)
-        4 -> listOf(0.2f, 0.4f, 0.6f, 0.8f)
-        5 -> listOf(0.20f, 0.35f, 0.50f, 0.65f, 0.80f)
-        else -> listOf(0f, 0.9f)
-    }

--- a/app/src/main/java/com/example/music/util/GradientScrim.kt
+++ b/app/src/main/java/com/example/music/util/GradientScrim.kt
@@ -22,7 +22,7 @@ import kotlin.math.min
 import kotlin.math.pow
 
 /**
- * Applies a radial gradient scrim in the foreground.
+ * Applies a monochromatic radial gradient scrim in the foreground emanating from any offset.
  */
 fun Modifier.radialGradientScrimAnyOffset(color: Color, xOffset: Int, yOffset: Int): Modifier {
     val radialGradient = object : ShaderBrush() {
@@ -31,38 +31,9 @@ fun Modifier.radialGradientScrimAnyOffset(color: Color, xOffset: Int, yOffset: I
             val smallerDimension = min(size.height, size.width)
             return RadialGradientShader(
                 center = size.center.copy(x = size.width / xOffset, y = size.height / yOffset),
-                colors = listOf(color, Color.Transparent), //colors + Color.Transparent, //for param colors, would need to change color stops to match amount of colors
+                colors = listOf(color, Color.Transparent),
                 radius = smallerDimension * 1.5f,
-                colorStops = listOf(0f, 0.9f) //colorStops = listOf(0.25f, 0.5f, 0.75f)//listOf(0.3f, 0.7f)
-            )
-        }
-    }
-    return this.background(radialGradient)
-}
-
-fun Modifier.radialGradientScrimAnyColorsOffset(colors: List<Color>, xOffset: Int, yOffset: Int): Modifier {
-    val colorStops = when(colors.size) {
-        1 -> {
-            listOf(0.3f, 0.7f)
-        }
-        2 -> {
-            listOf(0.25f, 0.5f, 0.75f)
-        }
-        3 -> {
-            listOf(0.2f, 0.4f, 0.6f, 0.8f)
-        }
-        else -> {
-            listOf(0f, 0.9f)
-        }
-    }
-    val radialGradient = object : ShaderBrush() {
-        override fun createShader(size: Size): Shader {
-            val largerDimension = max(size.height, size.width)
-            return RadialGradientShader(
-                center = size.center.copy(x = size.width / xOffset, y = size.height / yOffset),
-                colors = colors + Color.Transparent, //for param colors, would need to change color stops to match amount of colors
-                radius = (largerDimension / (colors.size + 1)) * colors.size, //largerDimension / 2
-                colorStops = colorStops //colorStops = listOf(0.25f, 0.5f, 0.75f)//listOf(0.3f, 0.7f)
+                colorStops = getColorStops(0) // forcing else branch
             )
         }
     }
@@ -70,7 +41,25 @@ fun Modifier.radialGradientScrimAnyColorsOffset(colors: List<Color>, xOffset: In
 }
 
 /**
- * Applies a radial gradient scrim in the foreground emanating from the top
+ * Applies a multicolor radial gradient scrim in the foreground emanating from any offset.
+ */
+fun Modifier.radialGradientScrimAnyColorsOffset(colors: List<Color>, xOffset: Int, yOffset: Int): Modifier {
+    val radialGradient = object : ShaderBrush() {
+        override fun createShader(size: Size): Shader {
+            val largerDimension = max(size.height, size.width)
+            return RadialGradientShader(
+                center = size.center.copy(x = size.width / xOffset, y = size.height / yOffset),
+                colors = colors + Color.Transparent,
+                radius = (largerDimension / (colors.size + 1)) * colors.size, //largerDimension / 2
+                colorStops = getColorStops(colors.size + 1) // adding Transparent color means +1 to og size
+            )
+        }
+    }
+    return this.background(radialGradient)
+}
+
+/**
+ * Applies a monochromatic radial gradient scrim in the foreground emanating from the top
  * center quarter of the element.
  */
 fun Modifier.radialGradientScrimCentered(color: Color): Modifier {
@@ -80,8 +69,8 @@ fun Modifier.radialGradientScrimCentered(color: Color): Modifier {
             return RadialGradientShader(
                 center = size.center.copy(y = size.height / 4),
                 colors = listOf(color, Color.Transparent),
-                radius = largerDimension / 2,
-                colorStops = listOf(0f, 0.9f)
+                radius = largerDimension / 3,
+                colorStops = getColorStops(0) // forcing else branch
             )
         }
     }
@@ -89,7 +78,8 @@ fun Modifier.radialGradientScrimCentered(color: Color): Modifier {
 }
 
 /**
- * Applies a radial gradient scrim in the foreground emanating from the bottom right of the element.
+ * Applies a multicolor radial gradient scrim in the foreground emanating from the bottom
+ * right of the element.
  */
 fun Modifier.radialGradientScrimBottomRight(colors: List<Color>,): Modifier {
     val radialGradient = object : ShaderBrush() {
@@ -97,9 +87,9 @@ fun Modifier.radialGradientScrimBottomRight(colors: List<Color>,): Modifier {
             val largerDimension = max(size.height, size.width)
             return RadialGradientShader(
                 center = size.center.copy(x = size.width, y = size.height),
-                colors = colors + Color.Transparent,//listOf(color, Color.Transparent),
-                radius = largerDimension * 1.5f,
-                colorStops = listOf(0.25f, 0.5f, 0.75f)//listOf(0.3f, 0.7f)
+                colors = colors + Color.Transparent,
+                radius = largerDimension * 1.75f,
+                colorStops = getColorStops(colors.size + 1)
             )
         }
     }
@@ -196,3 +186,16 @@ private class VerticalGradientModifier(
         drawContent()
     }
 }
+
+/**
+ * Defines the possible color stops for radial gradient scrims.
+ */
+private fun getColorStops(size: Int): List<Float> =
+    when (size) {
+        1 -> listOf(0.5f)
+        2 -> listOf(0.3f, 0.7f)
+        3 -> listOf(0.25f, 0.5f, 0.75f)
+        4 -> listOf(0.2f, 0.4f, 0.6f, 0.8f)
+        5 -> listOf(0.20f, 0.35f, 0.50f, 0.65f, 0.80f)
+        else -> listOf(0f, 0.9f)
+    }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <!-- Original Theme.Music here -->
     <style name="Theme.Music" parent="android:Theme.Material.Light.NoActionBar" >
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
-    <!-- Trying different theme to see if it changes preview / emulator rendering -->
-<!--    <style name="Theme.Music" parent="android:Theme.Material.Light.DarkActionBar" />-->
 </resources>

--- a/core/designsys/src/main/java/com/example/music/designsys/component/ImageBackground.kt
+++ b/core/designsys/src/main/java/com/example/music/designsys/component/ImageBackground.kt
@@ -35,7 +35,7 @@ import coil.compose.AsyncImage
 
 @Composable
 fun ImageBackgroundColorScrim(
-    imageId: String?,
+    imageId: String?, // imageId originally named url for image url
     color: Color,
     modifier: Modifier = Modifier,
 ) {
@@ -50,7 +50,7 @@ fun ImageBackgroundColorScrim(
 
 @Composable
 fun ImageBackgroundRadialGradientScrim(
-    imageId: String?, //FixMe: this needs to be either bitmap or uri
+    imageId: String?, // imageId originally named url for image url
     colors: List<Color>,
     modifier: Modifier = Modifier,
 ) {
@@ -73,12 +73,12 @@ fun ImageBackgroundRadialGradientScrim(
  */
 @Composable
 fun ImageBackground(
-    imageId: String?,
+    imageId: String?, // imageId originally named url for image url
     overlay: DrawScope.() -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AsyncImage(
-        model = imageId,
+        model = imageId, // imageId originally named url
         contentDescription = null,
         contentScale = ContentScale.Crop,
         modifier = modifier
@@ -99,6 +99,9 @@ fun ImageBackground(
  *
  **********************************************************************************************/
 
+/**
+ * Draws an image background with a color filter.
+ */
 @Composable
 fun ImageBackgroundColorScrim_Bm(
     imageId: Bitmap?,
@@ -116,6 +119,9 @@ fun ImageBackgroundColorScrim_Bm(
     )
 }
 
+/**
+ * Draws an image background with a multicolor filter from top left to bottom right.
+ */
 @Composable
 fun ImageBackgroundRadialGradientScrim_Bm(
     imageId: Bitmap?,
@@ -128,19 +134,12 @@ fun ImageBackgroundRadialGradientScrim_Bm(
         imageDescription = imageDescription,
         modifier = modifier,
         overlay = {
-            // trying to change center away from bottom left corner
-//            val brush = Brush.radialGradient(
-//                colors = colors,
-//                center = Offset((size.width * 0.25f), (size.height * 0.6f) ),
-//                radius = size.height * 1.3f
-//            )
-            //original brush
             val brush = Brush.radialGradient(
                 colors = colors,
                 center = Offset((0F), (size.height)),
                 radius = size.width * 3F
             )
-            drawRect(brush, blendMode = BlendMode.Multiply)
+            drawRect(brush, blendMode = BlendMode.Modulate)
             /** original is Multiply;
              *  Modulate returns same result as multiply;
              *  Xor returns inverse values;
@@ -157,6 +156,93 @@ fun ImageBackgroundRadialGradientScrim_Bm(
 @Composable
 fun ImageBackground_Bm(
     imageId: Bitmap?,
+    imageDescription: String,
+    overlay: DrawScope.() -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AsyncImage(
+        model = imageId,
+        contentDescription = imageDescription,
+        contentScale = ContentScale.Crop,
+        modifier = modifier
+//            .sizeIn(maxWidth = 300.dp, maxHeight = 300.dp)
+            .fillMaxWidth()
+            .drawWithCache {
+                onDrawWithContent {
+                    drawContent()
+                    overlay()
+                }
+            },
+//        alignment = Alignment.Center,
+//        alpha = 0.6f,
+//        clipToBounds = true,
+    )
+}
+
+
+/***********************************************************************************************
+ *
+ * **********  IMAGE BACKGROUND USING URI ***********
+ *
+ **********************************************************************************************/
+
+/**
+ * Draws an image background with a color filter.
+ */
+@Composable
+fun ImageBackgroundColorScrim_Uri(
+    imageId: Uri?,
+    imageDescription: String,
+    color: Color = Color.Transparent,
+    modifier: Modifier = Modifier,
+) {
+    ImageBackground_Uri(
+        imageId = imageId,
+        imageDescription = imageDescription,
+        modifier = modifier,
+        overlay = {
+            drawRect(color)
+        }
+    )
+}
+
+/**
+ * Draws an image background with a multicolor filter from top left to bottom right.
+ */
+@Composable
+fun ImageBackgroundRadialGradientScrim_Uri(
+    imageId: Uri?,
+    imageDescription: String,
+    colors: List<Color>,
+    modifier: Modifier = Modifier,
+) {
+    ImageBackground_Uri(
+        imageId = imageId,
+        imageDescription = imageDescription,
+        modifier = modifier,
+        overlay = {
+            val brush = Brush.radialGradient(
+                colors = colors,
+                center = Offset((0F), (size.height)),
+                radius = size.width * 3F
+            )
+            drawRect(brush, blendMode = BlendMode.Modulate)
+            /** original is Multiply;
+             *  Modulate returns same result as multiply;
+             *  Xor returns inverse values;
+             *  SrcOver returns brush behind 'destination' gradient scrim, showing ImageBgRadial over PlayerContentRegular column modifier scrims
+             *  DstOver returns scrim without brush
+             */
+        }
+    )
+}
+
+/**
+ * Displays an image scaled 150% overlaid by [overlay]
+ */
+@Composable
+fun ImageBackground_Uri(
+    imageId: Uri?,
     imageDescription: String,
     overlay: DrawScope.() -> Unit,
     modifier: Modifier = Modifier,

--- a/core/designsys/src/main/java/com/example/music/designsys/component/ImageBackground.kt
+++ b/core/designsys/src/main/java/com/example/music/designsys/component/ImageBackground.kt
@@ -1,25 +1,8 @@
-/*
- * Copyright 2024 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.example.music.designsys.component
 
 import android.graphics.Bitmap
 import android.net.Uri
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.BlurredEdgeTreatment
@@ -34,53 +17,23 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 
-@Composable
-fun ImageBackgroundColorScrim(
-    imageId: String?, // imageId originally named url for image url
-    color: Color,
-    modifier: Modifier = Modifier,
-) {
-    ImageBackground(
-        imageId = imageId,
-        modifier = modifier,
-        overlay = {
-            drawRect(color)
-        }
-    )
-}
-
-@Composable
-fun ImageBackgroundRadialGradientScrim(
-    imageId: String?, // imageId originally named url for image url
-    colors: List<Color>,
-    modifier: Modifier = Modifier,
-) {
-    ImageBackground(
-        imageId = imageId,
-        modifier = modifier,
-        overlay = {
-            val brush = Brush.radialGradient(
-                colors = colors,
-                center = Offset((0f), (size.height)),
-                radius = size.width * 2.5f
-            )
-            drawRect(brush, blendMode = BlendMode.Multiply)
-        }
-    )
-}
-
 /**
- * Displays an image scaled 150% overlaid by [overlay]
+ * Sends an image request and returns the image scaled 150% overlaid by [overlay] with a blur modifier
+ * @param imageId Nullable [String] : represents the image's unique identifier
+ * @param imageDescription Nullable [String] : describes the image
+ * @param overlay [DrawScope] -> [Unit] : defines the filter overlay to draw onto the image
+ * @param modifier [Modifier] : defines the modifiers to apply to image
  */
 @Composable
-fun ImageBackground(
-    imageId: String?, // imageId originally named url for image url
+internal fun ImageBackground(
+    imageId: Any?,
+    imageDescription: String? = null,
     overlay: DrawScope.() -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AsyncImage(
-        model = imageId, // imageId originally named url
-        contentDescription = null,
+        model = imageId,
+        contentDescription = imageDescription,
         contentScale = ContentScale.Crop,
         modifier = modifier
             .fillMaxWidth()
@@ -90,6 +43,71 @@ fun ImageBackground(
                     overlay()
                 }
             }
+            .blur(
+                radiusX = 5.dp,
+                radiusY = 5.dp,
+                edgeTreatment = BlurredEdgeTreatment.Rectangle
+            ),
+    )
+}
+
+
+/***********************************************************************************************
+ *
+ * **********  IMAGE BACKGROUND USING URL STRING ***********
+ *
+ **********************************************************************************************/
+
+/**
+ * Draws an image background with a color filter.
+ * @param imageId Nullable [String] : represents the image's url
+ * @param imageDescription Nullable [String] : describes the image
+ * @param color [Color] : defines the color to apply to filter
+ * @param modifier [Modifier] : defines any modifiers to apply to image
+ */
+@Composable
+fun ImageBackgroundColorFilter(
+    imageId: String?,
+    imageDescription: String? = null,
+    color: Color = Color.Transparent,
+    modifier: Modifier = Modifier,
+) {
+    ImageBackground(
+        imageId = imageId,
+        imageDescription = imageDescription,
+        modifier = modifier,
+        overlay = {
+            drawRect(color)
+        }
+    )
+}
+
+/**
+ * Draws an image background with a multicolor radial gradient filter centered on the bottom left.
+ * @param imageId Nullable [String] : represents the image's url
+ * @param imageDescription Nullable [String] : describes the image
+ * @param colors [List] of [Color] : defines the colors to apply to filter
+ * @param modifier [Modifier] : defines any modifiers to apply to image
+ */
+@Composable
+fun ImageBackgroundRadialGradientFilter(
+    imageId: String?,
+    imageDescription: String? = null,
+    colors: List<Color>,
+    modifier: Modifier = Modifier,
+) {
+    ImageBackground(
+        imageId = imageId,
+        imageDescription = imageDescription,
+        modifier = modifier,
+        overlay = {
+            val brush = Brush.radialGradient(
+                colors = colors,
+                center = Offset((0f), (size.height)),
+                radius = size.width * 2.5f
+            )
+            drawRect(brush, blendMode = BlendMode.Modulate)
+        }
     )
 }
 
@@ -102,15 +120,19 @@ fun ImageBackground(
 
 /**
  * Draws an image background with a color filter.
+ * @param imageId Nullable [String] : represents the image's bitmap
+ * @param imageDescription Nullable [String] : describes the image
+ * @param color [Color] : defines the color to apply to filter
+ * @param modifier [Modifier] : defines any modifiers to apply to image
  */
 @Composable
-fun ImageBackgroundColorScrim_Bm(
+fun ImageBackgroundColorFilter_Bm(
     imageId: Bitmap?,
-    imageDescription: String,
+    imageDescription: String? = null,
     color: Color = Color.Transparent,
     modifier: Modifier = Modifier,
 ) {
-    ImageBackground_Bm(
+    ImageBackground(
         imageId = imageId,
         imageDescription = imageDescription,
         modifier = modifier,
@@ -121,16 +143,20 @@ fun ImageBackgroundColorScrim_Bm(
 }
 
 /**
- * Draws an image background with a multicolor filter from top left to bottom right.
+ * Draws an image background with a multicolor radial gradient filter centered on the bottom left.
+ * @param imageId Nullable [String] : represents the image's bitmap
+ * @param imageDescription Nullable [String] : describes the image
+ * @param colors [List] of [Color] : defines the colors to apply to filter
+ * @param modifier [Modifier] : defines any modifiers to apply to image
  */
 @Composable
-fun ImageBackgroundRadialGradientScrim_Bm(
+fun ImageBackgroundRadialGradientFilter_Bm(
     imageId: Bitmap?,
-    imageDescription: String,
+    imageDescription: String? = null,
     colors: List<Color>,
     modifier: Modifier = Modifier,
 ) {
-    ImageBackground_Bm(
+    ImageBackground(
         imageId = imageId,
         imageDescription = imageDescription,
         modifier = modifier,
@@ -141,44 +167,7 @@ fun ImageBackgroundRadialGradientScrim_Bm(
                 radius = size.width * 3F
             )
             drawRect(brush, blendMode = BlendMode.Modulate)
-            /** original is Multiply;
-             *  Modulate returns same result as multiply;
-             *  Xor returns inverse values;
-             *  SrcOver returns brush behind 'destination' gradient scrim, showing ImageBgRadial over PlayerContentRegular column modifier scrims
-             *  DstOver returns scrim without brush
-             */
         }
-    )
-}
-
-/**
- * Displays an image scaled 150% overlaid by [overlay]
- */
-@Composable
-fun ImageBackground_Bm(
-    imageId: Bitmap?,
-    imageDescription: String,
-    overlay: DrawScope.() -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    AsyncImage(
-        model = imageId,
-        contentDescription = imageDescription,
-        contentScale = ContentScale.Crop,
-        modifier = modifier
-//            .sizeIn(maxWidth = 300.dp, maxHeight = 300.dp)
-            .fillMaxWidth()
-            .drawWithCache {
-                onDrawWithContent {
-                    drawContent()
-                    overlay()
-                }
-            }
-            .blur(
-                radiusX = 5.dp,
-                radiusY = 5.dp,
-                edgeTreatment = BlurredEdgeTreatment.Rectangle
-            ),
     )
 }
 
@@ -191,15 +180,19 @@ fun ImageBackground_Bm(
 
 /**
  * Draws an image background with a color filter.
+ * @param imageId Nullable [String] : represents the image's Uri
+ * @param imageDescription Nullable [String] : describes the image
+ * @param color [Color] : defines the color to apply to filter
+ * @param modifier [Modifier] : defines any modifiers to apply to image
  */
 @Composable
-fun ImageBackgroundColorScrim_Uri(
+fun ImageBackgroundColorFilter_Uri(
     imageId: Uri?,
-    imageDescription: String,
+    imageDescription: String? = null,
     color: Color = Color.Transparent,
     modifier: Modifier = Modifier,
 ) {
-    ImageBackground_Uri(
+    ImageBackground(
         imageId = imageId,
         imageDescription = imageDescription,
         modifier = modifier,
@@ -210,16 +203,20 @@ fun ImageBackgroundColorScrim_Uri(
 }
 
 /**
- * Draws an image background with a multicolor filter from top left to bottom right.
+ * Draws an image background with a multicolor radial gradient filter centered on the bottom left.
+ * @param imageId Nullable [String] : represents the image's Uri
+ * @param imageDescription Nullable [String] : describes the image
+ * @param colors [List] of [Color] : defines the colors to apply to filter
+ * @param modifier [Modifier] : defines any modifiers to apply to image
  */
 @Composable
-fun ImageBackgroundRadialGradientScrim_Uri(
+fun ImageBackgroundRadialGradientFilter_Uri(
     imageId: Uri?,
-    imageDescription: String,
+    imageDescription: String? = null,
     colors: List<Color>,
     modifier: Modifier = Modifier,
 ) {
-    ImageBackground_Uri(
+    ImageBackground(
         imageId = imageId,
         imageDescription = imageDescription,
         modifier = modifier,
@@ -230,43 +227,6 @@ fun ImageBackgroundRadialGradientScrim_Uri(
                 radius = size.width * 3F
             )
             drawRect(brush, blendMode = BlendMode.Modulate)
-            /** original is Multiply;
-             *  Modulate returns same result as multiply;
-             *  Xor returns inverse values;
-             *  SrcOver returns brush behind 'destination' gradient scrim, showing ImageBgRadial over PlayerContentRegular column modifier scrims
-             *  DstOver returns scrim without brush
-             */
         }
-    )
-}
-
-/**
- * Displays an image scaled 150% overlaid by [overlay]
- */
-@Composable
-fun ImageBackground_Uri(
-    imageId: Uri?,
-    imageDescription: String,
-    overlay: DrawScope.() -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    AsyncImage(
-        model = imageId,
-        contentDescription = imageDescription,
-        contentScale = ContentScale.Crop,
-        modifier = modifier
-//            .sizeIn(maxWidth = 300.dp, maxHeight = 300.dp)
-            .fillMaxWidth()
-            .drawWithCache {
-                onDrawWithContent {
-                    drawContent()
-                    overlay()
-                }
-            }
-            .blur(
-                radiusX = 5.dp,
-                radiusY = 5.dp,
-                edgeTreatment = BlurredEdgeTreatment.Rectangle
-            ),
     )
 }

--- a/core/designsys/src/main/java/com/example/music/designsys/component/ImageBackground.kt
+++ b/core/designsys/src/main/java/com/example/music/designsys/component/ImageBackground.kt
@@ -21,8 +21,9 @@ import android.net.Uri
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlendMode
@@ -172,10 +173,12 @@ fun ImageBackground_Bm(
                     drawContent()
                     overlay()
                 }
-            },
-//        alignment = Alignment.Center,
-//        alpha = 0.6f,
-//        clipToBounds = true,
+            }
+            .blur(
+                radiusX = 5.dp,
+                radiusY = 5.dp,
+                edgeTreatment = BlurredEdgeTreatment.Rectangle
+            ),
     )
 }
 
@@ -259,9 +262,11 @@ fun ImageBackground_Uri(
                     drawContent()
                     overlay()
                 }
-            },
-//        alignment = Alignment.Center,
-//        alpha = 0.6f,
-//        clipToBounds = true,
+            }
+            .blur(
+                radiusX = 5.dp,
+                radiusY = 5.dp,
+                edgeTreatment = BlurredEdgeTreatment.Rectangle
+            ),
     )
 }

--- a/core/designsys/src/main/java/com/example/music/designsys/component/ImageBackground.kt
+++ b/core/designsys/src/main/java/com/example/music/designsys/component/ImageBackground.kt
@@ -16,8 +16,12 @@
 
 package com.example.music.designsys.component
 
+import android.graphics.Bitmap
+import android.net.Uri
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
@@ -26,6 +30,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 
 @Composable
@@ -84,5 +89,93 @@ fun ImageBackground(
                     overlay()
                 }
             }
+    )
+}
+
+
+/***********************************************************************************************
+ *
+ * **********  IMAGE BACKGROUND USING BITMAP ***********
+ *
+ **********************************************************************************************/
+
+@Composable
+fun ImageBackgroundColorScrim_Bm(
+    imageId: Bitmap?,
+    imageDescription: String,
+    color: Color = Color.Transparent,
+    modifier: Modifier = Modifier,
+) {
+    ImageBackground_Bm(
+        imageId = imageId,
+        imageDescription = imageDescription,
+        modifier = modifier,
+        overlay = {
+            drawRect(color)
+        }
+    )
+}
+
+@Composable
+fun ImageBackgroundRadialGradientScrim_Bm(
+    imageId: Bitmap?,
+    imageDescription: String,
+    colors: List<Color>,
+    modifier: Modifier = Modifier,
+) {
+    ImageBackground_Bm(
+        imageId = imageId,
+        imageDescription = imageDescription,
+        modifier = modifier,
+        overlay = {
+            // trying to change center away from bottom left corner
+//            val brush = Brush.radialGradient(
+//                colors = colors,
+//                center = Offset((size.width * 0.25f), (size.height * 0.6f) ),
+//                radius = size.height * 1.3f
+//            )
+            //original brush
+            val brush = Brush.radialGradient(
+                colors = colors,
+                center = Offset((0F), (size.height)),
+                radius = size.width * 3F
+            )
+            drawRect(brush, blendMode = BlendMode.Multiply)
+            /** original is Multiply;
+             *  Modulate returns same result as multiply;
+             *  Xor returns inverse values;
+             *  SrcOver returns brush behind 'destination' gradient scrim, showing ImageBgRadial over PlayerContentRegular column modifier scrims
+             *  DstOver returns scrim without brush
+             */
+        }
+    )
+}
+
+/**
+ * Displays an image scaled 150% overlaid by [overlay]
+ */
+@Composable
+fun ImageBackground_Bm(
+    imageId: Bitmap?,
+    imageDescription: String,
+    overlay: DrawScope.() -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AsyncImage(
+        model = imageId,
+        contentDescription = imageDescription,
+        contentScale = ContentScale.Crop,
+        modifier = modifier
+//            .sizeIn(maxWidth = 300.dp, maxHeight = 300.dp)
+            .fillMaxWidth()
+            .drawWithCache {
+                onDrawWithContent {
+                    drawContent()
+                    overlay()
+                }
+            },
+//        alignment = Alignment.Center,
+//        alpha = 0.6f,
+//        clipToBounds = true,
     )
 }


### PR DESCRIPTION
### Description:
So as usual, attempting to do one thing meant I tried it across several things. So while the initial intent of changing the PlayerScreen UI was accomplished, it also led to changes to all screens' and components' backgrounds.

### Changes Made:
**DesignSys module:**
- Fixed ImageBackground.kt functions to use Uri and Bitmap to load artwork thumbnails
- Added blur modifier to ImageBackground()

**UI module:**
- Completely revised GradientScrim.kt so there's more customized options as well as a new horizontalGradientScrim
- Slight adjustment to a couple color values in Cool Tones Light Color set, reordered colors for Cool Tones Light and Dark sets, and added more value options to reference in comments
- Modified ScreenBackground.kt to use more saturated colors for radial gradient
- Modified MiniPlayer's background to use gradient scrim and changed the Play/Pause btn color filters to have more visual contrast

**PlayerScreen.kt**
- Function comment descriptions added or revised
- Adjusted PlayerBackground() to follow updates to DesignSys module's ImageBackground(). It uses currentSong's artworkBitmap to return song's artwork cover and apply it as the Player Screen's background with a blur effect and slight color filter
- Removed PlayerContentRegular()'s gradient scrim modifiers in favor of the fixed PlayerBackground
- Changed when Modifier system bar padding is applied so that the Scaffold's contentPadding can be in use without unintentionally amplifying the padding across PlayerContent() functions
- Moved the song duration text to the right side of the screen in PlayerSlider()
- Changed the PlayerButtons color filters to have more visual contrast

**MainActivity.kt:**
- Changed edge-to-edge to use transparent scrim for dark mode

### Related Issues:
none