### PR TITLE
Revised MediaResolver's query conventions; Revised Search Screen results view logic

### DIFF
--- a/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/albumdetails/AlbumDetailsViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import com.example.music.data.util.FLAG
 import com.example.music.domain.model.AlbumInfo
 import com.example.music.domain.model.ArtistInfo
 import com.example.music.domain.model.SongInfo
@@ -167,7 +168,7 @@ class AlbumDetailsViewModel @Inject constructor(
                     selectSortOrder = selectSort,
                 )
             }.catch { throwable ->
-                Log.i(TAG, "Error Caught: ${throwable.message}")
+                Log.e(TAG, "Error Caught: ${throwable.message}")
                 emit(
                     AlbumUiState(
                         isReady = true,
@@ -255,11 +256,10 @@ class AlbumDetailsViewModel @Inject constructor(
     }
 
     fun refresh(force: Boolean = true) {
-        Log.i(TAG, "Refresh call")
-        Log.i(TAG, "refreshing: ${refreshing.value}")
+        Log.i(TAG, "Refresh call -> refreshing: ${refreshing.value}")
         viewModelScope.launch {
             runCatching {
-                Log.i(TAG, "Refresh runCatching")
+                if (FLAG) Log.i(TAG, "Refresh runCatching")
                 refreshing.value = true
             }.onFailure {
                 Log.e(TAG, "$it ::: runCatching failed (not sure what this means)")

--- a/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/artistdetails/ArtistDetailsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
+import com.example.music.data.util.FLAG
 import com.example.music.data.util.combine
 import com.example.music.domain.model.AlbumInfo
 import com.example.music.domain.model.ArtistInfo
@@ -73,7 +74,6 @@ class ArtistDetailsViewModel @Inject constructor(
     private val _artistId: String = savedStateHandle.get<String>(Screen.ARG_ARTIST_ID)!!
     private val artistId = _artistId.toLong()
 
-    //private val getArtistDetailsData = getArtistDetailsUseCase(artistId)
     private val getArtistDetailsData = getArtistDetails(artistId)
         .shareIn(viewModelScope, SharingStarted.WhileSubscribed())
 
@@ -217,7 +217,7 @@ class ArtistDetailsViewModel @Inject constructor(
                     selectSongSortOrder = selectSongSort,
                 )
             }.catch { throwable ->
-                Log.i(TAG, "Error Caught: ${throwable.message}")
+                Log.e(TAG, "Error Caught: ${throwable.message}")
                 emit(
                     ArtistUiState(
                         isReady = true,
@@ -305,11 +305,10 @@ class ArtistDetailsViewModel @Inject constructor(
     }
 
     fun refresh(force: Boolean = true) {
-        Log.i(TAG, "Refresh call")
-        Log.i(TAG, "refreshing: ${refreshing.value}")
+        Log.i(TAG, "Refresh call -> refreshing: ${refreshing.value}")
         viewModelScope.launch {
             runCatching {
-                Log.i(TAG, "Refresh runCatching")
+                if (FLAG) Log.i(TAG, "Refresh runCatching")
                 refreshing.value = true
             }.onFailure {
                 Log.e(TAG, "$it ::: runCatching failed (not sure what this means)")

--- a/app/src/main/java/com/example/music/ui/composerdetails/ComposerDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/composerdetails/ComposerDetailsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
+import com.example.music.data.util.FLAG
 import com.example.music.domain.usecases.GetComposerDetailsUseCase
 import com.example.music.domain.model.ComposerInfo
 import com.example.music.domain.model.SongInfo
@@ -109,7 +110,7 @@ class ComposerDetailsViewModel @Inject constructor(
                     songs = composerDetailsFilterResult.songs,
                 )
             }.catch { throwable ->
-                Log.i(TAG, "Error Caught: ${throwable.message}")
+                Log.e(TAG, "Error Caught: ${throwable.message}")
                 emit(
                     ComposerUiState(
                         isReady = true,
@@ -199,11 +200,10 @@ class ComposerDetailsViewModel @Inject constructor(
     }
 
     fun refresh(force: Boolean = true) {
-        Log.i(TAG, "Refresh call")
-        Log.i(TAG, "refreshing: ${refreshing.value}")
+        Log.i(TAG, "Refresh call -> refreshing: ${refreshing.value}")
         viewModelScope.launch {
             runCatching {
-                Log.i(TAG, "Refresh runCatching")
+                if (FLAG) Log.i(TAG, "Refresh runCatching")
                 refreshing.value = true
             }.onFailure {
                 Log.e(TAG, "$it ::: runCatching failed (not sure what this means)")

--- a/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/genredetails/GenreDetailsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
+import com.example.music.data.util.FLAG
 import com.example.music.domain.model.GenreInfo
 import com.example.music.domain.model.SongInfo
 import com.example.music.domain.usecases.GetGenreDetails
@@ -183,7 +184,7 @@ class GenreDetailsViewModel @Inject constructor(
                     selectSortOrder = selectSort,
                 )
             }.catch { throwable ->
-                Log.i(TAG, "Error Caught: ${throwable.message}")
+                Log.e(TAG, "Error Caught: ${throwable.message}")
                 emit(
                     GenreUiState(
                         isReady = true,
@@ -271,11 +272,10 @@ class GenreDetailsViewModel @Inject constructor(
     }
 
     fun refresh(force: Boolean = true) {
-        Log.i(TAG, "Refresh call")
-        Log.i(TAG, "refreshing: ${refreshing.value}")
+        Log.i(TAG, "Refresh call -> refreshing: ${refreshing.value}")
         viewModelScope.launch {
             runCatching {
-                Log.i(TAG, "Refresh runCatching")
+                if (FLAG) Log.i(TAG, "Refresh runCatching")
                 refreshing.value = true
             }.onFailure {
                 Log.e(TAG, "$it ::: runCatching failed (not sure what this means)")

--- a/app/src/main/java/com/example/music/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/home/HomeViewModel.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
+import com.example.music.data.util.FLAG
 import com.example.music.data.util.combine
 import com.example.music.domain.model.AlbumInfo
 import com.example.music.domain.model.PlaylistInfo
@@ -145,7 +146,7 @@ class HomeViewModel @Inject constructor(
                     selectSong = selectSong,
                 )
             }.catch { throwable ->
-                Log.i(TAG, "Error Caught: ${throwable.message}")
+                Log.e(TAG, "Error Caught: ${throwable.message}")
                 emit(
                     HomeScreenUiState(
                         isLoading = false,
@@ -237,11 +238,10 @@ class HomeViewModel @Inject constructor(
     }
 
     fun refresh(force: Boolean = true) {
-        Log.i(TAG, "Refresh call")
-        Log.i(TAG, "refreshing: ${refreshing.value}")
+        Log.i(TAG, "Refresh call -> refreshing: ${refreshing.value}")
         viewModelScope.launch {
             runCatching {
-                Log.i(TAG, "Refresh runCatching")
+                if (FLAG) Log.i(TAG, "Refresh runCatching")
                 refreshing.value = true
             }.onFailure {
                 Log.e(TAG, "$it ::: runCatching failed (not sure what this means)")
@@ -295,7 +295,7 @@ class HomeViewModel @Inject constructor(
                 selectSong = selectSong,
             )
         }.catch { throwable ->
-            Log.i(TAG, "Error Caught: ${throwable.message}")
+            Log.e(TAG, "Error Caught: ${throwable.message}")
             emit(
                 HomeScreenUiState(
                     isLoading = false,

--- a/app/src/main/java/com/example/music/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/library/LibraryViewModel.kt
@@ -15,6 +15,7 @@ import com.example.music.data.repository.ComposerSortList
 import com.example.music.data.repository.GenreSortList
 import com.example.music.data.repository.PlaylistSortList
 import com.example.music.data.repository.SongSortList
+import com.example.music.data.util.FLAG
 import com.example.music.data.util.combine
 import com.example.music.domain.model.AlbumInfo
 import com.example.music.domain.model.ArtistInfo
@@ -197,7 +198,7 @@ class LibraryViewModel @Inject constructor(
                     totals = counts,
                 )
             }.catch { throwable ->
-                Log.i(TAG, "Error Caught: ${throwable.message}")
+                Log.e(TAG, "Error Caught: ${throwable.message}")
                 emit(
                     LibraryScreenUiState(
                         isLoading = false,
@@ -287,14 +288,13 @@ class LibraryViewModel @Inject constructor(
     }
 
     fun refresh(force: Boolean = true) {
-        Log.i(TAG, "Refresh call")
-        Log.i(TAG, "refreshing: ${refreshing.value}")
+        Log.i(TAG, "Refresh call -> refreshing: ${refreshing.value}")
         viewModelScope.launch {
             runCatching {
-                Log.i(TAG, "Refresh runCatching")
+                if (FLAG) Log.i(TAG, "Refresh runCatching")
                 refreshing.value = true
             }.onFailure {
-                Log.i(TAG, "$it ::: runCatching failed (not sure what this means)")
+                Log.e(TAG, "$it ::: runCatching failed (not sure what this means)")
             }
 
             Log.i(TAG, "refresh to be false -> sets screen to ready state")

--- a/app/src/main/java/com/example/music/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/library/LibraryViewModel.kt
@@ -345,7 +345,10 @@ class LibraryViewModel @Inject constructor(
         }
     }
 
-    private fun onAppPreferencesUpdate(libraryCategory: LibraryCategory, newSort: Pair<String, Boolean>) {
+    private fun onAppPreferencesUpdate(
+        libraryCategory: LibraryCategory,
+        newSort: Pair<String, Boolean>
+    ) {
         viewModelScope.launch {
             when(libraryCategory) {
                 LibraryCategory.Albums -> {
@@ -530,13 +533,14 @@ class LibraryViewModel @Inject constructor(
     }
 }
 
-enum class LibraryCategory {
-    Playlists, Songs, Artists, Albums, Genres, Composers
-}
+enum class LibraryCategory { Playlists, Songs, Artists, Albums, Genres, Composers }
 
 @Immutable
 sealed interface LibraryAction {
-    data class AppPreferencesUpdate(val libraryCategory: LibraryCategory, val newSort: Pair<String, Boolean>) : LibraryAction
+    data class AppPreferencesUpdate(
+        val libraryCategory: LibraryCategory,
+        val newSort: Pair<String, Boolean>
+    ) : LibraryAction
     data class LibraryCategorySelected(val libraryCategory: LibraryCategory) : LibraryAction
 
     data class PlaySong(val song: SongInfo) : LibraryAction

--- a/app/src/main/java/com/example/music/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/player/PlayerViewModel.kt
@@ -12,6 +12,7 @@ import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import com.example.music.data.repository.RepeatType
+import com.example.music.data.util.FLAG
 import com.example.music.domain.model.SongInfo
 import com.example.music.service.SongController
 import com.example.music.domain.usecases.GetSongData
@@ -117,6 +118,8 @@ class PlayerViewModel @Inject constructor(
                 }
             }
         }
+
+        refresh(force = false)
         Log.i(TAG, "init END")
     }
 
@@ -191,17 +194,16 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun refresh(force: Boolean = true) {
-        Log.e(TAG, "Refresh call")
-        Log.e(TAG, "refreshing: ${refreshing.value}")
+        Log.i(TAG, "Refresh call -> refreshing: ${refreshing.value}")
         viewModelScope.launch {
             runCatching {
-                Log.e(TAG,"Refresh runCatching")
+                if (FLAG) Log.i(TAG,"Refresh runCatching")
                 refreshing.value = true
             }.onFailure {
                 Log.e(TAG, "$it ::: runCatching failed (not sure what this means)")
             }
 
-            Log.e(TAG,"refresh to be false -> sets screen to ready state")
+            Log.i(TAG,"refresh to be false -> sets screen to ready state")
             refreshing.value = false
         }
     }

--- a/app/src/main/java/com/example/music/ui/playlistdetails/PlaylistDetailsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/playlistdetails/PlaylistDetailsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
+import com.example.music.data.util.FLAG
 import com.example.music.domain.model.PlaylistInfo
 import com.example.music.domain.model.SongInfo
 import com.example.music.ui.Screen
@@ -64,14 +65,6 @@ class PlaylistDetailsViewModel @Inject constructor(
 
     private val getPlaylistDetailsData = getPlaylistDetails(playlistId)
         .shareIn(viewModelScope, SharingStarted.WhileSubscribed())
-
-    /* ---- Initial version that uses playlistRepo directly to retrieve Flow data for Playlist Details
-    val playlist = playlistRepo.getPlaylistWithExtraInfo(playlistId)
-        .shareIn(viewModelScope, SharingStarted.WhileSubscribed())
-
-    // original version for getting Song objects
-    val songs = playlistRepo.sortSongsInPlaylistByTrackNumberAsc(playlistId)
-        .shareIn(viewModelScope, SharingStarted.WhileSubscribed())*/
 
     private val selectedSong = MutableStateFlow(SongInfo())
 
@@ -132,6 +125,7 @@ class PlaylistDetailsViewModel @Inject constructor(
                     "isReady?: ${!refreshing}")
 
                 getSongControllerState()
+
                 val sortedSongs = when(selectSort.first) {
                     "Track Number" -> {
                         if (selectSort.second) playlistDetailsFilterResult.songs
@@ -197,7 +191,7 @@ class PlaylistDetailsViewModel @Inject constructor(
                 )
             }
             .catch { throwable ->
-                Log.i(TAG, "Error Caught: ${throwable.message}")
+                Log.e(TAG, "Error Caught: ${throwable.message}")
                 emit(
                     PlaylistUiState(
                         isReady = true,
@@ -285,11 +279,10 @@ class PlaylistDetailsViewModel @Inject constructor(
     }
 
     fun refresh(force: Boolean = true) {
-        Log.i(TAG, "Refresh call")
-        Log.i(TAG, "refreshing: ${refreshing.value}")
+        Log.i(TAG, "Refresh call -> refreshing: ${refreshing.value}")
         viewModelScope.launch {
             runCatching {
-                Log.i(TAG, "Refresh runCatching")
+                if (FLAG) Log.i(TAG, "Refresh runCatching")
                 refreshing.value = true
             }.onFailure {
                 Log.e(TAG, "$it ::: runCatching failed (not sure what this means)")

--- a/app/src/main/java/com/example/music/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/search/SearchViewModel.kt
@@ -3,6 +3,7 @@ package com.example.music.ui.search
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.music.data.database.model.Song
 import com.example.music.domain.model.AlbumInfo
 import com.example.music.domain.model.ArtistInfo
 import com.example.music.domain.model.SearchQueryFilterResult
@@ -52,6 +53,10 @@ class SearchQueryViewModel @Inject constructor(
     val queryText: StateFlow<String>
         get() = _queryText
 
+    private val _resultView: MutableStateFlow<ResultView> = MutableStateFlow(ResultView.ALL)
+    val resultView: StateFlow<ResultView>
+        get() = _resultView
+
     init {
         Log.i(TAG, "init START --- query string: ${queryText.value}")
         viewModelScope.launch {
@@ -95,9 +100,9 @@ class SearchQueryViewModel @Inject constructor(
         viewModelScope.launch {
             val results = searchQuery(queryText.value)
             Log.i(TAG, "Query Search Results:\n" +
-                "${results.songs.size} songs\n" +
-                "${results.artists.size} artists\n" +
-                "${results.albums.size} albums")
+                "${results.songCount} songs\n" +
+                "${results.artistCount} artists\n" +
+                "${results.albumCount} albums")
             if ( results.songs.isEmpty() &&
                 results.artists.isEmpty() &&
                 results.albums.isEmpty()
@@ -112,13 +117,9 @@ class SearchQueryViewModel @Inject constructor(
         }
     }
 
-    fun onMoreQuery(item: String) {
-        Log.i(TAG, "onMoreQuery: ${queryText.value} -> $item")
-        when (item) {
-            "Songs" -> {}
-            "Artists" -> {}
-            "Albums" -> {}
-        }
+    fun onMoreQuery(newView: ResultView) {
+        Log.i(TAG, "onMoreQuery: ${queryText.value} -> $newView")
+        _resultView.value = newView
     }
 
     fun onMoreOptionsAction(action: MoreOptionsAction) {
@@ -266,5 +267,7 @@ data class ResultActions (
     val onArtistMoreOptionsClick: (ArtistInfo) -> Unit,
     val onAlbumClick: (AlbumInfo) -> Unit,
     val onAlbumMoreOptionsClick: (AlbumInfo) -> Unit,
-    val onMoreResultsClick: (String) -> Unit,
+    val onMoreResultsClick: (ResultView) -> Unit,
 )
+
+enum class ResultView { ALL, SONG, ARTIST, ALBUM }

--- a/app/src/main/java/com/example/music/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/search/SearchViewModel.kt
@@ -81,8 +81,9 @@ class SearchQueryViewModel @Inject constructor(
 
     fun sendQuery() {
         Log.i(TAG, "Send Query START -> query string: ${queryText.value}\n" +
-            "set uiState to Loading")
+            "set uiState to Loading & reset resultView to ALL")
         _state.update { SearchUiState.Loading }
+        _resultView.value = ResultView.ALL
         viewModelScope.launch {
             val results = searchQuery(queryText.value)
             Log.i(TAG, "Query Search Results:\n" +

--- a/app/src/main/java/com/example/music/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/music/ui/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.music.data.repository.AppPreferencesRepo
 import com.example.music.data.repository.ShuffleType
+import com.example.music.data.util.FLAG
 import com.example.music.domain.usecases.GetAppPreferencesUserSettings
 import com.example.music.domain.usecases.GetTotalCounts
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -55,8 +56,10 @@ class SettingsViewModel @Inject constructor(
             ) {
                 refreshing,
                 settings, ->
-                Log.i(TAG, "Shuffle type set to: ${settings.shuffleType}")
-                Log.i(TAG, "Theme mode set to: ${settings.theme}")
+                Log.i(TAG, "Settings State combine START\n" +
+                    "Shuffle type: ${settings.shuffleType}\n" +
+                    "Theme mode: ${settings.theme}\n" +
+                    "isReady?: ${!refreshing}")
 
                 SettingsUiState(
                     isLoading = refreshing,
@@ -65,26 +68,25 @@ class SettingsViewModel @Inject constructor(
                     totals = counts,
                 )
             }.catch { throwable ->
+                Log.e(TAG, "Error Caught: ${throwable.message}")
                 emit(
                     SettingsUiState(
                         isLoading = false,
                         errorMessage = throwable.message
                     )
                 )
-            }.collect {
-                _state.value = it
-            }
+            }.collect { _state.value = it }
         }
+
         refresh(force = false)
         Log.i(TAG, "init end")
     }
 
     fun refresh(force: Boolean = true) {
-        Log.i(TAG, "Refresh call")
-        Log.i(TAG, "refreshing: ${refreshing.value}")
+        Log.i(TAG, "Refresh call -> refreshing: ${refreshing.value}")
         viewModelScope.launch {
             runCatching {
-                Log.i(TAG, "Refresh runCatching")
+                if (FLAG) Log.i(TAG, "Refresh runCatching")
                 refreshing.value = true
             }.onFailure {
                 Log.e(TAG, "$it ::: runCatching failed (not sure what this means)")

--- a/app/src/main/java/com/example/music/ui/shared/Buttons.kt
+++ b/app/src/main/java/com/example/music/ui/shared/Buttons.kt
@@ -30,6 +30,8 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.KeyboardDoubleArrowLeft
+import androidx.compose.material.icons.filled.KeyboardDoubleArrowRight
 import androidx.compose.material.icons.filled.KeyboardDoubleArrowUp
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlayArrow
@@ -169,6 +171,64 @@ fun RowScope.NavToMoreBtn(
         Text(
             text = "More",
             style = MaterialTheme.typography.titleMedium
+        )
+    }
+}
+
+/**
+ * More button that will navigate to a longer list of the shown items
+ * @param onClick defines the action to take when the button is clicked
+ * @param modifier defines any modifiers to apply to button
+ */
+@Composable
+fun RowScope.ShowLessBtn(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.padding(horizontal = MARGIN_PADDING)
+            .align(Alignment.CenterVertically),
+        colors = ButtonDefaults.buttonColors(
+            contentColor = MaterialTheme.colorScheme.inversePrimary,
+        ),
+    ) {
+        Icon (
+            imageVector = Icons.Filled.KeyboardDoubleArrowLeft,
+            contentDescription = null,
+        )
+        Text(
+            text = "Back",
+            style = MaterialTheme.typography.titleMedium
+        )
+    }
+}
+
+/**
+ * More button that will navigate to a longer list of the shown items
+ * @param onClick defines the action to take when the button is clicked
+ * @param modifier defines any modifiers to apply to button
+ */
+@Composable
+fun RowScope.ShowMoreBtn(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.padding(horizontal = MARGIN_PADDING)
+            .align(Alignment.CenterVertically),
+        colors = ButtonDefaults.buttonColors(
+            contentColor = MaterialTheme.colorScheme.inversePrimary,
+        ),
+    ) {
+        Text(
+            text = "More",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Icon (
+            imageVector = Icons.Filled.KeyboardDoubleArrowRight,
+            contentDescription = null,
         )
     }
 }

--- a/core/data/src/main/java/com/example/music/data/mediaresolver/MediaRepo.kt
+++ b/core/data/src/main/java/com/example/music/data/mediaresolver/MediaRepo.kt
@@ -12,6 +12,7 @@ import com.example.music.data.mediaresolver.model.Album
 import com.example.music.data.mediaresolver.model.Artist
 import com.example.music.data.mediaresolver.model.Audio
 import com.example.music.data.mediaresolver.model.Genre
+import com.example.music.data.util.FLAG
 import com.example.music.data.util.combine
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -128,7 +129,7 @@ class MediaRepo (
         try {
             resolver.loadThumbnail(uri, Size(640, 480), null)
         } catch (e: Exception) {
-            Log.i(TAG, "ContentResolver error caught: $e", e)
+            Log.e(TAG, "ContentResolver error caught: $e", e)
             null
         }
 
@@ -168,7 +169,7 @@ class MediaRepo (
         order: String,
         ascending: Boolean
     ): List<Audio> {
-        Log.i(TAG, "Get All Audios")
+        if (FLAG) Log.i(TAG, "Get All Audios")
         return resolver.getAudios(
             order = order,
             ascending = ascending
@@ -185,7 +186,7 @@ class MediaRepo (
     ): Flow<List<Audio>> =
         observe(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI)
             .map {
-                Log.i(TAG, "Flow Get All Audios: observe MediaStore result: $it")
+                if (FLAG) Log.i(TAG, "Flow Get All Audios: observe MediaStore result: $it")
                 resolver.getAudios(
                     order = order,
                     ascending = ascending
@@ -205,7 +206,7 @@ class MediaRepo (
     fun getAudioFlow(id: Long) =
         observe(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI)
             .map {
-                Log.i(TAG, "Flow Get Audio by ID: $id; observe MediaStore result: $it")
+                if (FLAG) Log.i(TAG, "Flow Get Audio by ID: $id; observe MediaStore result: $it")
                 resolver.findAudio(id)
             }
 
@@ -215,7 +216,7 @@ class MediaRepo (
      */
     suspend fun getAudios(ids: List<Long>) =
         ids.map { id ->
-            Log.i(TAG, "Get Audios by ID: $id")
+            if (FLAG) Log.i(TAG, "Get Audios by ID: $id")
             resolver.findAudio(id)
         }
 
@@ -227,7 +228,7 @@ class MediaRepo (
         observe(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI)
             .map {
                 ids.map { id ->
-                    Log.i(TAG, "Flow Get Audios by ID: $id")
+                    if (FLAG) Log.i(TAG, "Flow Get Audios by ID: $id")
                     resolver.findAudio(id)
                 }
             }
@@ -258,7 +259,7 @@ class MediaRepo (
         order: String,
         ascending: Boolean
     ): List<Artist> {
-        Log.i(TAG, "Get All Artists")
+        if (FLAG) Log.i(TAG, "Get All Artists")
         return resolver.getArtists(
             order = order,
             ascending = ascending,
@@ -275,7 +276,7 @@ class MediaRepo (
     ): Flow<List<Artist>> =
         observe(MediaStore.Audio.Artists.EXTERNAL_CONTENT_URI)
             .map {
-                Log.i(TAG, "Flow Get All Artists: observe Media Store result: $it")
+                if (FLAG) Log.i(TAG, "Flow Get All Artists: observe Media Store result: $it")
                 resolver.getArtists(
                     order = order,
                     ascending = ascending,
@@ -314,7 +315,7 @@ class MediaRepo (
         artistId: Long
     ): Flow<Artist> = observe(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI)
         .map {
-            Log.i(TAG, "Flow Get Artist by ID: $artistId")
+            if (FLAG) Log.i(TAG, "Flow Get Artist by ID: $artistId")
             resolver.getArtist(artistId)
         }
 
@@ -325,9 +326,9 @@ class MediaRepo (
     suspend fun getArtistByAlbumId(
         albumId: Long
     ): Artist {
-        Log.i(TAG, "Get Artist by Album ID: $albumId")
+        if (FLAG) Log.i(TAG, "Get Artist by Album ID: $albumId")
         val album = resolver.findAlbum(albumId)
-        Log.i(TAG, "Get Artist by AlbumArtistId: ${album.artistId}")
+        if (FLAG) Log.i(TAG, "Get Artist by AlbumArtistId: ${album.artistId}")
         return resolver.getArtist(album.artistId)
     }
 
@@ -339,9 +340,9 @@ class MediaRepo (
         id: Long
     ): Flow<Artist> = observe(MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI)
         .map {
-            Log.i(TAG, "Flow Get Artist by Album ID: $id")
+            if (FLAG) Log.i(TAG, "Flow Get Artist by Album ID: $id")
             val album = resolver.findAlbum(id)
-            Log.i(TAG, "Flow Get Artist by AlbumArtistId: ${album.artistId}")
+            if (FLAG) Log.i(TAG, "Flow Get Artist by AlbumArtistId: ${album.artistId}")
             resolver.getArtist(album.artistId)
         }
 
@@ -480,7 +481,7 @@ class MediaRepo (
     fun getAlbumFlow(id: Long) =
         observe(MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI)
             .map {
-                Log.i(TAG, "Flow Get Album by ID: $id")
+                if (FLAG) Log.i(TAG, "Flow Get Album by ID: $id")
                 resolver.findAlbum(id)
             }
 
@@ -552,7 +553,7 @@ class MediaRepo (
     fun getGenreFlow(id: Long) =
         observe(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI)
             .map {
-                Log.i(TAG, "Flow Get Genre by ID: $id")
+                if (FLAG) Log.i(TAG, "Flow Get Genre by ID: $id")
                 resolver.findGenre(id)
             }
 

--- a/core/data/src/main/java/com/example/music/data/mediaresolver/MediaRepo.kt
+++ b/core/data/src/main/java/com/example/music/data/mediaresolver/MediaRepo.kt
@@ -12,6 +12,8 @@ import com.example.music.data.mediaresolver.model.Album
 import com.example.music.data.mediaresolver.model.Artist
 import com.example.music.data.mediaresolver.model.Audio
 import com.example.music.data.mediaresolver.model.Genre
+import com.example.music.data.mediaresolver.model.Playlist
+import com.example.music.data.mediaresolver.model.PlaylistTrack
 import com.example.music.data.util.FLAG
 import com.example.music.data.util.combine
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -162,32 +164,32 @@ class MediaRepo (
             }
 
     /**
-     * Get all audios
+     * Find all audios
      * @return [List] of [Audio]
      */
-    suspend fun getAllAudios(
+    suspend fun findAllAudios(
         order: String,
         ascending: Boolean
-    ): List<Audio> {
-        if (FLAG) Log.i(TAG, "Get All Audios")
-        return resolver.getAudios(
+    ): List<Audio>? {
+        if (FLAG) Log.i(TAG, "Find All Audios")
+        return resolver.findAudios(
             order = order,
             ascending = ascending
         )
     }
 
     /**
-     * Get all audios
+     * Find all audios
      * @return [Flow] of [List] of [Audio]
      */
-    fun getAllAudiosFlow(
+    fun findAllAudiosFlow(
         order: String,
         ascending: Boolean
-    ): Flow<List<Audio>> =
+    ): Flow<List<Audio>?> =
         observe(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI)
             .map {
-                if (FLAG) Log.i(TAG, "Flow Get All Audios: observe MediaStore result: $it")
-                resolver.getAudios(
+                if (FLAG) Log.i(TAG, "Flow Find All Audios")
+                resolver.findAudios(
                     order = order,
                     ascending = ascending
                 )
@@ -197,7 +199,7 @@ class MediaRepo (
      * Get Audio based on id
      * @return [Audio] filtered to match id
      */
-    suspend fun getAudio(id: Long) = resolver.findAudio(id)
+    suspend fun getAudio(id: Long) = resolver.getAudio(id)
 
     /**
      * Get Flow of Audio based on id
@@ -206,8 +208,8 @@ class MediaRepo (
     fun getAudioFlow(id: Long) =
         observe(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI)
             .map {
-                if (FLAG) Log.i(TAG, "Flow Get Audio by ID: $id; observe MediaStore result: $it")
-                resolver.findAudio(id)
+                if (FLAG) Log.i(TAG, "Flow Get Audio by ID: $id")
+                resolver.getAudio(id)
             }
 
     /**
@@ -217,7 +219,7 @@ class MediaRepo (
     suspend fun getAudios(ids: List<Long>) =
         ids.map { id ->
             if (FLAG) Log.i(TAG, "Get Audios by ID: $id")
-            resolver.findAudio(id)
+            resolver.getAudio(id)
         }
 
     /**
@@ -229,7 +231,7 @@ class MediaRepo (
             .map {
                 ids.map { id ->
                     if (FLAG) Log.i(TAG, "Flow Get Audios by ID: $id")
-                    resolver.findAudio(id)
+                    resolver.getAudio(id)
                 }
             }
 
@@ -242,7 +244,13 @@ class MediaRepo (
         ascending: Boolean = true,
         offset: Int = 0,
         limit: Int = Integer.MAX_VALUE,
-    ) = resolver.getAudios(query, order, ascending, offset, limit)
+    ): List<Audio>? = resolver.findAudios(
+        sQuery = query,
+        order = order,
+        ascending = ascending,
+        offset = offset,
+        limit = limit
+    )
 
 
     /***********************************************************************************************
@@ -252,36 +260,36 @@ class MediaRepo (
      **********************************************************************************************/
 
     /**
-     * Get all artists
+     * Find all artists
      * @return [List] of [Artist]
      */
-    suspend fun getAllArtists(
+    suspend fun findAllArtists(
         order: String,
         ascending: Boolean
-    ): List<Artist> {
-        if (FLAG) Log.i(TAG, "Get All Artists")
-        return resolver.getArtists(
+    ): List<Artist>? {
+        if (FLAG) Log.i(TAG, "Find All Artists")
+        return resolver.findArtists(
             order = order,
             ascending = ascending,
         )
     }
 
     /**
-     * Get all artists
+     * Find all artists
      * @return [Flow] of [List] of [Artist]
      */
-    fun getAllArtistsFlow(
+    fun findAllArtistsFlow(
         order: String,
         ascending: Boolean
-    ): Flow<List<Artist>> =
-        observe(MediaStore.Audio.Artists.EXTERNAL_CONTENT_URI)
-            .map {
-                if (FLAG) Log.i(TAG, "Flow Get All Artists: observe Media Store result: $it")
-                resolver.getArtists(
-                    order = order,
-                    ascending = ascending,
-                )
-            }
+    ) = observe(MediaStore.Audio.Artists.EXTERNAL_CONTENT_URI)
+        .map {
+            if (FLAG) Log.i(TAG, "Flow Find All Artists")
+            resolver.findArtists(
+                order = order,
+                ascending = ascending,
+            )
+        }
+
     /**
      * Search for artist, with query for user input
      * @param query string for filtering based on user input
@@ -292,7 +300,7 @@ class MediaRepo (
         order: String = MediaStore.Audio.Artists.ARTIST,
         ascending: Boolean = true,
         limit: Int = Integer.MAX_VALUE,
-    ): List<Artist> = resolver.getArtists(
+    ): List<Artist>? = resolver.findArtists(
         sQuery = query,
         order = order,
         ascending = ascending,
@@ -300,54 +308,46 @@ class MediaRepo (
     )
 
     /**
-     * Search for Artist based on id
+     * Get Artist based on id
      * @return [Artist]
      */
-    suspend fun getArtist(
-        id: Long
-    ): Artist = resolver.getArtist(id)
+    suspend fun getArtist(id: Long): Artist = resolver.getArtist(id)
 
     /**
-     * Search for Artist based on id
+     * Get Artist based on id
      * @return [Flow] of [Artist]
      */
-    fun getArtistFlow(
-        artistId: Long
-    ): Flow<Artist> = observe(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI)
-        .map {
-            if (FLAG) Log.i(TAG, "Flow Get Artist by ID: $artistId")
-            resolver.getArtist(artistId)
-        }
+    fun getArtistFlow(id: Long): Flow<Artist> =
+        observe(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI)
+            .map {
+                if (FLAG) Log.i(TAG, "Flow Get Artist by ID: $id")
+                resolver.getArtist(id)
+            }
 
     /**
-     * Search for Artist based on an Album Id
+     * Get Artist based on an Album Id
      * @return [Artist]
      */
-    suspend fun getArtistByAlbumId(
-        albumId: Long
-    ): Artist {
+    suspend fun getArtistByAlbumId(albumId: Long): Artist {
         if (FLAG) Log.i(TAG, "Get Artist by Album ID: $albumId")
-        val album = resolver.findAlbum(albumId)
-        if (FLAG) Log.i(TAG, "Get Artist by AlbumArtistId: ${album.artistId}")
+        val album = resolver.getAlbum(albumId)
         return resolver.getArtist(album.artistId)
     }
 
     /**
-     * Search for Artist based on an Album Id
+     * Get Artist based on an Album Id
      * @return [Flow] of [Artist]
      */
-    fun getArtistByAlbumIdFlow(
-        id: Long
-    ): Flow<Artist> = observe(MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI)
-        .map {
-            if (FLAG) Log.i(TAG, "Flow Get Artist by Album ID: $id")
-            val album = resolver.findAlbum(id)
-            if (FLAG) Log.i(TAG, "Flow Get Artist by AlbumArtistId: ${album.artistId}")
-            resolver.getArtist(album.artistId)
-        }
+    fun getArtistByAlbumIdFlow(albumId: Long): Flow<Artist> =
+        observe(MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI)
+            .map {
+                if (FLAG) Log.i(TAG, "Flow Get Artist by Album ID: $albumId")
+                val album = resolver.getAlbum(albumId)
+                resolver.getArtist(album.artistId)
+            }
 
     /**
-     * Search for Albums by an Artist based on an Artist Id
+     * Get Albums by an Artist based on an Artist Id
      * @return [Flow] of [List] of [Album]
      */
     fun getAlbumsByArtistId(
@@ -375,17 +375,38 @@ class MediaRepo (
         }
 
     /**
-     * Get Audios by Artist name, with query for user input
+     * Find Albums by an Artist based on an Artist Id
+     * @return [List] of [Album]
+     */
+    suspend fun findArtistAlbums(
+        artistId: Long,
+        order: String = MediaStore.Audio.Albums.ALBUM,
+        ascending: Boolean = true,
+    ): List<Album>? = resolver.findArtistAlbums(
+        artistId = artistId,
+        order = order,
+        ascending = ascending
+    )
+
+    /**
+     * Find Audios by Artist name, with query for user input
      * @return [List] of [Audio]
      */
-    suspend fun getArtistAudios(
+    suspend fun findArtistAudios(
         name: String,
         query: String? = null,
         order: String = MediaStore.Audio.Media.TITLE,
         ascending: Boolean = true,
         offset: Int = 0,
         limit: Int = Integer.MAX_VALUE,
-    ) = resolver.getArtistAudios(name, query, order, ascending, offset, limit)
+    ): List<Audio>? = resolver.findArtistAudios(
+        name = name,
+        sQuery = query,
+        order = order,
+        ascending = ascending,
+        offset = offset,
+        limit = limit
+    )
 
     /**
      * Get Audios by Artist id
@@ -397,7 +418,13 @@ class MediaRepo (
         ascending: Boolean = true,
         offset: Int = 0,
         limit: Int = Integer.MAX_VALUE,
-    ) = resolver.getArtistAudiosById(artistId, order, ascending, offset, limit)
+    ): List<Audio> = resolver.getArtistAudiosById(
+        artistId = artistId,
+        order = order,
+        ascending = ascending,
+        offset = offset,
+        limit = limit
+    )
 
 
     /***********************************************************************************************
@@ -429,27 +456,35 @@ class MediaRepo (
             }
 
     /**
-     * get all albums
+     * Find all albums
      * @return [List] of [Album]
      */
-    suspend fun getAllAlbums( order: String, ascending: Boolean ) =
-        findAlbums(
+    suspend fun findAllAlbums(
+        order: String,
+        ascending: Boolean
+    ): List<Album>? {
+        if (FLAG) Log.i(TAG, "Find All Albums")
+        return resolver.findAlbums(
             order = order,
             ascending = ascending,
         )
+    }
 
     /**
-     * get all albums
+     * Find all albums
      * @return [Flow] of [List] of [Album]
      */
-    fun getAllAlbumsFlow( order: String, ascending: Boolean ) =
-        observe(MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI)
-            .map {
-                findAlbums(
-                    order = order,
-                    ascending = ascending,
-                )
-            }
+    fun findAllAlbumsFlow(
+        order: String,
+        ascending: Boolean
+    ) = observe(MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI)
+        .map {
+            if (FLAG) Log.i(TAG, "Flow Find All Albums")
+            resolver.findAlbums(
+                order = order,
+                ascending = ascending,
+            )
+        }
 
     /**
      * Search for albums, with query for user input
@@ -461,7 +496,7 @@ class MediaRepo (
         order: String = MediaStore.Audio.Albums.ALBUM,
         ascending: Boolean = true,
         limit: Int = Integer.MAX_VALUE,
-    ) = resolver.getAlbums(
+    ): List<Album>? = resolver.findAlbums(
         sQuery = query,
         order = order,
         ascending = ascending,
@@ -469,34 +504,41 @@ class MediaRepo (
     )
 
     /**
-     * Search for Album based on id
+     * Get Album based on id
      * @return [Album]
      */
-    suspend fun getAlbum(id: Long) = resolver.findAlbum(id)
+    suspend fun getAlbum(id: Long): Album = resolver.getAlbum(id)
 
     /**
-     * Search for Album based on id
+     * Get Album based on id
      * @return [Flow] of [Album]
      */
-    fun getAlbumFlow(id: Long) =
+    fun getAlbumFlow(id: Long): Flow<Album> =
         observe(MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI)
             .map {
                 if (FLAG) Log.i(TAG, "Flow Get Album by ID: $id")
-                resolver.findAlbum(id)
+                resolver.getAlbum(id)
             }
 
     /**
      * Get Audios based on Album title
      * @return [List] of [Audio]
      */
-    suspend fun getAlbumAudios(
+    suspend fun findAlbumAudios(
         title: String,
         query: String? = null,
         order: String = MediaStore.Audio.Media.TRACK,
         ascending: Boolean = true,
         offset: Int = 0,
         limit: Int = Integer.MAX_VALUE,
-    ) = resolver.getAlbumAudios(title, query, order, ascending, offset, limit)
+    ): List<Audio>? = resolver.findAlbumAudios(
+        title = title,
+        sQuery = query,
+        order = order,
+        ascending = ascending,
+        offset = offset,
+        limit = limit
+    )
 
     /**
      * Get Audios based on Album id
@@ -508,7 +550,13 @@ class MediaRepo (
         ascending: Boolean = true,
         offset: Int = 0,
         limit: Int = Integer.MAX_VALUE,
-    ) = resolver.getAlbumAudiosById(albumId, order, ascending, offset, limit)
+    ): List<Audio> = resolver.getAlbumAudiosById(
+        albumId = albumId,
+        order = order,
+        ascending = ascending,
+        offset = offset,
+        limit = limit
+    )
 
 
     /***********************************************************************************************
@@ -518,67 +566,86 @@ class MediaRepo (
      **********************************************************************************************/
 
     /**
-     * get all genres
+     * Find all genres
      * @return [List] of [Genre]
      */
-    suspend fun getAllGenres(order: String, ascending: Boolean) =
-        findGenres(
+    suspend fun findAllGenres(
+        order: String,
+        ascending: Boolean
+    ): List<Genre>? {
+        if (FLAG) Log.i(TAG, "Find All Genres")
+        return resolver.findGenres(
             order = order,
             ascending = ascending
         )
+    }
 
     /**
-     * get all genres
+     * Find all genres
      * @return [Flow] of [List] of [Genre]
      */
-    fun getAllGenresFlow(order: String, ascending: Boolean) =
-        observe(MediaStore.Audio.Genres.EXTERNAL_CONTENT_URI)
-            .map {
-                findGenres(
-                    order = order,
-                    ascending = ascending
-                )
-            }
+    fun findAllGenresFlow(
+        order: String,
+        ascending: Boolean
+    ) = observe(MediaStore.Audio.Genres.EXTERNAL_CONTENT_URI)
+        .map {
+            if (FLAG) Log.i(TAG, "Flow Find All Genres")
+            resolver.findGenres(
+                order = order,
+                ascending = ascending
+            )
+        }
 
     /**
      * Search for Genre based on id
      * @return [Genre]
      */
-    suspend fun getGenre(id: Long) = resolver.findGenre(id)
+    suspend fun getGenre(id: Long): Genre = resolver.getGenre(id)
 
     /**
-     * Search for Genre based on id
+     * Get Genre based on id
      * @return [Flow] of [Genre]
      */
-    fun getGenreFlow(id: Long) =
+    fun getGenreFlow(id: Long): Flow<Genre> =
         observe(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI)
             .map {
                 if (FLAG) Log.i(TAG, "Flow Get Genre by ID: $id")
-                resolver.findGenre(id)
+                resolver.getGenre(id)
             }
 
     /**
-     * Get Genres via resolver
+     * Find Genres based on genre name
      * @return [List] of [Genre]
      */
     private suspend fun findGenres(
         query: String? = null,
         order: String = MediaStore.Audio.Genres.NAME,
         ascending: Boolean = true,
-    ) = resolver.getGenres(query, order, ascending)
+    ): List<Genre>? = resolver.findGenres(
+        sQuery = query,
+        order = order,
+        ascending = ascending
+    )
 
     /**
-     * Get Audios based on Genre name
+     * Find Audios based on Genre name
      * @return [List] of [Audio]
      */
-    suspend fun getGenreAudios(
+    suspend fun findGenreAudios(
         name: String,
         query: String? = null,
         order: String = MediaStore.Audio.Media.TITLE,
         ascending: Boolean = true,
         offset: Int = 0,
         limit: Int = Integer.MAX_VALUE,
-    ) = resolver.getGenreAudios(name, query, order, ascending, offset, limit)
+    ): List<Audio>? = resolver.findGenreAudios(
+        name = name,
+        sQuery = query,
+        order = order,
+        ascending = ascending,
+        offset = offset,
+        limit = limit
+    )
 
     /**
      * Get Audios based on Genre id
@@ -590,7 +657,13 @@ class MediaRepo (
         ascending: Boolean = true,
         offset: Int = 0,
         limit: Int = Integer.MAX_VALUE,
-    ) = resolver.getGenreAudiosById(id, order, ascending, offset, limit)
+    ): List<Audio> = resolver.getGenreAudiosById(
+        id = id,
+        order = order,
+        ascending = ascending,
+        offset = offset,
+        limit = limit
+    )
 
 
     /***********************************************************************************************
@@ -616,33 +689,67 @@ class MediaRepo (
                 }
             }
 
-    suspend fun getAllPlaylists(order: String, ascending: Boolean) =
-        resolver.getPlaylists(
+    /**
+     * Find all playlists
+     * @return [List] of [Playlist]
+     */
+    suspend fun findAllPlaylists(
+        order: String,
+        ascending: Boolean
+    ): List<Playlist>? {
+        if (FLAG) Log.i(TAG, "Find All Playlists")
+        return resolver.findPlaylists(
             order = order,
             ascending = ascending
         )
-    fun getAllPlaylistsFlow(order: String, ascending: Boolean) =
-        observe(MediaStore.Audio.Playlists.EXTERNAL_CONTENT_URI)
-            .map {
-                resolver.getPlaylists(
-                    order = order,
-                    ascending = ascending
-                )
-            }
+    }
 
-    suspend fun getPlaylist(id: Long) =
-        resolver.getPlaylist(id)
-    fun getPlaylistFlow(id: Long) =
+    /**
+     * Find all playlists
+     * @return [Flow] of [List] of [Playlist]
+     */
+    fun findAllPlaylistsFlow(
+        order: String,
+        ascending: Boolean
+    ) = observe(MediaStore.Audio.Playlists.EXTERNAL_CONTENT_URI)
+        .map {
+            if (FLAG) Log.i(TAG, "Flow Find All Playlists")
+            resolver.findPlaylists(
+                order = order,
+                ascending = ascending
+            )
+        }
+
+    /**
+     * Get Playlist based on id
+     * @return [Playlist]
+     */
+    suspend fun getPlaylist(id: Long): Playlist = resolver.getPlaylist(id)
+
+    /**
+     * Get Playlist based on id
+     * @return [Flow] of [Playlist]
+     */
+    fun getPlaylistFlow(id: Long): Flow<Playlist> =
         observe(MediaStore.Audio.Playlists.EXTERNAL_CONTENT_URI)
             .map {
+                if (FLAG) Log.i(TAG, "Flow Get Playlist by ID: $id")
                 resolver.getPlaylist(id)
             }
 
-    suspend fun findPlaylistTracks(id: Long, limit: Int = Int.MAX_VALUE) =
-        resolver.findPlaylistTracks(id = id, limit = limit)
+    /**
+     * Find Playlist Track Members based on Playlist id
+     * @return [List] of [PlaylistTrack]
+     */
+    suspend fun findPlaylistTracks(
+        id: Long,
+        limit: Int = Int.MAX_VALUE
+    ): List<PlaylistTrack>? = resolver.findPlaylistTracks(
+        id = id,
+        limit = limit
+    )
 
-    //would likely get playlists here as well
-    // and be able to get playlist's songs here too, ie "playlist members" or "playlist tracks"
+    //would likely get playlists here as well and be able to get playlist's songs here too, ie "playlist members" or "playlist tracks"
     //rest of the playlist functions may as well be dbRepo functions that should be encapsulated elsewhere before coming here
 
     /* // insert new track into playlist, still don't get how it specifies a playlist ... or is it just calling the playlist db that?

--- a/core/domain/src/main/java/com/example/music/domain/model/SearchQueryFilterResult.kt
+++ b/core/domain/src/main/java/com/example/music/domain/model/SearchQueryFilterResult.kt
@@ -5,6 +5,9 @@ package com.example.music.domain.model
  */
 data class SearchQueryFilterResult (
     val songs: List<SongInfo> = emptyList(),
+    val songCount: Int = 0,
     val artists: List<ArtistInfo> = emptyList(),
+    val artistCount: Int = 0,
     val albums: List<AlbumInfo> = emptyList(),
+    val albumCount: Int = 0,
 )

--- a/core/domain/src/main/java/com/example/music/domain/usecases/FeaturedLibraryAlbums.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/FeaturedLibraryAlbums.kt
@@ -16,6 +16,7 @@ private const val TAG = "Featured Library Albums"
  * Use case to retrieve data for [FeaturedLibraryAlbumsFilterResult] domain model which returns
  * the most recently modified albums and the most recently added songs to populate the
  * Home screen.
+ * @property mediaRepo Content Resolver Repository for MediaStore
  */
 class FeaturedLibraryAlbums @Inject constructor(
     private val mediaRepo: MediaRepo,

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetAlbumDetails.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetAlbumDetails.kt
@@ -4,19 +4,23 @@ import android.provider.MediaStore
 import android.util.Log
 import com.example.music.data.mediaresolver.MediaRepo
 import com.example.music.data.mediaresolver.model.Album
-import com.example.music.data.mediaresolver.model.Artist
 import com.example.music.data.mediaresolver.model.uri
 import com.example.music.data.util.FLAG
 import com.example.music.domain.model.AlbumDetailsFilterResult
 import com.example.music.domain.model.asExternalModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 private const val TAG = "Get Album Details"
 
+/**
+ * Use case to retrieve data for [AlbumDetailsFilterResult] domain model which returns
+ * the AlbumInfo data, the album's ArtistInfo, and the album's track list as list of SongInfo
+ * to populate the AlbumDetails screen.
+ * @property mediaRepo Content Resolver Repository for MediaStore
+ */
 class GetAlbumDetails @Inject constructor(
     private val mediaRepo: MediaRepo,
 ) {

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetAlbumDetails.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetAlbumDetails.kt
@@ -39,7 +39,7 @@ class GetAlbumDetails @Inject constructor(
                 "Album Title: ${album.title}\n" +
                 "Artist: ${album.artist}"
             )
-            Log.i(TAG, "ALBUM ARTIST: $artist ---\n" +
+            if (FLAG) Log.i(TAG, "ALBUM ARTIST: $artist ---\n" +
                 "Artist ID: ${artist.id}\n" +
                 "Artist Name: ${artist.name}\n" +
                 "Number Albums: ${artist.numAlbums}\n" +
@@ -48,9 +48,9 @@ class GetAlbumDetails @Inject constructor(
             AlbumDetailsFilterResult(
                 album = album.asExternalModel(),
                 artist = artist.asExternalModel(),
-                songs = songs.map {
-                    if (FLAG) Log.i(TAG, "SONG: ${it.title}")
-                    it.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(it.uri))
+                songs = songs.map { song ->
+                    if (FLAG) Log.i(TAG, "SONG: ${song.title}")
+                    song.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(song.uri))
                 },
             )
         }

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetAppPreferencesLibrarySort.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetAppPreferencesLibrarySort.kt
@@ -9,7 +9,8 @@ import javax.inject.Inject
 private const val TAG = "App Pref :: Library Sort"
 
 /**
- * Function for Accessing Library Sort Orders from App Preferences DataStore
+ * Use case for accessing Library Sort Orders saved to data store
+ * @property appRepo Repository for App Preferences DataStore
  */
 class GetAppPreferencesLibrarySort @Inject constructor(
     private val appRepo: AppPreferencesRepo,

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetAppPreferencesUserSettings.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetAppPreferencesUserSettings.kt
@@ -9,7 +9,8 @@ import javax.inject.Inject
 private const val TAG = "App Pref :: User Settings"
 
 /**
- * Function for Accessing User Settings from App Preferences DataStore
+ * Use case for accessing User Settings saved to data store
+ * @property appRepo Repository for App Preferences DataStore
  */
 class GetAppPreferencesUserSettings @Inject constructor(
     private val appRepo: AppPreferencesRepo,

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetArtistDetails.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetArtistDetails.kt
@@ -2,12 +2,12 @@ package com.example.music.domain.usecases
 
 import android.provider.MediaStore
 import android.util.Log
-import com.example.music.domain.model.ArtistDetailsFilterResult
-import com.example.music.domain.model.asExternalModel
-import com.example.music.data.mediaresolver.model.Artist
 import com.example.music.data.mediaresolver.MediaRepo
+import com.example.music.data.mediaresolver.model.Artist
 import com.example.music.data.mediaresolver.model.uri
 import com.example.music.data.util.FLAG
+import com.example.music.domain.model.ArtistDetailsFilterResult
+import com.example.music.domain.model.asExternalModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -15,6 +15,12 @@ import javax.inject.Inject
 
 private const val TAG = "Get Artist Details"
 
+/**
+ * Use case to retrieve data for [ArtistDetailsFilterResult] domain model which returns
+ * the ArtistInfo data, the artist's albums as list of AlbumInfo, and the artist's songs as
+ * list of SongInfo to populate the ArtistDetails screen.
+ * @property mediaRepo Content Resolver Repository for MediaStore
+ */
 class GetArtistDetails @Inject constructor(
     private val mediaRepo: MediaRepo,
 ) {
@@ -25,7 +31,7 @@ class GetArtistDetails @Inject constructor(
         return combine(
             artistItem,
             artistItem.map { artist ->
-                mediaRepo.getArtistAlbums(
+                mediaRepo.findArtistAlbums(
                     artistId = artist.id,
                     order = MediaStore.Audio.Albums.ALBUM
                 )
@@ -46,10 +52,10 @@ class GetArtistDetails @Inject constructor(
 
             ArtistDetailsFilterResult(
                 artist = artist.asExternalModel(),
-                albums = albums.map { album ->
+                albums = albums?.map { album ->
                     if (FLAG) Log.i(TAG, "ALBUM: ${album.title}")
                     album.asExternalModel()
-                },
+                } ?: emptyList(),
                 songs = songs.map { song ->
                     if (FLAG) Log.i(TAG, "SONG: ${song.title}")
                     song.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(song.uri))

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetArtistDetails.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetArtistDetails.kt
@@ -4,10 +4,10 @@ import android.provider.MediaStore
 import android.util.Log
 import com.example.music.domain.model.ArtistDetailsFilterResult
 import com.example.music.domain.model.asExternalModel
-import com.example.music.data.mediaresolver.model.Album
 import com.example.music.data.mediaresolver.model.Artist
 import com.example.music.data.mediaresolver.MediaRepo
 import com.example.music.data.mediaresolver.model.uri
+import com.example.music.data.util.FLAG
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -21,14 +21,20 @@ class GetArtistDetails @Inject constructor(
     operator fun invoke(artistId: Long): Flow<ArtistDetailsFilterResult> {
         Log.i(TAG, "START --- artistID: $artistId")
         val artistItem: Flow<Artist> = mediaRepo.getArtistFlow(artistId)
-        val albumsList: Flow<List<Album>> = mediaRepo.getAlbumsByArtistId(artistId)
 
         return combine(
             artistItem,
-            albumsList,
-            artistItem.map {
-                Log.i(TAG, "Fetching songs from artist $artistId")
-                mediaRepo.getArtistAudios(it.id, order = MediaStore.Audio.Media.TITLE)
+            artistItem.map { artist ->
+                mediaRepo.getArtistAlbums(
+                    artistId = artist.id,
+                    order = MediaStore.Audio.Albums.ALBUM
+                )
+            },
+            artistItem.map { artist ->
+                mediaRepo.getArtistAudios(
+                    artistId = artist.id,
+                    order = MediaStore.Audio.Media.TITLE
+                )
             },
         ) { artist, albums, songs ->
             Log.i(TAG, "ARTIST: $artist ---\n" +
@@ -40,13 +46,13 @@ class GetArtistDetails @Inject constructor(
 
             ArtistDetailsFilterResult(
                 artist = artist.asExternalModel(),
-                albums = albums.map {
-                    Log.i(TAG, "ALBUM: ${it.title}")
-                    it.asExternalModel()
+                albums = albums.map { album ->
+                    if (FLAG) Log.i(TAG, "ALBUM: ${album.title}")
+                    album.asExternalModel()
                 },
-                songs = songs.map {
-                    Log.i(TAG, "SONG: ${it.title}")
-                    it.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(it.uri))
+                songs = songs.map { song ->
+                    if (FLAG) Log.i(TAG, "SONG: ${song.title}")
+                    song.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(song.uri))
                 },
             )
         }

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetGenreDetails.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetGenreDetails.kt
@@ -7,6 +7,7 @@ import com.example.music.domain.model.asExternalModel
 import com.example.music.data.mediaresolver.model.Genre
 import com.example.music.data.mediaresolver.MediaRepo
 import com.example.music.data.mediaresolver.model.uri
+import com.example.music.data.util.FLAG
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -24,17 +25,21 @@ class GetGenreDetails @Inject constructor(
         return combine(
             genreItem,
             genreItem.map {
-                Log.i(TAG, "Fetching songs from genre $genreId")
-                mediaRepo.getGenreAudios(it.id, order = MediaStore.Audio.AudioColumns.TITLE)
+                mediaRepo.getGenreAudios(
+                    id = it.id,
+                    order = MediaStore.Audio.AudioColumns.TITLE
+                )
             }
         ) { genre, songs ->
-            Log.i(TAG, "GENRE: $genre --- \n" +
-                "Genre Name: ${genre.name}")
+            Log.i(TAG, "GENRE: $genre ---\n" +
+                "Genre ID: ${genre.id}\n" +
+                "Genre Name: ${genre.name}"
+            )
             GenreDetailsFilterResult(
                 genre = genre.asExternalModel(),
-                songs = songs.map {
-                    Log.i(TAG, "SONG: ${it.title}")
-                    it.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(it.uri))
+                songs = songs.map { song ->
+                    if (FLAG) Log.i(TAG, "SONG: ${song.title}")
+                    song.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(song.uri))
                 },
             )
         }

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetGenreDetails.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetGenreDetails.kt
@@ -2,12 +2,12 @@ package com.example.music.domain.usecases
 
 import android.provider.MediaStore
 import android.util.Log
-import com.example.music.domain.model.GenreDetailsFilterResult
-import com.example.music.domain.model.asExternalModel
-import com.example.music.data.mediaresolver.model.Genre
 import com.example.music.data.mediaresolver.MediaRepo
+import com.example.music.data.mediaresolver.model.Genre
 import com.example.music.data.mediaresolver.model.uri
 import com.example.music.data.util.FLAG
+import com.example.music.domain.model.GenreDetailsFilterResult
+import com.example.music.domain.model.asExternalModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -15,6 +15,11 @@ import javax.inject.Inject
 
 private const val TAG = "Get Genre Details"
 
+/**
+ * Use case to retrieve data for [GenreDetailsFilterResult] domain model which returns
+ * the GenreInfo data and the genre's songs as list of SongInfo to populate the GenreDetails screen.
+ * @property mediaRepo Content Resolver Repository for MediaStore
+ */
 class GetGenreDetails @Inject constructor(
     private val mediaRepo: MediaRepo
 ) {

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetLibraryAlbums.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetLibraryAlbums.kt
@@ -24,43 +24,43 @@ class GetLibraryAlbums @Inject constructor(
 
         when (sortColumn) {
             AlbumSortList[0] -> { //"Title"
-                albumsList = mediaRepo.getAllAlbums(
+                albumsList = mediaRepo.findAllAlbums(
                     order = MediaStore.Audio.Albums.ALBUM,
                     ascending = isAscending
-                ).sortedBy { it.title.lowercase() }
+                )?.sortedBy { it.title.lowercase() } ?: emptyList()
                 if (!isAscending) albumsList = albumsList.reversed()
             }
 
             AlbumSortList[1] -> { //"Artist"
-                albumsList = mediaRepo.getAllAlbums(
+                albumsList = mediaRepo.findAllAlbums(
                     order = MediaStore.Audio.Albums.ARTIST,
                     ascending = isAscending
-                ).sortedWith(
+                )?.sortedWith(
                     compareBy<Album> { it.artist.lowercase() }
                         .thenBy { it.title.lowercase() }
-                )
+                ) ?: emptyList()
                 if (!isAscending) albumsList = albumsList.reversed()
             }
 
             AlbumSortList[2] -> { //"Song Count"
-                albumsList = mediaRepo.getAllAlbums(
+                albumsList = mediaRepo.findAllAlbums(
                     order = MediaStore.Audio.Albums.NUMBER_OF_SONGS,
                     ascending = isAscending
-                ).sortedWith(
+                )?.sortedWith(
                     compareBy<Album> { it.numTracks }
                         .thenBy { it.title.lowercase() }
-                )
+                ) ?: emptyList()
                 if (!isAscending) albumsList = albumsList.reversed()
             }
 
             AlbumSortList[3] -> { //"Year"
-                albumsList = mediaRepo.getAllAlbums(
+                albumsList = mediaRepo.findAllAlbums(
                     order = MediaStore.Audio.Albums.ALBUM,
                     ascending = isAscending
-                ).sortedWith(
+                )?.sortedWith(
                     compareBy<Album, Int?>(nullsLast(), { it.lastYear })
                         .thenBy { it.title.lowercase() }
-                )
+                ) ?: emptyList()
                 if (!isAscending) albumsList = albumsList
                     .sortedWith(
                         compareByDescending<Album, Int?> (nullsFirst(),{ it.lastYear })
@@ -69,10 +69,10 @@ class GetLibraryAlbums @Inject constructor(
             }
 
             else -> {
-                albumsList = mediaRepo.getAllAlbums(
+                albumsList = mediaRepo.findAllAlbums(
                     order = MediaStore.Audio.Albums.ALBUM,
                     ascending = isAscending
-                )
+                ) ?: emptyList()
             }
         }
 

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetLibraryArtists.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetLibraryArtists.kt
@@ -24,40 +24,40 @@ class GetLibraryArtists @Inject constructor(
 
         when (sortColumn) {
             ArtistSortList[0] -> { //"Name"
-                artistsList = mediaRepo.getAllArtists(
+                artistsList = mediaRepo.findAllArtists(
                     order = MediaStore.Audio.Artists.ARTIST,
                     ascending = isAscending,
-                ).sortedBy { it.name.lowercase() }
+                )?.sortedBy { it.name.lowercase() } ?: emptyList()
                 if (!isAscending) artistsList = artistsList.reversed()
             }
 
             ArtistSortList[1] -> { //"Album Count"
-                artistsList = mediaRepo.getAllArtists(
+                artistsList = mediaRepo.findAllArtists(
                     order = MediaStore.Audio.Artists.NUMBER_OF_ALBUMS,
                     ascending = isAscending,
-                ).sortedWith(
+                )?.sortedWith(
                     compareBy<Artist> { it.numAlbums }
                         .thenBy { it.name.lowercase() }
-                )
+                ) ?: emptyList()
                 if (!isAscending) artistsList = artistsList.reversed()
             }
 
             ArtistSortList[2] -> { //"Song Count"
-                artistsList = mediaRepo.getAllArtists(
+                artistsList = mediaRepo.findAllArtists(
                     order = MediaStore.Audio.Artists.NUMBER_OF_TRACKS,
                     ascending = isAscending,
-                ).sortedWith(
+                )?.sortedWith(
                     compareBy<Artist> { it.numTracks }
                         .thenBy { it.name.lowercase() }
-                )
+                ) ?: emptyList()
                 if (!isAscending) artistsList = artistsList.reversed()
             }
 
             else -> {
-                artistsList = mediaRepo.getAllArtists(
+                artistsList = mediaRepo.findAllArtists(
                     order = MediaStore.Audio.Artists.ARTIST,
                     ascending = isAscending,
-                )
+                ) ?: emptyList()
             }
         }
 

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetLibraryComposers.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetLibraryComposers.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.example.music.data.database.model.ComposerWithExtraInfo
 import com.example.music.data.repository.ComposerRepo
 import com.example.music.data.repository.ComposerSortList
+import com.example.music.data.util.FLAG
 import com.example.music.domain.model.ComposerInfo
 import com.example.music.domain.model.asExternalModel
 import kotlinx.coroutines.flow.Flow
@@ -46,10 +47,11 @@ class GetLibraryComposers @Inject constructor(
             }
         }
 
-        return composersList.map { items ->
-            Log.i(TAG, "********** Library Composers count: ${items.size} **********")
-            items.map { item ->
-                item.asExternalModel()
+        return composersList.map { composers ->
+            Log.i(TAG, "********** Library Composers count: ${composers.size} **********")
+            composers.map { composer ->
+                if (FLAG) Log.i(TAG, "**** Composer: ${composer.composer.id} + ${composer.composer.name} ****")
+                composer.asExternalModel()
             }
         }
     }

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetLibraryGenres.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetLibraryGenres.kt
@@ -24,26 +24,26 @@ class GetLibraryGenres @Inject constructor(
 
         when (sortColumn) {
             GenreSortList[0] -> { // "Name"
-                genresList = mediaRepo.getAllGenres(
+                genresList = mediaRepo.findAllGenres(
                     order = MediaStore.Audio.Genres.NAME,
                     ascending = isAscending
-                ).sortedBy { it.name.lowercase() }
+                )?.sortedBy { it.name.lowercase() } ?: emptyList()
                 if (!isAscending) genresList = genresList.reversed()
             }
 
             GenreSortList[1] -> { // "Song Count"
-                genresList = mediaRepo.getAllGenres(
+                genresList = mediaRepo.findAllGenres(
                     order = MediaStore.Audio.Genres.NAME,
                     ascending = isAscending
-                ).sortedBy { it.numTracks }
+                )?.sortedBy { it.numTracks } ?: emptyList()
                 if (!isAscending) genresList = genresList.reversed()
             }
 
             else -> {
-                genresList = mediaRepo.getAllGenres(
+                genresList = mediaRepo.findAllGenres(
                     order = MediaStore.Audio.Genres.NAME,
                     ascending = isAscending
-                )
+                ) ?: emptyList()
             }
         }
 

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetLibraryPlaylists.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetLibraryPlaylists.kt
@@ -141,13 +141,12 @@ class GetLibraryPlaylists @Inject constructor(
         Log.i(TAG, "********** Library Playlists count: ${playlistsList.size} **********")
         return playlistsList.map { item ->
             val playlist = item.asExternalModel()
-            if (FLAG) Log.i(TAG, "**** Playlist: ${playlist.id} + ${playlist.name} ****")
+            if (FLAG) Log.i(TAG, "**** Playlist: ${playlist.id} + ${playlist.name} + ${playlist.songCount} ****")
             if (playlist.songCount > 0) {
                 val songIds = mediaRepo.findPlaylistTracks(playlist.id, 4).map { it.audioId }
                 val songs = mediaRepo.getAudios(songIds).map { song ->
                     song.asExternalModel()
                 }
-                if (FLAG) Log.i(TAG, "song size: ${songs.size}")
                 playlist.copy(playlistImage = playlist.getArtworkUris(songs))
             } else {
                 playlist

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetLibrarySongs.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetLibrarySongs.kt
@@ -24,61 +24,61 @@ class GetLibrarySongs @Inject constructor(
 
         when (sortColumn) {
             SongSortList[0] -> { // "Title"
-                songsList = mediaRepo.getAllAudios(
+                songsList = mediaRepo.findAllAudios(
                     order = MediaStore.Audio.Media.TITLE,
                     ascending = isAscending,
-                ).sortedBy { it.title.lowercase() }
+                )?.sortedBy { it.title.lowercase() } ?: emptyList()
                 if (!isAscending) songsList = songsList.reversed()
             }
 
             SongSortList[1] -> { // "Artist"
-                songsList = mediaRepo.getAllAudios(
+                songsList = mediaRepo.findAllAudios(
                     order = MediaStore.Audio.Media.ARTIST,
                     ascending = isAscending,
-                ).sortedWith(
+                )?.sortedWith(
                     compareBy<Audio> { it.artist.lowercase() }
                         .thenBy { it.title.lowercase() }
-                )
+                ) ?: emptyList()
                 if (!isAscending) songsList = songsList.reversed()
             }
 
             SongSortList[2] -> { // "Album"
-                songsList = mediaRepo.getAllAudios(
+                songsList = mediaRepo.findAllAudios(
                     order = MediaStore.Audio.Media.ALBUM,
                     ascending = isAscending,
-                ).sortedWith(
+                )?.sortedWith(
                     compareBy<Audio> { it.album.lowercase() }
                         .thenBy { it.title.lowercase() }
-                )
+                ) ?: emptyList()
                 if (!isAscending) songsList = songsList.reversed()
             }
 
             SongSortList[3] -> { // "Date Added"
-                songsList = mediaRepo.getAllAudios(
+                songsList = mediaRepo.findAllAudios(
                     order = MediaStore.Audio.Media.DATE_ADDED,
                     ascending = isAscending,
-                )
+                ) ?: emptyList()
             }
 
             SongSortList[4] -> { // "Date Modified"
-                songsList = mediaRepo.getAllAudios(
+                songsList = mediaRepo.findAllAudios(
                     order = MediaStore.Audio.Media.DATE_MODIFIED,
                     ascending = isAscending,
-                )
+                ) ?: emptyList()
             }
 
             SongSortList[5] -> { // "Duration"
-                songsList = mediaRepo.getAllAudios(
+                songsList = mediaRepo.findAllAudios(
                     order = MediaStore.Audio.Media.DURATION,
                     ascending = isAscending,
-                )
+                ) ?: emptyList()
             }
 
             else -> {
-                songsList = mediaRepo.getAllAudios(
+                songsList = mediaRepo.findAllAudios(
                     order = MediaStore.Audio.Media.TITLE,
                     ascending = isAscending,
-                )
+                ) ?: emptyList()
             }
         }
 

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetPlaylistDetails.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetPlaylistDetails.kt
@@ -1,12 +1,12 @@
 package com.example.music.domain.usecases
 
 import android.util.Log
-import com.example.music.domain.model.PlaylistDetailsFilterResult
-import com.example.music.domain.model.asExternalModel
 import com.example.music.data.mediaresolver.MediaRepo
 import com.example.music.data.mediaresolver.model.Playlist
 import com.example.music.data.mediaresolver.model.uri
 import com.example.music.data.util.FLAG
+import com.example.music.domain.model.PlaylistDetailsFilterResult
+import com.example.music.domain.model.asExternalModel
 import com.example.music.domain.model.getArtworkUris
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -16,8 +16,10 @@ import javax.inject.Inject
 private const val TAG = "Get Playlist Details"
 
 /**
- * Use case to retrieve data for [PlaylistDetailsFilterResult] domain model for PlaylistDetailsScreen UI.
- * @property mediaRepo Content Resolver for MediaStore
+ * Use case to retrieve data for [PlaylistDetailsFilterResult] domain model which returns
+ * the PlaylistInfo data and the playlist's songs as list of SongInfo to populate the
+ * PlaylistDetails screen.
+ * @property mediaRepo Content Resolver Repository for MediaStore
  */
 class GetPlaylistDetails @Inject constructor(
     private val mediaRepo: MediaRepo,
@@ -29,33 +31,27 @@ class GetPlaylistDetails @Inject constructor(
         return combine(
             playlistFlow,
             playlistFlow.map {
-                mediaRepo.findPlaylistTracks(playlistId).map { track ->
+                mediaRepo.findPlaylistTracks(playlistId)?.map { track ->
                     mediaRepo.getAudio(track.audioId)
                 }
             },
-        ) { playlist, audios ->
-            Log.i(TAG, "PLAYLIST: $playlist ---\n" +
-                "Playlist ID: ${playlist.id}\n" +
-                "Playlist Name: ${playlist.name}\n" +
-                "Number Songs: ${playlist.numTracks}"
+        ) { p, audios ->
+            Log.i(TAG, "PLAYLIST: $p ---\n" +
+                "Playlist ID: ${p.id}\n" +
+                "Playlist Name: ${p.name}\n" +
+                "Number Songs: ${p.numTracks}"
             )
 
-            val p = playlist.asExternalModel()
-            if (p.songCount > 0){
-                val songs = audios.map { song ->
-                    if (FLAG) Log.i(TAG, "SONG: ${song.title}")
-                    song.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(song.uri))
-                }
-                PlaylistDetailsFilterResult(
-                    playlist = p.copy(playlistImage = p.getArtworkUris(songs)),
-                    songs = songs,
-                )
-            } else { // playlist.songCount less than or equal to 0 will be set to empty
-                PlaylistDetailsFilterResult(
-                    playlist = p,
-                    songs = emptyList(),
-                )
+            var playlist = p.asExternalModel()
+            val songs = audios?.map { audio ->
+                if (FLAG) Log.i(TAG, "SONG: ${audio.title}")
+                audio.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(audio.uri))
             }
+            if (songs != null) playlist = playlist.copy(playlistImage = playlist.getArtworkUris(songs))
+            PlaylistDetailsFilterResult(
+                playlist = playlist,
+                songs = songs ?: emptyList(),
+            )
         }
     }
 }

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetPlaylistDetails.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetPlaylistDetails.kt
@@ -34,12 +34,18 @@ class GetPlaylistDetails @Inject constructor(
                 }
             },
         ) { playlist, audios ->
-            if (FLAG) Log.i(TAG, "Playlist: ${playlist.name} :: ${playlist.numTracks} songs\n" +
-                "Is audio count == Playlist.numTracks? ${audios.size == playlist.numTracks}")
+            Log.i(TAG, "PLAYLIST: $playlist ---\n" +
+                "Playlist ID: ${playlist.id}\n" +
+                "Playlist Name: ${playlist.name}\n" +
+                "Number Songs: ${playlist.numTracks}"
+            )
 
             val p = playlist.asExternalModel()
             if (p.songCount > 0){
-                val songs = audios.map { it.asExternalModel()/*.copy(artworkBitmap = mediaRepo.loadThumbnail(it.uri))*/ }
+                val songs = audios.map { song ->
+                    if (FLAG) Log.i(TAG, "SONG: ${song.title}")
+                    song.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(song.uri))
+                }
                 PlaylistDetailsFilterResult(
                     playlist = p.copy(playlistImage = p.getArtworkUris(songs)),
                     songs = songs,

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetSongData.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetSongData.kt
@@ -6,6 +6,7 @@ import com.example.music.domain.model.asExternalModel
 import com.example.music.data.mediaresolver.MediaRepo
 import com.example.music.data.mediaresolver.model.uri
 import com.example.music.data.util.FLAG
+import com.example.music.domain.model.PlaylistDetailsFilterResult
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -13,6 +14,10 @@ import javax.inject.Inject
 
 private const val TAG = "Get Song Data"
 
+/**
+ * Use case to retrieve [SongInfo] or list of [SongInfo] data from MediaStore
+ * @property mediaRepo Content Resolver Repository for MediaStore
+ */
 class GetSongData @Inject constructor(
     private val mediaRepo: MediaRepo
 ) {

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetSongData.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetSongData.kt
@@ -30,7 +30,7 @@ class GetSongData @Inject constructor(
             "Title: ${audio.title}\n" +
             "Artist: ${audio.artist}\n" +
             "Album: ${audio.album}")
-        return audio.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(audio.uri))
+        return audio.asExternalModel().copy(artworkBitmap = mediaRepo.loadThumbnail(audio.uri))
     }
 
     // use to build list of SongInfo from list of Audio ids
@@ -44,7 +44,7 @@ class GetSongData @Inject constructor(
                         "Title: ${song.title}\n" +
                         "Artist: ${song.artist}\n" +
                         "Album: ${song.album}")
-                    song.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(song.uri))
+                    song.asExternalModel().copy(artworkBitmap = mediaRepo.loadThumbnail(song.uri))
                 }
             }
     }

--- a/core/domain/src/main/java/com/example/music/domain/usecases/GetTotalCounts.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/GetTotalCounts.kt
@@ -6,6 +6,10 @@ import javax.inject.Inject
 
 private const val TAG = "Get Total Counts"
 
+/**
+ * Use case to retrieve total row counts for the tables in MediaStore
+ * @property mediaRepo Content Resolver Repository for MediaStore
+ */
 class GetTotalCounts @Inject constructor(
     private val mediaRepo: MediaRepo,
 ) {

--- a/core/domain/src/main/java/com/example/music/domain/usecases/SearchQuery.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/SearchQuery.kt
@@ -1,10 +1,10 @@
 package com.example.music.domain.usecases
 
 import android.util.Log
-import com.example.music.domain.model.SearchQueryFilterResult
-import com.example.music.domain.model.asExternalModel
 import com.example.music.data.mediaresolver.MediaRepo
 import com.example.music.data.mediaresolver.model.uri
+import com.example.music.domain.model.SearchQueryFilterResult
+import com.example.music.domain.model.asExternalModel
 import javax.inject.Inject
 
 private const val TAG = "Search Query"
@@ -17,28 +17,28 @@ class SearchQuery @Inject constructor(
     private val mediaRepo: MediaRepo,
 ) {
     suspend operator fun invoke(query: String): SearchQueryFilterResult {
-        Log.i(TAG, "START")
+        Log.i(TAG, "START --- query: $query")
 
         val audios = mediaRepo.findAudios(
             query = query,
             limit = 20,
-        ).map { audio ->
-            audio.asExternalModel().copy(artworkBitmap = mediaRepo.loadThumbnail(audio.uri))
-        }
+        )?.map { audio ->
+            audio.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(audio.uri))
+        } ?: emptyList()
 
         val artists = mediaRepo.findArtists(
             query = query,
             limit = 20,
-        ).map { artist ->
+        )?.map { artist ->
             artist.asExternalModel()
-        }
+        } ?: emptyList()
 
         val albums = mediaRepo.findAlbums(
             query = query,
             limit = 20,
-        ).map { album ->
+        )?.map { album ->
             album.asExternalModel()
-        }
+        } ?: emptyList()
 
         Log.i(TAG, "Results:\n" +
             "Songs list: ${audios.size}\n" +

--- a/core/domain/src/main/java/com/example/music/domain/usecases/SearchQuery.kt
+++ b/core/domain/src/main/java/com/example/music/domain/usecases/SearchQuery.kt
@@ -21,21 +21,21 @@ class SearchQuery @Inject constructor(
 
         val audios = mediaRepo.findAudios(
             query = query,
-            limit = 20,
+            //limit = 20,
         )?.map { audio ->
             audio.asExternalModel()//.copy(artworkBitmap = mediaRepo.loadThumbnail(audio.uri))
         } ?: emptyList()
 
         val artists = mediaRepo.findArtists(
             query = query,
-            limit = 20,
+            //limit = 20,
         )?.map { artist ->
             artist.asExternalModel()
         } ?: emptyList()
 
         val albums = mediaRepo.findAlbums(
             query = query,
-            limit = 20,
+            //limit = 20,
         )?.map { album ->
             album.asExternalModel()
         } ?: emptyList()
@@ -47,8 +47,11 @@ class SearchQuery @Inject constructor(
 
         return SearchQueryFilterResult(
             songs = audios,
+            songCount = audios.size,
             artists = artists,
+            artistCount = artists.size,
             albums = albums,
+            albumCount = albums.size,
         )
     }
 }


### PR DESCRIPTION
### Background:
This pull request covers three things.
1. I wanted to revise the SearchScreen so that it would show all the results that came back from a query and not just the 20 items limit that I had initially set when writing the search query.
3. I wanted to fix MediaRepo's and Resolver's search queries to reflect proper naming and functionality of "Find" and "Get" functions
4. I needed to fix some of the error logging in the UI, because they were set to INFO instead of ERROR. 

### Changes Made: 
**In Data module:**
- Fixed missing AlbumArtist logic for Resolver's findAlbum(String) function
- Revised MediaResolver's MediaRepo and Resolver query functions logic so that "Find" functions can 1. convey that the provided parameter is not guaranteed to have a value, and 2. handle returning null if query does not find a value
- Revised MediaResolver's MediaRepo and Resolver query functions logic so that "Get" functions can 1. convey that the provided parameter must have at least one returned value, and 2. error when returning null

**In Domain module:**
- Revised all affected query use cases to reflect updated Find/Get logic from MediaResolver
- Revised SearchQueryFilterResult to hold the values of songs, artists, and albums returned list sizes, as songCount, artistCount, albumCount
- Removed limit on SearchQuery domain use case
- Slight class description comment updates
- Fixed GetSongData so that setting artworkBitmap is not commented (would cause PlayerScreen to not load artwork)

**In UI module:**
- Adjusted error log statements to use Log.e
- Added more FLAG toggles to log statements
- Slight blank space edits
- Added new Buttons: ShowMoreBtn and ShowLessBtn just for SearchScreen

**In SearchViewModel specifically:**
- Reordered placement of properties and methods in SearchViewModel, and function parameters and arguments in SearchScreen
- Added ResultView enum type to reflect the view of the results list.
ALL (0) means show songs, artists, and albums, so screen shows first 20 results of all three. 
SONG (1) means show only songs, so screen shows all results for songs.
ARTIST (2) means show only artists, so screen shows all results for artists. 
ALBUM (3) means show only albums, so screen shows all results for albums.
- Added resultView property to uiState to track the current state of the results lists
- Renamed onMoreQuery to updateResultView to convey that it now updates resultView value
- Added extra state logic to compensate for resultView property
- Using SearchQueryFilterResult's songCount, artistCount, albumCount in place of their respective list.size arguments

**In SearchScreen specifically:**
- Completely modified the search results list view content so that it can accommodate switching between viewing initial results list of first 20 items (ResultView.ALL) or a dedicated result list view of all items for respective list if its count is above 20 (ResultView.SONG, ResultView.ARTIST, or ResultView.ALBUM)
- Moved search results list view content from SearchField() into SearchContent()
- Deleted SearchScreen's SearchScreenReady() function and moved the code from it into stateful SearchScreen()
- Added a ShowLess button that calls updateResultView() to set view back to ResultView.ALL
- Updated NavToMore button to be ShowMore button that calls updateResultView to update result list to specific view of Songs, Artists, or Albums: ResultView.SONG, ResultView.ARTIST, or ResultView.ALBUM respectively
- Added ScrollToTop FAB
- Reordered some parameter settings and BottomModal if statements

### Related Issues:
none